### PR TITLE
Initialize SemanticStub .NET 10 solution with OpenAPI stub server and test scaffolding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# SemanticStub
+
+SemanticStub is a **.NET 10** project and an **OpenAPI-based stub server**.
+
+## Contract and matching requirements
+- Use **OpenAPI 3.1** as the base API contract.
+- Keep API definitions compliant with OpenAPI where possible.
+- Implement custom behavior with `x-stub-*` extensions.
+- Support **strict** and **hybrid** request matching modes.
+- **Strict mode** validates method, path, content-type, and request schema.
+- **Hybrid mode** keeps structure strict but allows flexible matching on selected request body fields.
+
+## Architecture
+- Keep the architecture modular and easy to extend.
+- Prefer simple, readable C# code.
+- Avoid over-engineering in early versions.
+
+## Project structure
+- `SemanticStub.Core`: shared models and abstractions.
+- `SemanticStub.OpenApi`: OpenAPI parsing and mapping.
+- `SemanticStub.Matching`: matching logic.
+- `SemanticStub.Api`: ASP.NET Core hosting.
+
+## Development guidelines
+- Keep responsibilities separated by project.
+- Use `Directory.Packages.props` for central package management.
+- Write tests for parsing, matching, and API behavior.
+- Prefer incremental implementation.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,13 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="NUnit" Version="4.4.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+  </ItemGroup>
+</Project>

--- a/SemanticStub.sln
+++ b/SemanticStub.sln
@@ -1,0 +1,63 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SemanticStub.Api", "src\SemanticStub.Api\SemanticStub.Api.csproj", "{22E204CB-E3BE-4E73-A349-A6D04DBF00BA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SemanticStub.Core", "src\SemanticStub.Core\SemanticStub.Core.csproj", "{D4452481-F5D6-4A12-8BD6-E04689EF43A6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SemanticStub.OpenApi", "src\SemanticStub.OpenApi\SemanticStub.OpenApi.csproj", "{4CEBE9CC-4A20-472A-BF6E-AB1FA7502377}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SemanticStub.Matching", "src\SemanticStub.Matching\SemanticStub.Matching.csproj", "{5E2D95F5-FD4E-494B-AE8A-6569102F15A8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SemanticStub.Api.Tests", "tests\SemanticStub.Api.Tests\SemanticStub.Api.Tests.csproj", "{19C36325-4E38-4F2C-B45D-709CF63B56B4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SemanticStub.Core.Tests", "tests\SemanticStub.Core.Tests\SemanticStub.Core.Tests.csproj", "{126D504F-BF6A-4E37-9E1D-C365F68DE2C9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SemanticStub.OpenApi.Tests", "tests\SemanticStub.OpenApi.Tests\SemanticStub.OpenApi.Tests.csproj", "{855EF30F-240C-4DF2-81A9-1DBCA17E2AF1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SemanticStub.Matching.Tests", "tests\SemanticStub.Matching.Tests\SemanticStub.Matching.Tests.csproj", "{4D1971DF-31E0-44E2-8233-0C201D226AA7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{22E204CB-E3BE-4E73-A349-A6D04DBF00BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{22E204CB-E3BE-4E73-A349-A6D04DBF00BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22E204CB-E3BE-4E73-A349-A6D04DBF00BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{22E204CB-E3BE-4E73-A349-A6D04DBF00BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4452481-F5D6-4A12-8BD6-E04689EF43A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4452481-F5D6-4A12-8BD6-E04689EF43A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4452481-F5D6-4A12-8BD6-E04689EF43A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4452481-F5D6-4A12-8BD6-E04689EF43A6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4CEBE9CC-4A20-472A-BF6E-AB1FA7502377}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4CEBE9CC-4A20-472A-BF6E-AB1FA7502377}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4CEBE9CC-4A20-472A-BF6E-AB1FA7502377}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4CEBE9CC-4A20-472A-BF6E-AB1FA7502377}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5E2D95F5-FD4E-494B-AE8A-6569102F15A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5E2D95F5-FD4E-494B-AE8A-6569102F15A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5E2D95F5-FD4E-494B-AE8A-6569102F15A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5E2D95F5-FD4E-494B-AE8A-6569102F15A8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{19C36325-4E38-4F2C-B45D-709CF63B56B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{19C36325-4E38-4F2C-B45D-709CF63B56B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{19C36325-4E38-4F2C-B45D-709CF63B56B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{19C36325-4E38-4F2C-B45D-709CF63B56B4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{126D504F-BF6A-4E37-9E1D-C365F68DE2C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{126D504F-BF6A-4E37-9E1D-C365F68DE2C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{126D504F-BF6A-4E37-9E1D-C365F68DE2C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{126D504F-BF6A-4E37-9E1D-C365F68DE2C9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{855EF30F-240C-4DF2-81A9-1DBCA17E2AF1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{855EF30F-240C-4DF2-81A9-1DBCA17E2AF1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{855EF30F-240C-4DF2-81A9-1DBCA17E2AF1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{855EF30F-240C-4DF2-81A9-1DBCA17E2AF1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4D1971DF-31E0-44E2-8233-0C201D226AA7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4D1971DF-31E0-44E2-8233-0C201D226AA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4D1971DF-31E0-44E2-8233-0C201D226AA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4D1971DF-31E0-44E2-8233-0C201D226AA7}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
+  }
+}

--- a/src/SemanticStub.Api/Program.cs
+++ b/src/SemanticStub.Api/Program.cs
@@ -1,0 +1,14 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddOpenApi();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
+
+app.MapGet("/", () => Results.Ok("SemanticStub.Api is running."));
+
+app.Run();

--- a/src/SemanticStub.Api/SemanticStub.Api.csproj
+++ b/src/SemanticStub.Api/SemanticStub.Api.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SemanticStub.Core\SemanticStub.Core.csproj" />
+    <ProjectReference Include="..\SemanticStub.OpenApi\SemanticStub.OpenApi.csproj" />
+    <ProjectReference Include="..\SemanticStub.Matching\SemanticStub.Matching.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/SemanticStub.Core/Class1.cs
+++ b/src/SemanticStub.Core/Class1.cs
@@ -1,0 +1,5 @@
+namespace SemanticStub.Core;
+
+public class Class1
+{
+}

--- a/src/SemanticStub.Core/SemanticStub.Core.csproj
+++ b/src/SemanticStub.Core/SemanticStub.Core.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/src/SemanticStub.Matching/Class1.cs
+++ b/src/SemanticStub.Matching/Class1.cs
@@ -1,0 +1,5 @@
+namespace SemanticStub.Matching;
+
+public class Class1
+{
+}

--- a/src/SemanticStub.Matching/SemanticStub.Matching.csproj
+++ b/src/SemanticStub.Matching/SemanticStub.Matching.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SemanticStub.Core\SemanticStub.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/SemanticStub.OpenApi/Class1.cs
+++ b/src/SemanticStub.OpenApi/Class1.cs
@@ -1,0 +1,5 @@
+namespace SemanticStub.OpenApi;
+
+public class Class1
+{
+}

--- a/src/SemanticStub.OpenApi/SemanticStub.OpenApi.csproj
+++ b/src/SemanticStub.OpenApi/SemanticStub.OpenApi.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SemanticStub.Core\SemanticStub.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj
+++ b/tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\src\\SemanticStub.Api\\SemanticStub.Api.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/SemanticStub.Api.Tests/UnitTest1.cs
+++ b/tests/SemanticStub.Api.Tests/UnitTest1.cs
@@ -1,0 +1,12 @@
+using NUnit.Framework;
+
+namespace SemanticStub.Api.Tests;
+
+public class UnitTest1
+{
+    [Test]
+    public void PlaceholderTest()
+    {
+        Assert.That(true, Is.True);
+    }
+}

--- a/tests/SemanticStub.Core.Tests/SemanticStub.Core.Tests.csproj
+++ b/tests/SemanticStub.Core.Tests/SemanticStub.Core.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\src\\SemanticStub.Core\\SemanticStub.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/SemanticStub.Core.Tests/UnitTest1.cs
+++ b/tests/SemanticStub.Core.Tests/UnitTest1.cs
@@ -1,0 +1,12 @@
+using NUnit.Framework;
+
+namespace SemanticStub.Core.Tests;
+
+public class UnitTest1
+{
+    [Test]
+    public void PlaceholderTest()
+    {
+        Assert.That(true, Is.True);
+    }
+}

--- a/tests/SemanticStub.Matching.Tests/SemanticStub.Matching.Tests.csproj
+++ b/tests/SemanticStub.Matching.Tests/SemanticStub.Matching.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\src\\SemanticStub.Matching\\SemanticStub.Matching.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/SemanticStub.Matching.Tests/UnitTest1.cs
+++ b/tests/SemanticStub.Matching.Tests/UnitTest1.cs
@@ -1,0 +1,12 @@
+using NUnit.Framework;
+
+namespace SemanticStub.Matching.Tests;
+
+public class UnitTest1
+{
+    [Test]
+    public void PlaceholderTest()
+    {
+        Assert.That(true, Is.True);
+    }
+}

--- a/tests/SemanticStub.OpenApi.Tests/SemanticStub.OpenApi.Tests.csproj
+++ b/tests/SemanticStub.OpenApi.Tests/SemanticStub.OpenApi.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\src\\SemanticStub.OpenApi\\SemanticStub.OpenApi.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/SemanticStub.OpenApi.Tests/UnitTest1.cs
+++ b/tests/SemanticStub.OpenApi.Tests/UnitTest1.cs
@@ -1,0 +1,12 @@
+using NUnit.Framework;
+
+namespace SemanticStub.OpenApi.Tests;
+
+public class UnitTest1
+{
+    [Test]
+    public void PlaceholderTest()
+    {
+        Assert.That(true, Is.True);
+    }
+}


### PR DESCRIPTION
### Motivation
- Bootstraps a new modular SemanticStub project intended to be an OpenAPI-based stub server targeting .NET 10 and using OpenAPI 3.1 as the contract.
- Provide a clear project structure separating core, OpenAPI parsing, matching logic, and the ASP.NET Core API host to enable incremental implementation.
- Centralize package versions and SDK settings to ensure consistent builds across projects.

### Description
- Adds a new solution `SemanticStub.sln` and project scaffolding: `SemanticStub.Api`, `SemanticStub.Core`, `SemanticStub.OpenApi`, and `SemanticStub.Matching`, each with `net10.0` `csproj` files and minimal placeholder classes (`Class1`).
- Adds an ASP.NET Core entrypoint in `src/SemanticStub.Api/Program.cs` that registers OpenAPI (`AddOpenApi` / `MapOpenApi`) and exposes a root `GET /` health endpoint returning `"SemanticStub.Api is running."`.
- Introduces centralized package management via `Directory.Packages.props` and SDK pinning via `global.json` (`version: 10.0.100` and `rollForward: latestFeature`).
- Adds test projects for each component with NUnit placeholders and a sample passing assertion, and documents the project intent and guidelines in `AGENTS.md`.

### Testing
- No automated tests were executed as part of this rollout; test projects and placeholder NUnit tests were added for each component but were not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1409114608325a986d8b844f96bb9)