### PR TITLE
Add x-response-file support to the exact matcher

### DIFF
--- a/SemanticStub.http
+++ b/SemanticStub.http
@@ -4,6 +4,20 @@
 GET {{host}}/hello
 Accept: application/json
 
+### Users stub from x-response-file
+GET {{host}}/users
+Accept: application/json
+
+### Login stub
+POST {{host}}/login
+Content-Type: application/json
+Accept: application/json
+
+{
+  "username": "demo",
+  "password": "secret"
+}
+
 ### Unknown route returns 404
 GET {{host}}/missing
 Accept: application/json

--- a/samples/basic-routing.yaml
+++ b/samples/basic-routing.yaml
@@ -29,6 +29,7 @@ paths:
       responses:
         '200':
           description: User list
+          x-response-file: users.json
           content:
             application/json:
               schema:
@@ -50,12 +51,6 @@ paths:
                         - name
                 required:
                   - users
-              example:
-                users:
-                  - id: 1
-                    name: Alice
-                  - id: 2
-                    name: Bob
 
   /login:
     post:

--- a/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionLoader.cs
+++ b/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionLoader.cs
@@ -34,6 +34,13 @@ public sealed class StubDefinitionLoader
         return document;
     }
 
+    public string LoadResponseFileContent(string fileName)
+    {
+        var path = ResolveSamplePath(fileName);
+
+        return File.ReadAllText(path);
+    }
+
     private string ResolveSamplePath(string fileName)
     {
         var current = new DirectoryInfo(environment.ContentRootPath);

--- a/src/SemanticStub.Api/Models/ResponseDefinition.cs
+++ b/src/SemanticStub.Api/Models/ResponseDefinition.cs
@@ -1,8 +1,13 @@
+using YamlDotNet.Serialization;
+
 namespace SemanticStub.Api.Models;
 
 public sealed class ResponseDefinition
 {
     public string Description { get; init; } = string.Empty;
+
+    [YamlMember(Alias = "x-response-file", ApplyNamingConventions = false)]
+    public string? ResponseFile { get; init; }
 
     public Dictionary<string, MediaTypeDefinition> Content { get; init; } = new(StringComparer.Ordinal);
 }

--- a/src/SemanticStub.Api/Services/StubService.cs
+++ b/src/SemanticStub.Api/Services/StubService.cs
@@ -7,15 +7,24 @@ public sealed class StubService
 {
     private const string JsonContentType = "application/json";
     private readonly StubDocument document;
+    private readonly Func<string, string> responseFileReader;
 
     public StubService(StubDefinitionLoader loader)
     {
         document = loader.LoadDefaultDefinition();
+        responseFileReader = loader.LoadResponseFileContent;
     }
 
     public StubService(StubDocument document)
     {
         this.document = document;
+        responseFileReader = _ => throw new InvalidOperationException("No response file reader configured.");
+    }
+
+    public StubService(StubDocument document, Func<string, string> responseFileReader)
+    {
+        this.document = document;
+        this.responseFileReader = responseFileReader;
     }
 
     public StubMatchResult TryGetResponse(string method, string path, out StubResponse response)
@@ -45,7 +54,9 @@ public sealed class StubService
             return StubMatchResult.ResponseNotConfigured;
         }
 
-        if (!matchedResponse.Value.Content.TryGetValue(JsonContentType, out var mediaType))
+        var body = BuildResponseBody(matchedResponse.Value);
+
+        if (body is null)
         {
             return StubMatchResult.ResponseNotConfigured;
         }
@@ -54,7 +65,7 @@ public sealed class StubService
         {
             StatusCode = statusCode,
             ContentType = JsonContentType,
-            Body = StubDefinitionLoader.SerializeExample(mediaType.Example)
+            Body = body
         };
 
         return StubMatchResult.Matched;
@@ -73,5 +84,20 @@ public sealed class StubService
         }
 
         return null;
+    }
+
+    private string? BuildResponseBody(ResponseDefinition responseDefinition)
+    {
+        if (!string.IsNullOrEmpty(responseDefinition.ResponseFile))
+        {
+            return responseFileReader(responseDefinition.ResponseFile);
+        }
+
+        if (!responseDefinition.Content.TryGetValue(JsonContentType, out var mediaType))
+        {
+            return null;
+        }
+
+        return StubDefinitionLoader.SerializeExample(mediaType.Example);
     }
 }

--- a/tests/SemanticStub.Api.Tests/Integration/HelloWorldStubTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/HelloWorldStubTests.cs
@@ -36,7 +36,7 @@ public sealed class HelloWorldStubTests : IClassFixture<WebApplicationFactory<Pr
     }
 
     [Fact]
-    public async Task GetUsers_ReturnsJsonExampleFromYaml()
+    public async Task GetUsers_ReturnsJsonFromResponseFile()
     {
         var response = await client.GetAsync("/users");
 

--- a/tests/SemanticStub.Api.Tests/Unit/StubServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubServiceTests.cs
@@ -47,4 +47,40 @@ public sealed class StubServiceTests
         Assert.Equal(201, response.StatusCode);
         Assert.Equal("{\"message\":\"Created\"}", response.Body);
     }
+
+    [Fact]
+    public void TryGetResponse_UsesResponseFileContentWhenConfigured()
+    {
+        var document = new StubDocument
+        {
+            Paths = new Dictionary<string, PathItemDefinition>(StringComparer.Ordinal)
+            {
+                ["/users"] = new()
+                {
+                    Get = new OperationDefinition
+                    {
+                        Responses = new Dictionary<string, ResponseDefinition>(StringComparer.Ordinal)
+                        {
+                            ["200"] = new()
+                            {
+                                ResponseFile = "users.json",
+                                Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+                                {
+                                    ["application/json"] = new()
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        var service = new StubService(document, _ => "{\"users\":[{\"id\":1,\"name\":\"Alice\"}]}");
+
+        var matched = service.TryGetResponse(HttpMethods.Get, "/users", out var response);
+
+        Assert.Equal(StubMatchResult.Matched, matched);
+        Assert.Equal(200, response.StatusCode);
+        Assert.Equal("{\"users\":[{\"id\":1,\"name\":\"Alice\"}]}", response.Body);
+    }
 }


### PR DESCRIPTION
## Summary
- add `x-response-file` support for exact path and method matches using OpenAPI 3.1-based YAML
- keep existing `application/json` example responses working while allowing response bodies to be loaded from external JSON files
- update samples, tests, and the REST Client file to cover file-backed responses

## Validation
- `dotnet build SemanticStub.sln`
- `dotnet test SemanticStub.sln`

## Notes
- matching remains exact-only
- scenario, semantic, regex, and query/header/body matching are still intentionally out of scope