### PR TITLE
fix: validate invalid stub definitions at startup

### DIFF
--- a/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionLoader.cs
+++ b/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionLoader.cs
@@ -27,7 +27,7 @@ public sealed class StubDefinitionLoader
         return LoadDefinition(path);
     }
 
-    public StubDocument LoadDefinition(string path)
+    private StubDocument LoadDefinition(string path)
     {
         var yaml = File.ReadAllText(path);
         var document = deserializer.Deserialize<StubDocument>(yaml);
@@ -71,18 +71,30 @@ public sealed class StubDefinitionLoader
     private void ValidateDocument(StubDocument document)
     {
         var errors = new List<string>();
+        var paths = document.Paths;
 
         if (string.IsNullOrWhiteSpace(document.OpenApi))
         {
             errors.Add("The 'openapi' field is required.");
         }
 
-        if (document.Paths.Count == 0)
+        if (paths is null || paths.Count == 0)
         {
             errors.Add("At least one path must be configured under 'paths'.");
         }
 
-        foreach (var pathEntry in document.Paths)
+        if (paths is null)
+        {
+            if (errors.Count > 0)
+            {
+                throw new InvalidOperationException(
+                    "Invalid stub definition:" + Environment.NewLine + string.Join(Environment.NewLine, errors.Select(error => "- " + error)));
+            }
+
+            return;
+        }
+
+        foreach (var pathEntry in paths)
         {
             if (pathEntry.Value.Get is null && pathEntry.Value.Post is null)
             {
@@ -106,6 +118,11 @@ public sealed class StubDefinitionLoader
         if (operation is null)
         {
             return;
+        }
+
+        if (operation.Responses.Count == 0 && operation.Matches.Count == 0)
+        {
+            errors.Add($"Path '{path}' {method.ToUpperInvariant()} must define at least one response or x-match entry.");
         }
 
         foreach (var responseEntry in operation.Responses)
@@ -164,6 +181,14 @@ public sealed class StubDefinitionLoader
             {
                 errors.Add($"Path '{path}' {method.ToUpperInvariant()} {location} references missing response file '{responseFile}'.");
             }
+        }
+
+        if (content.Count == 0)
+        {
+            if (string.IsNullOrWhiteSpace(responseFile))
+            {
+                errors.Add($"Path '{path}' {method.ToUpperInvariant()} {location} must define '{JsonContentType}' content or 'x-response-file'.");
+            }
 
             return;
         }
@@ -171,6 +196,11 @@ public sealed class StubDefinitionLoader
         if (!content.TryGetValue(JsonContentType, out var mediaType))
         {
             errors.Add($"Path '{path}' {method.ToUpperInvariant()} {location} must define '{JsonContentType}' content or 'x-response-file'.");
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(responseFile))
+        {
             return;
         }
 

--- a/tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs
@@ -8,6 +8,81 @@ namespace SemanticStub.Api.Tests.Unit;
 public sealed class StubDefinitionLoaderTests
 {
     [Fact]
+    public void LoadDefaultDefinition_ThrowsWhenOpenApiIsMissing()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            paths:
+              /hello:
+                get:
+                  responses:
+                    "200":
+                      description: ok
+                      content:
+                        application/json:
+                          example:
+                            message: hello
+            """);
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
+
+        Assert.Contains("The 'openapi' field is required.", exception.Message);
+    }
+
+    [Fact]
+    public void LoadDefaultDefinition_ThrowsWhenPathsIsNull()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+            """);
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
+
+        Assert.Contains("At least one path must be configured under 'paths'.", exception.Message);
+    }
+
+    [Fact]
+    public void LoadDefaultDefinition_ThrowsWhenPathHasNoSupportedOperation()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+              /hello: {}
+            """);
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
+
+        Assert.Contains("Path '/hello' must define at least one supported operation.", exception.Message);
+    }
+
+    [Fact]
+    public void LoadDefaultDefinition_ThrowsWhenOperationHasNoResponses()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+              /hello:
+                get: {}
+            """);
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
+
+        Assert.Contains("Path '/hello' GET must define at least one response or x-match entry.", exception.Message);
+    }
+
+    [Fact]
     public void LoadDefaultDefinition_ThrowsForMissingResponseFile()
     {
         using var workspace = TestWorkspace.Create(
@@ -62,6 +137,31 @@ public sealed class StubDefinitionLoaderTests
         var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
 
         Assert.Contains("x-match[0] must define a positive statusCode", exception.Message);
+    }
+
+    [Fact]
+    public void LoadDefaultDefinition_ThrowsWhenResponseFileContentTypeIsInvalid()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+              /users:
+                get:
+                  responses:
+                    "200":
+                      description: ok
+                      x-response-file: users.json
+                      content:
+                        text/plain: {}
+            """,
+            ("users.json", "[{\"id\":1,\"name\":\"Alice\"}]"));
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
+
+        Assert.Contains("must define 'application/json' content or 'x-response-file'", exception.Message);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- validate stub definitions during loading so invalid configs fail at startup
- report actionable errors for missing response files, invalid matched responses, and missing JSON examples
- add unit tests covering invalid and valid definition loading

## Validation
- dotnet build
- dotnet test