### PR TITLE
fix: expand edge-case coverage

### DIFF
--- a/src/SemanticStub.Api/Services/StubService.cs
+++ b/src/SemanticStub.Api/Services/StubService.cs
@@ -169,6 +169,11 @@ public sealed class StubService
             return null;
         }
 
+        if (mediaType.Example is null)
+        {
+            return null;
+        }
+
         return StubDefinitionLoader.SerializeExample(mediaType.Example);
     }
 }

--- a/tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs
@@ -140,6 +140,92 @@ public sealed class StubDefinitionLoaderTests
     }
 
     [Fact]
+    public void LoadDefaultDefinition_ThrowsForMalformedMatchedResponseWithoutResponse()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+              /users:
+                get:
+                  x-match:
+                    - query:
+                        role: admin
+                  responses:
+                    "200":
+                      description: ok
+                      content:
+                        application/json:
+                          example:
+                            message: default
+            """);
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
+
+        Assert.Contains("x-match[0] must define a positive statusCode", exception.Message);
+        Assert.Contains("x-match[0].response must define 'application/json' content or 'x-response-file'", exception.Message);
+    }
+
+    [Fact]
+    public void LoadDefaultDefinition_ThrowsForMatchedResponseWithMissingResponseFile()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+              /users:
+                get:
+                  x-match:
+                    - query:
+                        role: admin
+                      response:
+                        statusCode: 200
+                        x-response-file: admin-users.json
+                  responses:
+                    "200":
+                      description: ok
+                      content:
+                        application/json:
+                          example:
+                            message: default
+            """);
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
+
+        Assert.Contains("references missing response file 'admin-users.json'", exception.Message);
+        Assert.Contains("Path '/users' GET x-match[0].response", exception.Message);
+    }
+
+    [Fact]
+    public void LoadDefaultDefinition_ThrowsForUnsupportedResponseStatusKey()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+              /hello:
+                get:
+                  responses:
+                    default:
+                      description: ok
+                      content:
+                        application/json:
+                          example:
+                            message: hello
+            """);
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
+
+        Assert.Contains("uses unsupported response key 'default'", exception.Message);
+    }
+
+    [Fact]
     public void LoadDefaultDefinition_ThrowsWhenResponseFileContentTypeIsInvalid()
     {
         using var workspace = TestWorkspace.Create(

--- a/tests/SemanticStub.Api.Tests/Unit/StubServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubServiceTests.cs
@@ -293,4 +293,129 @@ public sealed class StubServiceTests
 
         Assert.Equal(StubMatchResult.ResponseNotConfigured, matched);
     }
+
+    [Fact]
+    public void TryGetResponse_ReturnsResponseNotConfigured_WhenFallbackResponseHasNoJsonContent()
+    {
+        var document = new StubDocument
+        {
+            Paths = new Dictionary<string, PathItemDefinition>(StringComparer.Ordinal)
+            {
+                ["/users"] = new()
+                {
+                    Get = new OperationDefinition
+                    {
+                        Matches =
+                        [
+                            new QueryMatchDefinition
+                            {
+                                Query = new Dictionary<string, string>(StringComparer.Ordinal)
+                                {
+                                    ["role"] = "admin"
+                                },
+                                Response = new QueryMatchResponseDefinition
+                                {
+                                    StatusCode = 200,
+                                    Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+                                    {
+                                        ["application/json"] = new()
+                                        {
+                                            Example = new Dictionary<object, object>
+                                            {
+                                                ["message"] = "admin"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        Responses = new Dictionary<string, ResponseDefinition>(StringComparer.Ordinal)
+                        {
+                            ["200"] = new()
+                            {
+                                Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+                                {
+                                    ["text/plain"] = new()
+                                    {
+                                        Example = "default"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        var service = new StubService(document);
+        var query = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["role"] = "guest"
+        };
+
+        var matched = service.TryGetResponse(HttpMethods.Get, "/users", query, out _);
+
+        Assert.Equal(StubMatchResult.ResponseNotConfigured, matched);
+    }
+
+    [Fact]
+    public void TryGetResponse_ReturnsResponseNotConfigured_WhenFallbackJsonExampleIsMissing()
+    {
+        var document = new StubDocument
+        {
+            Paths = new Dictionary<string, PathItemDefinition>(StringComparer.Ordinal)
+            {
+                ["/users"] = new()
+                {
+                    Get = new OperationDefinition
+                    {
+                        Matches =
+                        [
+                            new QueryMatchDefinition
+                            {
+                                Query = new Dictionary<string, string>(StringComparer.Ordinal)
+                                {
+                                    ["role"] = "admin"
+                                },
+                                Response = new QueryMatchResponseDefinition
+                                {
+                                    StatusCode = 200,
+                                    Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+                                    {
+                                        ["application/json"] = new()
+                                        {
+                                            Example = new Dictionary<object, object>
+                                            {
+                                                ["message"] = "admin"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        Responses = new Dictionary<string, ResponseDefinition>(StringComparer.Ordinal)
+                        {
+                            ["200"] = new()
+                            {
+                                Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+                                {
+                                    ["application/json"] = new()
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        var service = new StubService(document);
+        var query = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["role"] = "guest"
+        };
+
+        var matched = service.TryGetResponse(HttpMethods.Get, "/users", query, out _);
+
+        Assert.Equal(StubMatchResult.ResponseNotConfigured, matched);
+    }
 }


### PR DESCRIPTION
## Summary
- expand loader coverage for malformed x-match entries, missing matched response files, and unsupported response keys
- add matcher fallback tests for invalid default responses
- treat missing application/json examples as response misconfiguration instead of serializing null

## Validation
- dotnet build
- dotnet test

## Impact
- no YAML schema changes
- existing compatibility preserved while tightening invalid-definition handling