### PR TITLE
feat: configure stub definitions path

### DIFF
--- a/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionLoader.cs
+++ b/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionLoader.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Microsoft.Extensions.Options;
 using SemanticStub.Api.Models;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
@@ -8,13 +9,22 @@ namespace SemanticStub.Api.Infrastructure.Yaml;
 public sealed class StubDefinitionLoader
 {
     private const string DefaultStubFileName = "basic-routing.yaml";
+    private static readonly string[] AdditionalStubFilePatterns = ["*.stub.yaml", "*.stub.yml"];
+    private const string DefaultDefinitionsDirectoryName = "samples";
     private const string JsonContentType = "application/json";
     private readonly IWebHostEnvironment environment;
+    private readonly StubSettings settings;
     private readonly IDeserializer deserializer;
 
     public StubDefinitionLoader(IWebHostEnvironment environment)
+        : this(environment, Options.Create(new StubSettings()))
+    {
+    }
+
+    public StubDefinitionLoader(IWebHostEnvironment environment, IOptions<StubSettings> settings)
     {
         this.environment = environment;
+        this.settings = settings.Value;
         deserializer = new DeserializerBuilder()
             .WithNamingConvention(CamelCaseNamingConvention.Instance)
             .IgnoreUnmatchedProperties()
@@ -23,41 +33,135 @@ public sealed class StubDefinitionLoader
 
     public StubDocument LoadDefaultDefinition()
     {
-        var path = ResolveSamplePath(DefaultStubFileName);
-        return LoadDefinition(path);
+        var definitionsRootPath = ResolveDefinitionsDirectory();
+        var definitionPaths = ResolveDefinitionPaths();
+        var documents = definitionPaths
+            .Select(path => (Path: path, Label: GetDefinitionSourceLabel(path, definitionsRootPath), Document: LoadDefinition(path)))
+            .ToArray();
+
+        return MergeDefinitions(documents);
     }
 
     private StubDocument LoadDefinition(string path)
     {
         var yaml = File.ReadAllText(path);
         var document = deserializer.Deserialize<StubDocument>(yaml);
+        var definitionDirectory = Path.GetDirectoryName(path)
+            ?? throw new InvalidOperationException($"Could not determine definition directory for '{path}'.");
 
         if (document is null)
         {
             throw new InvalidOperationException("Failed to deserialize stub definition.");
         }
 
-        ValidateDocument(document);
+        ValidateDocument(document, definitionDirectory);
 
-        return document;
+        return NormalizeDocument(document, definitionDirectory);
     }
 
     public string LoadResponseFileContent(string fileName)
     {
+        if (Path.IsPathRooted(fileName))
+        {
+            return File.ReadAllText(fileName);
+        }
+
         var path = ResolveSamplePath(fileName);
 
         return File.ReadAllText(path);
     }
 
+    private string[] ResolveDefinitionPaths()
+    {
+        var samplesPath = ResolveDefinitionsDirectory();
+        var paths = new List<string>();
+        var defaultDefinitionPath = Path.Combine(samplesPath, DefaultStubFileName);
+
+        if (File.Exists(defaultDefinitionPath))
+        {
+            paths.Add(defaultDefinitionPath);
+        }
+
+        foreach (var pattern in AdditionalStubFilePatterns)
+        {
+            var discoveredPaths = Directory
+                .GetFiles(samplesPath, pattern, SearchOption.AllDirectories)
+                .OrderBy(path => path, StringComparer.Ordinal);
+
+            foreach (var discoveredPath in discoveredPaths)
+            {
+                if (!paths.Contains(discoveredPath, StringComparer.Ordinal))
+                {
+                    paths.Add(discoveredPath);
+                }
+            }
+        }
+
+        if (paths.Count > 0)
+        {
+            return [.. paths];
+        }
+
+        throw new FileNotFoundException(
+            $"Could not locate {Path.Combine(GetDefinitionsPathLabel(), DefaultStubFileName)} from the current content root.",
+            Path.Combine(GetDefinitionsPathLabel(), DefaultStubFileName));
+    }
+
     private string ResolveSamplePath(string fileName)
     {
+        var samplesPath = ResolveDefinitionsDirectory();
+        var candidate = Path.Combine(samplesPath, fileName);
+
+        if (File.Exists(candidate))
+        {
+            return candidate;
+        }
+
+        throw new FileNotFoundException(
+            $"Could not locate {Path.Combine(GetDefinitionsPathLabel(), fileName)} from the current content root.",
+            Path.Combine(GetDefinitionsPathLabel(), fileName));
+    }
+
+    private string ResolveDefinitionsDirectory()
+    {
+        if (!string.IsNullOrWhiteSpace(settings.DefinitionsPath))
+        {
+            var configuredPath = settings.DefinitionsPath!;
+
+            if (Path.IsPathRooted(configuredPath))
+            {
+                if (Directory.Exists(configuredPath))
+                {
+                    return configuredPath;
+                }
+
+                throw new DirectoryNotFoundException($"Could not locate configured definitions path '{configuredPath}'.");
+            }
+
+            var configuredCurrent = new DirectoryInfo(environment.ContentRootPath);
+
+            while (configuredCurrent is not null)
+            {
+                var candidate = Path.Combine(configuredCurrent.FullName, configuredPath);
+
+                if (Directory.Exists(candidate))
+                {
+                    return candidate;
+                }
+
+                configuredCurrent = configuredCurrent.Parent;
+            }
+
+            throw new DirectoryNotFoundException($"Could not locate configured definitions path '{configuredPath}'.");
+        }
+
         var current = new DirectoryInfo(environment.ContentRootPath);
 
         while (current is not null)
         {
-            var candidate = Path.Combine(current.FullName, "samples", fileName);
+            var candidate = Path.Combine(current.FullName, DefaultDefinitionsDirectoryName);
 
-            if (File.Exists(candidate))
+            if (Directory.Exists(candidate))
             {
                 return candidate;
             }
@@ -65,10 +169,106 @@ public sealed class StubDefinitionLoader
             current = current.Parent;
         }
 
-        throw new FileNotFoundException($"Could not locate samples/{fileName} from the current content root.", Path.Combine("samples", fileName));
+        throw new FileNotFoundException($"Could not locate {DefaultDefinitionsDirectoryName} from the current content root.", DefaultDefinitionsDirectoryName);
     }
 
-    private void ValidateDocument(StubDocument document)
+    private string GetDefinitionsPathLabel()
+    {
+        return string.IsNullOrWhiteSpace(settings.DefinitionsPath)
+            ? DefaultDefinitionsDirectoryName
+            : settings.DefinitionsPath!;
+    }
+
+    private static StubDocument MergeDefinitions(IReadOnlyCollection<(string Path, string Label, StubDocument Document)> sources)
+    {
+        if (sources.Count == 1)
+        {
+            return sources.First().Document;
+        }
+
+        var openApiVersions = sources
+            .Select(source => source.Document.OpenApi)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        if (openApiVersions.Length != 1)
+        {
+            throw new InvalidOperationException("Stub definition files must use the same 'openapi' version.");
+        }
+
+        var mergedPaths = new Dictionary<string, PathItemDefinition>(StringComparer.Ordinal);
+        var pathSources = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var source in sources)
+        {
+            foreach (var pathEntry in source.Document.Paths)
+            {
+                if (!mergedPaths.TryGetValue(pathEntry.Key, out var existingPathItem))
+                {
+                    mergedPaths[pathEntry.Key] = pathEntry.Value;
+                    pathSources[pathEntry.Key] = source.Label;
+                    continue;
+                }
+
+                var mergedPathItem = MergePathItem(
+                    pathEntry.Key,
+                    existingPathItem,
+                    pathEntry.Value,
+                    pathSources[pathEntry.Key],
+                    source.Label);
+
+                mergedPaths[pathEntry.Key] = mergedPathItem;
+            }
+        }
+
+        return new StubDocument
+        {
+            OpenApi = openApiVersions[0],
+            Paths = mergedPaths
+        };
+    }
+
+    private static PathItemDefinition MergePathItem(
+        string path,
+        PathItemDefinition existing,
+        PathItemDefinition incoming,
+        string existingSource,
+        string incomingSource)
+    {
+        return new PathItemDefinition
+        {
+            Get = MergeOperation(path, "GET", existing.Get, incoming.Get, existingSource, incomingSource),
+            Post = MergeOperation(path, "POST", existing.Post, incoming.Post, existingSource, incomingSource)
+        };
+    }
+
+    private static OperationDefinition? MergeOperation(
+        string path,
+        string method,
+        OperationDefinition? existing,
+        OperationDefinition? incoming,
+        string existingSource,
+        string incomingSource)
+    {
+        if (existing is null)
+        {
+            return incoming;
+        }
+
+        if (incoming is null)
+        {
+            return existing;
+        }
+
+        throw new InvalidOperationException(
+            $"Path '{path}' {method} is defined in both '{existingSource}' and '{incomingSource}'.");
+    }
+
+    private static string GetDefinitionSourceLabel(string definitionPath, string definitionsRootPath)
+    {
+        return Path.GetRelativePath(definitionsRootPath, definitionPath);
+    }
+
+    private void ValidateDocument(StubDocument document, string definitionDirectory)
     {
         var errors = new List<string>();
         var paths = document.Paths;
@@ -102,8 +302,8 @@ public sealed class StubDefinitionLoader
                 continue;
             }
 
-            ValidateOperation(pathEntry.Key, "get", pathEntry.Value.Get, errors);
-            ValidateOperation(pathEntry.Key, "post", pathEntry.Value.Post, errors);
+            ValidateOperation(pathEntry.Key, "get", pathEntry.Value.Get, definitionDirectory, errors);
+            ValidateOperation(pathEntry.Key, "post", pathEntry.Value.Post, definitionDirectory, errors);
         }
 
         if (errors.Count > 0)
@@ -113,7 +313,12 @@ public sealed class StubDefinitionLoader
         }
     }
 
-    private void ValidateOperation(string path, string method, OperationDefinition? operation, ICollection<string> errors)
+    private void ValidateOperation(
+        string path,
+        string method,
+        OperationDefinition? operation,
+        string definitionDirectory,
+        ICollection<string> errors)
     {
         if (operation is null)
         {
@@ -133,6 +338,7 @@ public sealed class StubDefinitionLoader
                 $"responses['{responseEntry.Key}']",
                 responseEntry.Key,
                 responseEntry.Value.ResponseFile,
+                definitionDirectory,
                 responseEntry.Value.Content,
                 errors);
         }
@@ -152,6 +358,7 @@ public sealed class StubDefinitionLoader
                 $"x-match[{index}].response",
                 match.Response.StatusCode.ToString(),
                 match.Response.ResponseFile,
+                definitionDirectory,
                 match.Response.Content,
                 errors);
         }
@@ -163,6 +370,7 @@ public sealed class StubDefinitionLoader
         string location,
         string statusCode,
         string? responseFile,
+        string definitionDirectory,
         IReadOnlyDictionary<string, MediaTypeDefinition> content,
         ICollection<string> errors)
     {
@@ -173,11 +381,9 @@ public sealed class StubDefinitionLoader
 
         if (!string.IsNullOrWhiteSpace(responseFile))
         {
-            try
-            {
-                ResolveSamplePath(responseFile);
-            }
-            catch (FileNotFoundException)
+            var resolvedPath = ResolveResponseFilePath(definitionDirectory, responseFile);
+
+            if (!File.Exists(resolvedPath))
             {
                 errors.Add($"Path '{path}' {method.ToUpperInvariant()} {location} references missing response file '{responseFile}'.");
             }
@@ -208,6 +414,77 @@ public sealed class StubDefinitionLoader
         {
             errors.Add($"Path '{path}' {method.ToUpperInvariant()} {location} must define an example for '{JsonContentType}'.");
         }
+    }
+
+    private static StubDocument NormalizeDocument(StubDocument document, string definitionDirectory)
+    {
+        return new StubDocument
+        {
+            OpenApi = document.OpenApi,
+            Paths = document.Paths.ToDictionary(
+                entry => entry.Key,
+                entry => NormalizePathItem(entry.Value, definitionDirectory),
+                StringComparer.Ordinal)
+        };
+    }
+
+    private static PathItemDefinition NormalizePathItem(PathItemDefinition pathItem, string definitionDirectory)
+    {
+        return new PathItemDefinition
+        {
+            Get = NormalizeOperation(pathItem.Get, definitionDirectory),
+            Post = NormalizeOperation(pathItem.Post, definitionDirectory)
+        };
+    }
+
+    private static OperationDefinition? NormalizeOperation(OperationDefinition? operation, string definitionDirectory)
+    {
+        if (operation is null)
+        {
+            return null;
+        }
+
+        return new OperationDefinition
+        {
+            OperationId = operation.OperationId,
+            Matches =
+            [
+                .. operation.Matches.Select(match => new QueryMatchDefinition
+                {
+                    Query = new Dictionary<string, string>(match.Query, StringComparer.Ordinal),
+                    Response = new QueryMatchResponseDefinition
+                    {
+                        StatusCode = match.Response.StatusCode,
+                        ResponseFile = ResolveResponseFilePath(definitionDirectory, match.Response.ResponseFile),
+                        Content = new Dictionary<string, MediaTypeDefinition>(match.Response.Content, StringComparer.Ordinal)
+                    }
+                })
+            ],
+            Responses = operation.Responses.ToDictionary(
+                entry => entry.Key,
+                entry => new ResponseDefinition
+                {
+                    Description = entry.Value.Description,
+                    ResponseFile = ResolveResponseFilePath(definitionDirectory, entry.Value.ResponseFile),
+                    Content = new Dictionary<string, MediaTypeDefinition>(entry.Value.Content, StringComparer.Ordinal)
+                },
+                StringComparer.Ordinal)
+        };
+    }
+
+    private static string? ResolveResponseFilePath(string definitionDirectory, string? responseFile)
+    {
+        if (string.IsNullOrWhiteSpace(responseFile))
+        {
+            return responseFile;
+        }
+
+        if (Path.IsPathRooted(responseFile))
+        {
+            return responseFile;
+        }
+
+        return Path.GetFullPath(Path.Combine(definitionDirectory, responseFile));
     }
 
     public static string SerializeExample(object? example)

--- a/src/SemanticStub.Api/Infrastructure/Yaml/StubSettings.cs
+++ b/src/SemanticStub.Api/Infrastructure/Yaml/StubSettings.cs
@@ -1,0 +1,6 @@
+namespace SemanticStub.Api.Infrastructure.Yaml;
+
+public sealed class StubSettings
+{
+    public string? DefinitionsPath { get; init; }
+}

--- a/src/SemanticStub.Api/Program.cs
+++ b/src/SemanticStub.Api/Program.cs
@@ -4,6 +4,7 @@ using SemanticStub.Api.Services;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
+builder.Services.Configure<StubSettings>(builder.Configuration.GetSection("StubSettings"));
 builder.Services.AddSingleton<StubDefinitionLoader>();
 builder.Services.AddSingleton<StubService>();
 

--- a/src/SemanticStub.Api/appsettings.json
+++ b/src/SemanticStub.Api/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "StubSettings": {
+    "DefinitionsPath": "samples"
+  }
+}

--- a/tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
 using SemanticStub.Api.Infrastructure.Yaml;
 using Xunit;
 
@@ -241,7 +242,10 @@ public sealed class StubDefinitionLoaderTests
                       content:
                         text/plain: {}
             """,
-            ("users.json", "[{\"id\":1,\"name\":\"Alice\"}]"));
+            sampleFiles:
+            [
+                ("users.json", "[{\"id\":1,\"name\":\"Alice\"}]")
+            ]);
 
         var loader = new StubDefinitionLoader(workspace.Environment);
 
@@ -287,7 +291,10 @@ public sealed class StubDefinitionLoaderTests
                       description: ok
                       x-response-file: users.json
             """,
-            ("users.json", "[{\"id\":1,\"name\":\"Alice\"}]"));
+            sampleFiles:
+            [
+                ("users.json", "[{\"id\":1,\"name\":\"Alice\"}]")
+            ]);
 
         var loader = new StubDefinitionLoader(workspace.Environment);
 
@@ -295,6 +302,280 @@ public sealed class StubDefinitionLoaderTests
 
         Assert.Equal("3.1.0", document.OpenApi);
         Assert.True(document.Paths.ContainsKey("/users"));
+    }
+
+    [Fact]
+    public void LoadDefaultDefinition_UsesConfiguredDefinitionsPath()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+              /configured:
+                get:
+                  responses:
+                    "200":
+                      description: ok
+                      content:
+                        application/json:
+                          example:
+                            message: configured
+            """,
+            definitionsDirectoryName: "custom-stubs");
+
+        var loader = new StubDefinitionLoader(
+            workspace.Environment,
+            Options.Create(new StubSettings
+            {
+                DefinitionsPath = "custom-stubs"
+            }));
+
+        var document = loader.LoadDefaultDefinition();
+
+        Assert.True(document.Paths.ContainsKey("/configured"));
+    }
+
+    [Fact]
+    public void LoadDefaultDefinition_ResolvesResponseFileRelativeToDefinitionFile()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+              /users:
+                get:
+                  responses:
+                    "200":
+                      description: ok
+                      x-response-file: responses/users.json
+            """,
+            sampleFiles:
+            [
+                ("responses/users.json", "[{\"id\":1,\"name\":\"Alice\"}]")
+            ]);
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var document = loader.LoadDefaultDefinition();
+        var responseFile = document.Paths["/users"].Get!.Responses["200"].ResponseFile;
+
+        Assert.Equal(
+            Path.Combine(workspace.RootPath, "samples", "responses", "users.json"),
+            responseFile);
+    }
+
+    [Fact]
+    public void LoadDefaultDefinition_ResolvesResponseFileRelativeToAdditionalDefinitionFile()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+              /status:
+                get:
+                  responses:
+                    "200":
+                      description: ok
+                      content:
+                        application/json:
+                          example:
+                            status: base
+            """,
+            additionalStubFiles:
+            [
+                ("features/orders.stub.yaml",
+                """
+                openapi: 3.1.0
+                paths:
+                  /orders:
+                    get:
+                      responses:
+                        "200":
+                          description: ok
+                          x-response-file: responses/orders.json
+                """),
+                ("features/responses/orders.json", "[{\"id\":10}]")
+            ]);
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var document = loader.LoadDefaultDefinition();
+        var responseFile = document.Paths["/orders"].Get!.Responses["200"].ResponseFile;
+
+        Assert.Equal(
+            Path.Combine(workspace.RootPath, "samples", "features", "responses", "orders.json"),
+            responseFile);
+    }
+
+    [Fact]
+    public void LoadDefaultDefinition_LoadsAdditionalStubFiles()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+              /users:
+                get:
+                  responses:
+                    "200":
+                      description: ok
+                      content:
+                        application/json:
+                          example:
+                            source: base
+            """,
+            additionalStubFiles:
+            [
+                ("orders.stub.yaml",
+                """
+                openapi: 3.1.0
+                paths:
+                  /orders:
+                    get:
+                      responses:
+                        "200":
+                          description: ok
+                          content:
+                            application/json:
+                              example:
+                                source: additional
+                """)
+            ]);
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var document = loader.LoadDefaultDefinition();
+
+        Assert.Equal("3.1.0", document.OpenApi);
+        Assert.True(document.Paths.ContainsKey("/users"));
+        Assert.True(document.Paths.ContainsKey("/orders"));
+    }
+
+    [Fact]
+    public void LoadDefaultDefinition_MergesDistinctMethodsAcrossStubFiles()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+              /users:
+                get:
+                  responses:
+                    "200":
+                      description: ok
+                      content:
+                        application/json:
+                          example:
+                            method: get
+            """,
+            additionalStubFiles:
+            [
+                ("users.stub.yaml",
+                """
+                openapi: 3.1.0
+                paths:
+                  /users:
+                    post:
+                      responses:
+                        "201":
+                          description: created
+                          content:
+                            application/json:
+                              example:
+                                method: post
+                """)
+            ]);
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var document = loader.LoadDefaultDefinition();
+
+        Assert.NotNull(document.Paths["/users"].Get);
+        Assert.NotNull(document.Paths["/users"].Post);
+    }
+
+    [Fact]
+    public void LoadDefaultDefinition_ThrowsWhenStubFilesDefineSamePathAndMethod()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+              /users:
+                get:
+                  responses:
+                    "200":
+                      description: ok
+                      content:
+                        application/json:
+                          example:
+                            source: base
+            """,
+            additionalStubFiles:
+            [
+                ("users.stub.yaml",
+                """
+                openapi: 3.1.0
+                paths:
+                  /users:
+                    get:
+                      responses:
+                        "200":
+                          description: ok
+                          content:
+                            application/json:
+                              example:
+                                source: duplicate
+                """)
+            ]);
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
+
+        Assert.Contains("Path '/users' GET is defined in both 'basic-routing.yaml' and 'users.stub.yaml'.", exception.Message);
+    }
+
+    [Fact]
+    public void LoadDefaultDefinition_ThrowsWhenStubFilesUseDifferentOpenApiVersions()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+              /users:
+                get:
+                  responses:
+                    "200":
+                      description: ok
+                      content:
+                        application/json:
+                          example:
+                            source: base
+            """,
+            additionalStubFiles:
+            [
+                ("orders.stub.yaml",
+                """
+                openapi: 3.0.3
+                paths:
+                  /orders:
+                    get:
+                      responses:
+                        "200":
+                          description: ok
+                          content:
+                            application/json:
+                              example:
+                                source: additional
+                """)
+            ]);
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
+
+        Assert.Contains("must use the same 'openapi' version", exception.Message);
     }
 
     private sealed class TestWorkspace : IDisposable
@@ -312,19 +593,41 @@ public sealed class StubDefinitionLoaderTests
 
         public IWebHostEnvironment Environment { get; }
 
-        public static TestWorkspace Create(string yaml, params (string FileName, string Content)[] sampleFiles)
+        public static TestWorkspace Create(
+            string yaml,
+            (string FileName, string Content)[]? sampleFiles = null,
+            (string FileName, string Content)[]? additionalStubFiles = null,
+            string definitionsDirectoryName = "samples")
         {
             var rootPath = Path.Combine(Path.GetTempPath(), "semanticstub-tests", Guid.NewGuid().ToString("N"));
-            var samplesPath = Path.Combine(rootPath, "samples");
+            var samplesPath = Path.Combine(rootPath, definitionsDirectoryName);
             Directory.CreateDirectory(samplesPath);
-            File.WriteAllText(Path.Combine(samplesPath, "basic-routing.yaml"), yaml);
+            WriteFile(samplesPath, "basic-routing.yaml", yaml);
 
-            foreach (var (fileName, content) in sampleFiles)
+            foreach (var (fileName, content) in sampleFiles ?? [])
             {
-                File.WriteAllText(Path.Combine(samplesPath, fileName), content);
+                WriteFile(samplesPath, fileName, content);
+            }
+
+            foreach (var (fileName, content) in additionalStubFiles ?? [])
+            {
+                WriteFile(samplesPath, fileName, content);
             }
 
             return new TestWorkspace(rootPath);
+        }
+
+        private static void WriteFile(string rootPath, string relativePath, string content)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+
+            if (!string.IsNullOrWhiteSpace(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, content);
         }
 
         public void Dispose()


### PR DESCRIPTION
## Summary
- make the stub definitions directory configurable via StubSettings:DefinitionsPath
- keep existing samples compatibility while loading additional .stub.yaml and .stub.yml files recursively
- resolve x-response-file relative to the YAML file that declares it and add regression coverage

## Validation
- dotnet build SemanticStub.sln
- dotnet test SemanticStub.sln