### PR TITLE
feat: add body-based request matching

### DIFF
--- a/samples/basic-routing.yaml
+++ b/samples/basic-routing.yaml
@@ -93,6 +93,17 @@ paths:
   /login:
     post:
       operationId: login
+      x-match:
+        - body:
+            username: demo
+            password: secret
+          response:
+            statusCode: 200
+            content:
+              application/json:
+                example:
+                  result: ok
+                  token: demo-token
       requestBody:
         required: true
         content:
@@ -122,7 +133,9 @@ paths:
                 properties:
                   result:
                     type: string
+                  token:
+                    type: string
                 required:
                   - result
               example:
-                result: ok
+                result: invalid

--- a/src/SemanticStub.Api/Controllers/StubController.cs
+++ b/src/SemanticStub.Api/Controllers/StubController.cs
@@ -16,22 +16,23 @@ public sealed class StubController : ControllerBase
     }
 
     [HttpGet]
-    public IActionResult Get(string? path)
+    public Task<IActionResult> Get(string? path)
     {
         return HandleRequest(HttpMethods.Get, path);
     }
 
     [HttpPost]
-    public IActionResult Post(string? path)
+    public Task<IActionResult> Post(string? path)
     {
         return HandleRequest(HttpMethods.Post, path);
     }
 
-    private IActionResult HandleRequest(string method, string? path)
+    private async Task<IActionResult> HandleRequest(string method, string? path)
     {
         var requestPath = string.IsNullOrEmpty(path) ? "/" : "/" + path;
         var query = Request.Query.ToDictionary(entry => entry.Key, entry => entry.Value.ToString(), StringComparer.Ordinal);
-        var matchResult = stubService.TryGetResponse(method, requestPath, query, out var response);
+        var requestBody = await ReadRequestBodyAsync();
+        var matchResult = stubService.TryGetResponse(method, requestPath, query, requestBody, out var response);
 
         if (matchResult == StubMatchResult.PathNotFound)
         {
@@ -54,5 +55,13 @@ public sealed class StubController : ControllerBase
             ContentType = response.ContentType,
             Content = response.Body
         };
+    }
+
+    private async Task<string?> ReadRequestBodyAsync()
+    {
+        using var reader = new StreamReader(Request.Body);
+        var body = await reader.ReadToEndAsync();
+
+        return string.IsNullOrWhiteSpace(body) ? null : body;
     }
 }

--- a/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionLoader.cs
+++ b/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionLoader.cs
@@ -452,6 +452,7 @@ public sealed class StubDefinitionLoader
                 .. operation.Matches.Select(match => new QueryMatchDefinition
                 {
                     Query = new Dictionary<string, string>(match.Query, StringComparer.Ordinal),
+                    Body = NormalizeYamlValue(match.Body),
                     Response = new QueryMatchResponseDefinition
                     {
                         StatusCode = match.Response.StatusCode,

--- a/src/SemanticStub.Api/Models/QueryMatchDefinition.cs
+++ b/src/SemanticStub.Api/Models/QueryMatchDefinition.cs
@@ -6,5 +6,7 @@ public sealed class QueryMatchDefinition
 {
     public Dictionary<string, string> Query { get; init; } = new(StringComparer.Ordinal);
 
+    public object? Body { get; init; }
+
     public QueryMatchResponseDefinition Response { get; init; } = new();
 }

--- a/src/SemanticStub.Api/Services/StubService.cs
+++ b/src/SemanticStub.Api/Services/StubService.cs
@@ -1,3 +1,5 @@
+using System.Collections;
+using System.Text.Json;
 using SemanticStub.Api.Infrastructure.Yaml;
 using SemanticStub.Api.Models;
 
@@ -29,10 +31,15 @@ public sealed class StubService
 
     public StubMatchResult TryGetResponse(string method, string path, out StubResponse response)
     {
-        return TryGetResponse(method, path, new Dictionary<string, string>(StringComparer.Ordinal), out response);
+        return TryGetResponse(method, path, new Dictionary<string, string>(StringComparer.Ordinal), body: null, out response);
     }
 
     public StubMatchResult TryGetResponse(string method, string path, IReadOnlyDictionary<string, string> query, out StubResponse response)
+    {
+        return TryGetResponse(method, path, query, body: null, out response);
+    }
+
+    public StubMatchResult TryGetResponse(string method, string path, IReadOnlyDictionary<string, string> query, string? body, out StubResponse response)
     {
         response = null!;
 
@@ -48,7 +55,7 @@ public sealed class StubService
             return StubMatchResult.MethodNotAllowed;
         }
 
-        var queryMatchResult = TryBuildMatchedQueryResponse(operation, query, out response);
+        var queryMatchResult = TryBuildMatchedQueryResponse(operation, query, body, out response);
 
         if (queryMatchResult == QueryMatchEvaluationResult.Matched)
         {
@@ -71,9 +78,9 @@ public sealed class StubService
             return StubMatchResult.ResponseNotConfigured;
         }
 
-        var body = BuildResponseBody(matchedResponse.Value);
+        var responseBody = BuildResponseBody(matchedResponse.Value);
 
-        if (body is null)
+        if (responseBody is null)
         {
             return StubMatchResult.ResponseNotConfigured;
         }
@@ -82,7 +89,7 @@ public sealed class StubService
         {
             StatusCode = statusCode,
             ContentType = JsonContentType,
-            Body = body
+            Body = responseBody
         };
 
         return StubMatchResult.Matched;
@@ -103,7 +110,11 @@ public sealed class StubService
         return null;
     }
 
-    private QueryMatchEvaluationResult TryBuildMatchedQueryResponse(OperationDefinition operation, IReadOnlyDictionary<string, string> query, out StubResponse response)
+    private QueryMatchEvaluationResult TryBuildMatchedQueryResponse(
+        OperationDefinition operation,
+        IReadOnlyDictionary<string, string> query,
+        string? body,
+        out StubResponse response)
     {
         response = null!;
 
@@ -112,9 +123,11 @@ public sealed class StubService
             return QueryMatchEvaluationResult.NoMatch;
         }
 
+        using var bodyDocument = ParseRequestBody(body);
         var matchedCandidate = operation.Matches
             .Where(candidate => IsExactQueryMatch(candidate.Query, query))
-            .OrderByDescending(candidate => candidate.Query.Count)
+            .Where(candidate => IsBodyMatch(candidate.Body, bodyDocument?.RootElement))
+            .OrderByDescending(GetMatchSpecificity)
             .FirstOrDefault();
 
         if (matchedCandidate is null)
@@ -122,9 +135,9 @@ public sealed class StubService
             return QueryMatchEvaluationResult.NoMatch;
         }
 
-        var body = BuildResponseBody(matchedCandidate.Response.ResponseFile, matchedCandidate.Response.Content);
+        var responseBody = BuildResponseBody(matchedCandidate.Response.ResponseFile, matchedCandidate.Response.Content);
 
-        if (body is null || matchedCandidate.Response.StatusCode <= 0)
+        if (responseBody is null || matchedCandidate.Response.StatusCode <= 0)
         {
             return QueryMatchEvaluationResult.MatchedButInvalidResponse;
         }
@@ -133,7 +146,7 @@ public sealed class StubService
         {
             StatusCode = matchedCandidate.Response.StatusCode,
             ContentType = JsonContentType,
-            Body = body
+            Body = responseBody
         };
 
         return QueryMatchEvaluationResult.Matched;
@@ -150,6 +163,119 @@ public sealed class StubService
         }
 
         return true;
+    }
+
+    private static JsonDocument? ParseRequestBody(string? body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonDocument.Parse(body);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static bool IsBodyMatch(object? expectedBody, JsonElement? actualBody)
+    {
+        if (expectedBody is null)
+        {
+            return true;
+        }
+
+        if (actualBody is null)
+        {
+            return false;
+        }
+
+        var expectedJson = StubDefinitionLoader.SerializeExample(expectedBody);
+        using var expectedDocument = JsonDocument.Parse(expectedJson);
+
+        return IsJsonMatch(expectedDocument.RootElement, actualBody.Value);
+    }
+
+    private static bool IsJsonMatch(JsonElement expected, JsonElement actual)
+    {
+        if (expected.ValueKind == JsonValueKind.Object)
+        {
+            if (actual.ValueKind != JsonValueKind.Object)
+            {
+                return false;
+            }
+
+            foreach (var property in expected.EnumerateObject())
+            {
+                if (!actual.TryGetProperty(property.Name, out var actualProperty) ||
+                    !IsJsonMatch(property.Value, actualProperty))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        if (expected.ValueKind == JsonValueKind.Array)
+        {
+            if (actual.ValueKind != JsonValueKind.Array)
+            {
+                return false;
+            }
+
+            var expectedItems = expected.EnumerateArray().ToArray();
+            var actualItems = actual.EnumerateArray().ToArray();
+
+            if (expectedItems.Length != actualItems.Length)
+            {
+                return false;
+            }
+
+            for (var index = 0; index < expectedItems.Length; index++)
+            {
+                if (!IsJsonMatch(expectedItems[index], actualItems[index]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        if (expected.ValueKind != actual.ValueKind)
+        {
+            return false;
+        }
+
+        return expected.ValueKind switch
+        {
+            JsonValueKind.String => expected.GetString() == actual.GetString(),
+            JsonValueKind.Number => expected.GetRawText() == actual.GetRawText(),
+            JsonValueKind.True or JsonValueKind.False => expected.GetBoolean() == actual.GetBoolean(),
+            JsonValueKind.Null => true,
+            _ => expected.GetRawText() == actual.GetRawText()
+        };
+    }
+
+    private static int GetMatchSpecificity(QueryMatchDefinition match)
+    {
+        return match.Query.Count + GetBodySpecificity(match.Body);
+    }
+
+    private static int GetBodySpecificity(object? body)
+    {
+        return body switch
+        {
+            null => 0,
+            IDictionary dictionary => dictionary.Count + dictionary.Values.Cast<object?>().Sum(GetBodySpecificity),
+            IEnumerable list when body is not string => list.Cast<object?>().Sum(GetBodySpecificity),
+            _ => 1
+        };
     }
 
     private string? BuildResponseBody(ResponseDefinition responseDefinition)

--- a/tests/SemanticStub.Api.Tests/Integration/HelloWorldStubTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/HelloWorldStubTests.cs
@@ -143,6 +143,24 @@ public sealed class HelloWorldStubTests : IClassFixture<WebApplicationFactory<Pr
         var payload = await response.Content.ReadFromJsonAsync<LoginResponse>();
         Assert.NotNull(payload);
         Assert.Equal("ok", payload.Result);
+        Assert.Equal("demo-token", payload.Token);
+    }
+
+    [Fact]
+    public async Task PostLogin_WithUnknownCredentials_ReturnsDefaultResponse()
+    {
+        var response = await client.PostAsJsonAsync("/login", new LoginRequest
+        {
+            Username = "other",
+            Password = "wrong"
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var payload = await response.Content.ReadFromJsonAsync<LoginResponse>();
+        Assert.NotNull(payload);
+        Assert.Equal("invalid", payload.Result);
+        Assert.Null(payload.Token);
     }
 
     [Fact]
@@ -192,5 +210,7 @@ public sealed class HelloWorldStubTests : IClassFixture<WebApplicationFactory<Pr
     public sealed class LoginResponse
     {
         public string Result { get; init; } = string.Empty;
+
+        public string? Token { get; init; }
     }
 }

--- a/tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs
@@ -278,6 +278,44 @@ public sealed class StubDefinitionLoaderTests
     }
 
     [Fact]
+    public void LoadDefaultDefinition_LoadsBodyMatchDefinitions()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+              /login:
+                post:
+                  x-match:
+                    - body:
+                        username: demo
+                        password: secret
+                      response:
+                        statusCode: 200
+                        content:
+                          application/json:
+                            example:
+                              result: ok
+                  responses:
+                    "200":
+                      description: ok
+                      content:
+                        application/json:
+                          example:
+                            result: fallback
+            """);
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var document = loader.LoadDefaultDefinition();
+        var match = Assert.Single(document.Paths["/login"].Post!.Matches);
+
+        var body = Assert.IsAssignableFrom<IReadOnlyDictionary<string, object?>>(match.Body);
+        Assert.Equal("demo", body["username"]);
+        Assert.Equal("secret", body["password"]);
+    }
+
+    [Fact]
     public void LoadDefaultDefinition_LoadsValidDefinition()
     {
         using var workspace = TestWorkspace.Create(

--- a/tests/SemanticStub.Api.Tests/Unit/StubServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubServiceTests.cs
@@ -418,4 +418,218 @@ public sealed class StubServiceTests
 
         Assert.Equal(StubMatchResult.ResponseNotConfigured, matched);
     }
+
+    [Fact]
+    public void TryGetResponse_MatchesResponseUsingRequestBody()
+    {
+        var document = new StubDocument
+        {
+            Paths = new Dictionary<string, PathItemDefinition>(StringComparer.Ordinal)
+            {
+                ["/login"] = new()
+                {
+                    Post = new OperationDefinition
+                    {
+                        Matches =
+                        [
+                            new QueryMatchDefinition
+                            {
+                                Body = new Dictionary<object, object>
+                                {
+                                    ["username"] = "demo",
+                                    ["password"] = "secret"
+                                },
+                                Response = new QueryMatchResponseDefinition
+                                {
+                                    StatusCode = 200,
+                                    Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+                                    {
+                                        ["application/json"] = new()
+                                        {
+                                            Example = new Dictionary<object, object>
+                                            {
+                                                ["result"] = "ok"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        Responses = new Dictionary<string, ResponseDefinition>(StringComparer.Ordinal)
+                        {
+                            ["200"] = new()
+                            {
+                                Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+                                {
+                                    ["application/json"] = new()
+                                    {
+                                        Example = new Dictionary<object, object>
+                                        {
+                                            ["result"] = "fallback"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        var service = new StubService(document);
+
+        var matched = service.TryGetResponse(
+            HttpMethods.Post,
+            "/login",
+            new Dictionary<string, string>(StringComparer.Ordinal),
+            "{\"username\":\"demo\",\"password\":\"secret\",\"rememberMe\":true}",
+            out var response);
+
+        Assert.Equal(StubMatchResult.Matched, matched);
+        Assert.Equal("{\"result\":\"ok\"}", response.Body);
+    }
+
+    [Fact]
+    public void TryGetResponse_PrefersMoreSpecificBodyMatch()
+    {
+        var document = new StubDocument
+        {
+            Paths = new Dictionary<string, PathItemDefinition>(StringComparer.Ordinal)
+            {
+                ["/login"] = new()
+                {
+                    Post = new OperationDefinition
+                    {
+                        Matches =
+                        [
+                            new QueryMatchDefinition
+                            {
+                                Body = new Dictionary<object, object>
+                                {
+                                    ["username"] = "demo"
+                                },
+                                Response = new QueryMatchResponseDefinition
+                                {
+                                    StatusCode = 200,
+                                    Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+                                    {
+                                        ["application/json"] = new()
+                                        {
+                                            Example = new Dictionary<object, object>
+                                            {
+                                                ["result"] = "basic"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            new QueryMatchDefinition
+                            {
+                                Body = new Dictionary<object, object>
+                                {
+                                    ["username"] = "demo",
+                                    ["password"] = "secret"
+                                },
+                                Response = new QueryMatchResponseDefinition
+                                {
+                                    StatusCode = 200,
+                                    Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+                                    {
+                                        ["application/json"] = new()
+                                        {
+                                            Example = new Dictionary<object, object>
+                                            {
+                                                ["result"] = "specific"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        };
+
+        var service = new StubService(document);
+
+        var matched = service.TryGetResponse(
+            HttpMethods.Post,
+            "/login",
+            new Dictionary<string, string>(StringComparer.Ordinal),
+            "{\"username\":\"demo\",\"password\":\"secret\"}",
+            out var response);
+
+        Assert.Equal(StubMatchResult.Matched, matched);
+        Assert.Equal("{\"result\":\"specific\"}", response.Body);
+    }
+
+    [Fact]
+    public void TryGetResponse_FallsBackToDefaultResponseWhenBodyIsInvalidJson()
+    {
+        var document = new StubDocument
+        {
+            Paths = new Dictionary<string, PathItemDefinition>(StringComparer.Ordinal)
+            {
+                ["/login"] = new()
+                {
+                    Post = new OperationDefinition
+                    {
+                        Matches =
+                        [
+                            new QueryMatchDefinition
+                            {
+                                Body = new Dictionary<object, object>
+                                {
+                                    ["username"] = "demo"
+                                },
+                                Response = new QueryMatchResponseDefinition
+                                {
+                                    StatusCode = 200,
+                                    Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+                                    {
+                                        ["application/json"] = new()
+                                        {
+                                            Example = new Dictionary<object, object>
+                                            {
+                                                ["result"] = "matched"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        Responses = new Dictionary<string, ResponseDefinition>(StringComparer.Ordinal)
+                        {
+                            ["200"] = new()
+                            {
+                                Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+                                {
+                                    ["application/json"] = new()
+                                    {
+                                        Example = new Dictionary<object, object>
+                                        {
+                                            ["result"] = "fallback"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        var service = new StubService(document);
+
+        var matched = service.TryGetResponse(
+            HttpMethods.Post,
+            "/login",
+            new Dictionary<string, string>(StringComparer.Ordinal),
+            "{not-json",
+            out var response);
+
+        Assert.Equal(StubMatchResult.Matched, matched);
+        Assert.Equal("{\"result\":\"fallback\"}", response.Body);
+    }
 }


### PR DESCRIPTION
## Purpose
Add request body based matching to x-match without breaking existing query-based matching.

## Changes
- add optional body condition support to x-match definitions
- evaluate JSON request bodies in StubService and keep deterministic match precedence
- pass request body from StubController into matching
- add unit and integration tests for body matching and fallback behavior
- update the sample login route to demonstrate body-based branching

## Validation
- dotnet build SemanticStub.sln
- dotnet test SemanticStub.sln

## Impact
- existing YAML remains compatible
- body matching currently targets JSON requests
- object matching is partial by property and array matching remains order-sensitive