### PR TITLE
test: rename basic routing integration tests

### DIFF
--- a/tests/SemanticStub.Api.Tests/Integration/BasicRoutingStubTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/BasicRoutingStubTests.cs
@@ -5,11 +5,11 @@ using Xunit;
 
 namespace SemanticStub.Api.Tests.Integration;
 
-public sealed class HelloWorldStubTests : IClassFixture<WebApplicationFactory<Program>>
+public sealed class BasicRoutingStubTests : IClassFixture<WebApplicationFactory<Program>>
 {
     private readonly HttpClient client;
 
-    public HelloWorldStubTests(WebApplicationFactory<Program> factory)
+    public BasicRoutingStubTests(WebApplicationFactory<Program> factory)
     {
         client = factory.CreateClient();
     }


### PR DESCRIPTION
## Purpose
- align the integration test file name with the actual scope of the sample coverage

## Changes
- rename HelloWorldStubTests to BasicRoutingStubTests
- update the test class and constructor names to match the file name

## Validation
- dotnet test SemanticStub.sln

## Impact
- no behavior changes
- makes the test suite easier to navigate