### PR TITLE
feat: support non-JSON content types

### DIFF
--- a/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionValidator.cs
+++ b/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionValidator.cs
@@ -4,7 +4,6 @@ namespace SemanticStub.Api.Infrastructure.Yaml;
 
 internal sealed class StubDefinitionValidator
 {
-    private const string JsonContentType = "application/json";
 
     public void ValidateDocument(StubDocument document, string definitionDirectory)
     {
@@ -140,15 +139,9 @@ internal sealed class StubDefinitionValidator
         {
             if (string.IsNullOrWhiteSpace(responseFile))
             {
-                errors.Add($"Path '{path}' {method.ToUpperInvariant()} {location} must define '{JsonContentType}' content or 'x-response-file'.");
+                errors.Add($"Path '{path}' {method.ToUpperInvariant()} {location} must define content or 'x-response-file'.");
             }
 
-            return;
-        }
-
-        if (!content.TryGetValue(JsonContentType, out var mediaType))
-        {
-            errors.Add($"Path '{path}' {method.ToUpperInvariant()} {location} must define '{JsonContentType}' content or 'x-response-file'.");
             return;
         }
 
@@ -158,9 +151,12 @@ internal sealed class StubDefinitionValidator
             return;
         }
 
-        if (mediaType.Example is null)
+        // At least one media type must provide an inline example.
+        // We report against the first entry to give a concrete target in the error message.
+        if (content.All(static entry => entry.Value.Example is null))
         {
-            errors.Add($"Path '{path}' {method.ToUpperInvariant()} {location} must define an example for '{JsonContentType}'.");
+            var firstKey = content.First().Key;
+            errors.Add($"Path '{path}' {method.ToUpperInvariant()} {location} must define an example for '{firstKey}'.");
         }
     }
 }

--- a/src/SemanticStub.Api/Services/StubService.cs
+++ b/src/SemanticStub.Api/Services/StubService.cs
@@ -115,7 +115,7 @@ public sealed class StubService
         var matchedResponse = operation.Responses
             .FirstOrDefault(entry =>
                 int.TryParse(entry.Key, out _) &&
-                entry.Value.Content.ContainsKey(JsonContentType));
+                (entry.Value.Content.Count > 0 || !string.IsNullOrEmpty(entry.Value.ResponseFile)));
 
         if (string.IsNullOrEmpty(matchedResponse.Key) ||
             !int.TryParse(matchedResponse.Key, out var statusCode))
@@ -133,7 +133,7 @@ public sealed class StubService
         response = new StubResponse
         {
             StatusCode = statusCode,
-            ContentType = JsonContentType,
+            ContentType = ResolveContentType(matchedResponse.Value.Content),
             Headers = BuildResponseHeaders(matchedResponse.Value.Headers),
             Body = responseBody
         };
@@ -272,7 +272,7 @@ public sealed class StubService
         response = new StubResponse
         {
             StatusCode = matchedCandidate.Response.StatusCode,
-            ContentType = JsonContentType,
+            ContentType = ResolveContentType(matchedCandidate.Response.Content),
             Headers = BuildResponseHeaders(matchedCandidate.Response.Headers),
             Body = responseBody
         };
@@ -291,17 +291,39 @@ public sealed class StubService
             return responseFileReader(responseFile);
         }
 
-        if (!content.TryGetValue(JsonContentType, out var mediaType))
+        var selectedKey = SelectMediaTypeKey(content);
+
+        if (selectedKey is null || !content.TryGetValue(selectedKey, out var mediaType) || mediaType.Example is null)
         {
             return null;
         }
 
-        if (mediaType.Example is null)
+        // Non-JSON string examples are returned as-is; JSON types go through serialization.
+        if (!IsJsonContentType(selectedKey) && mediaType.Example is string rawExample)
         {
-            return null;
+            return rawExample;
         }
 
         return StubExampleSerializer.Serialize(mediaType.Example);
+    }
+
+    private static string ResolveContentType(IReadOnlyDictionary<string, MediaTypeDefinition> content)
+    {
+        return SelectMediaTypeKey(content) ?? JsonContentType;
+    }
+
+    // Prefer JSON content types to preserve deterministic behavior for stubs that declare
+    // multiple media types (e.g. application/json alongside text/plain for documentation).
+    // Fall back to the first declared entry only when no JSON type is present.
+    private static string? SelectMediaTypeKey(IReadOnlyDictionary<string, MediaTypeDefinition> content)
+    {
+        return content.Keys.FirstOrDefault(IsJsonContentType) ?? content.Keys.FirstOrDefault();
+    }
+
+    private static bool IsJsonContentType(string contentType)
+    {
+        return contentType.Equals(JsonContentType, StringComparison.OrdinalIgnoreCase)
+            || contentType.EndsWith("+json", StringComparison.OrdinalIgnoreCase);
     }
 
     private static IReadOnlyDictionary<string, StringValues> BuildResponseHeaders(IReadOnlyDictionary<string, HeaderDefinition> headers)

--- a/tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs
@@ -239,7 +239,7 @@ public sealed class StubDefinitionLoaderTests
         var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
 
         Assert.Contains("x-match[0] must define a positive statusCode", exception.Message);
-        Assert.Contains("x-match[0].response must define 'application/json' content or 'x-response-file'", exception.Message);
+        Assert.Contains("x-match[0].response must define content or 'x-response-file'", exception.Message);
     }
 
     [Fact]
@@ -297,34 +297,6 @@ public sealed class StubDefinitionLoaderTests
         var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
 
         Assert.Contains("uses unsupported response key 'default'", exception.Message);
-    }
-
-    [Fact]
-    public void LoadDefaultDefinition_ThrowsWhenResponseFileContentTypeIsInvalid()
-    {
-        using var workspace = TestWorkspace.Create(
-            """
-            openapi: 3.1.0
-            paths:
-              /users:
-                get:
-                  responses:
-                    "200":
-                      description: ok
-                      x-response-file: users.json
-                      content:
-                        text/plain: {}
-            """,
-            sampleFiles:
-            [
-                ("users.json", "[{\"id\":1,\"name\":\"Alice\"}]")
-            ]);
-
-        var loader = new StubDefinitionLoader(workspace.Environment);
-
-        var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
-
-        Assert.Contains("must define 'application/json' content or 'x-response-file'", exception.Message);
     }
 
     [Fact]

--- a/tests/SemanticStub.Api.Tests/Unit/StubServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubServiceTests.cs
@@ -636,40 +636,16 @@ public sealed class StubServiceTests
     }
 
     [Fact]
-    public void TryGetResponse_ReturnsResponseNotConfigured_WhenFallbackResponseHasNoJsonContent()
+    public void TryGetResponse_ReturnsTextPlainBodyWithCorrectContentType()
     {
         var document = new StubDocument
         {
             Paths = new Dictionary<string, PathItemDefinition>(StringComparer.Ordinal)
             {
-                ["/users"] = new()
+                ["/hello"] = new()
                 {
                     Get = new OperationDefinition
                     {
-                        Matches =
-                        [
-                            new QueryMatchDefinition
-                            {
-                                Query = new Dictionary<string, string>(StringComparer.Ordinal)
-                                {
-                                    ["role"] = "admin"
-                                },
-                                Response = new QueryMatchResponseDefinition
-                                {
-                                    StatusCode = 200,
-                                    Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
-                                    {
-                                        ["application/json"] = new()
-                                        {
-                                            Example = new Dictionary<object, object>
-                                            {
-                                                ["message"] = "admin"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        ],
                         Responses = new Dictionary<string, ResponseDefinition>(StringComparer.Ordinal)
                         {
                             ["200"] = new()
@@ -678,7 +654,7 @@ public sealed class StubServiceTests
                                 {
                                     ["text/plain"] = new()
                                     {
-                                        Example = "default"
+                                        Example = "Hello, world!"
                                     }
                                 }
                             }
@@ -689,14 +665,95 @@ public sealed class StubServiceTests
         };
 
         var service = new StubService(document);
-        var query = new Dictionary<string, string>(StringComparer.Ordinal)
+
+        var matched = service.TryGetResponse(HttpMethods.Get, "/hello", out var response);
+
+        Assert.Equal(StubMatchResult.Matched, matched);
+        Assert.Equal("text/plain", response.ContentType);
+        Assert.Equal("Hello, world!", response.Body);
+    }
+
+    [Fact]
+    public void TryGetResponse_ReturnsXmlContentTypeForResponseFile()
+    {
+        var document = new StubDocument
         {
-            ["role"] = "guest"
+            Paths = new Dictionary<string, PathItemDefinition>(StringComparer.Ordinal)
+            {
+                ["/data"] = new()
+                {
+                    Get = new OperationDefinition
+                    {
+                        Responses = new Dictionary<string, ResponseDefinition>(StringComparer.Ordinal)
+                        {
+                            ["200"] = new()
+                            {
+                                ResponseFile = "data.xml",
+                                Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+                                {
+                                    ["application/xml"] = new()
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         };
 
-        var matched = service.TryGetResponse(HttpMethods.Get, "/users", query, out _);
+        var service = new StubService(document, _ => "<root><item>1</item></root>");
 
-        Assert.Equal(StubMatchResult.ResponseNotConfigured, matched);
+        var matched = service.TryGetResponse(HttpMethods.Get, "/data", out var response);
+
+        Assert.Equal(StubMatchResult.Matched, matched);
+        Assert.Equal("application/xml", response.ContentType);
+        Assert.Equal("<root><item>1</item></root>", response.Body);
+    }
+
+    [Fact]
+    public void TryGetResponse_ReturnsNonJsonContentTypeFromXMatch()
+    {
+        var document = new StubDocument
+        {
+            Paths = new Dictionary<string, PathItemDefinition>(StringComparer.Ordinal)
+            {
+                ["/report"] = new()
+                {
+                    Get = new OperationDefinition
+                    {
+                        Matches =
+                        [
+                            new QueryMatchDefinition
+                            {
+                                Query = new Dictionary<string, string>(StringComparer.Ordinal)
+                                {
+                                    ["format"] = "csv"
+                                },
+                                Response = new QueryMatchResponseDefinition
+                                {
+                                    StatusCode = 200,
+                                    Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+                                    {
+                                        ["text/csv"] = new()
+                                        {
+                                            Example = "id,name\n1,Alice"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        };
+
+        var service = new StubService(document);
+        var query = new Dictionary<string, string>(StringComparer.Ordinal) { ["format"] = "csv" };
+
+        var matched = service.TryGetResponse(HttpMethods.Get, "/report", query, out var response);
+
+        Assert.Equal(StubMatchResult.Matched, matched);
+        Assert.Equal("text/csv", response.ContentType);
+        Assert.Equal("id,name\n1,Alice", response.Body);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Remove `application/json` requirement from validator — any content type is now accepted
- Validator requires at least one inline `example` across declared media types (when no `x-response-file`)
- Service prefers JSON content types (`application/json`, `*+json`) when multiple types are declared, preserving backward compatibility for existing stubs
- Non-JSON `string` examples are returned as-is without JSON serialization

## Changes

| File | Change |
|---|---|
| `StubDefinitionValidator.cs` | Accept any content type; validate that at least one entry has an `example` |
| `StubService.cs` | Add `SelectMediaTypeKey` / `ResolveContentType` / `IsJsonContentType` helpers; use first JSON type or fall back to first declared |
| `StubDefinitionLoaderTests.cs` | Remove `application/json`-specific validation test; update error message assertion |
| `StubServiceTests.cs` | Add tests for `text/plain`, `application/xml` (file-backed), `text/csv` (x-match) |

## Validation

```
dotnet build   → 0 warnings, 0 errors
dotnet test    → 72 passed, 0 failed
```

## Notes

- **Backward compatible**: existing JSON-only stubs are unaffected
- **Multi-type stubs**: JSON type always wins regardless of declaration order (e.g. `text/plain` + `application/json` → uses JSON)
- **Non-JSON-only stubs**: first declared entry is used when no JSON type is present
- Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)