### PR TITLE
docs: add XML comments to public services

### DIFF
--- a/src/SemanticStub.Api/Controllers/StubController.cs
+++ b/src/SemanticStub.Api/Controllers/StubController.cs
@@ -4,6 +4,9 @@ using SemanticStub.Api.Services;
 
 namespace SemanticStub.Api.Controllers;
 
+/// <summary>
+/// Routes every incoming request through the stub engine so mocked behavior stays defined in YAML rather than duplicated across controllers.
+/// </summary>
 [ApiController]
 [Route("{*path}")]
 public sealed class StubController : ControllerBase
@@ -15,30 +18,45 @@ public sealed class StubController : ControllerBase
         this.stubService = stubService;
     }
 
+    /// <summary>
+    /// Handles GET requests through the shared stub resolution path so verb-specific endpoints do not drift from YAML definitions.
+    /// </summary>
     [HttpGet]
     public Task<IActionResult> Get(string? path)
     {
         return HandleRequest(HttpMethods.Get, path);
     }
 
+    /// <summary>
+    /// Handles POST requests through the shared stub resolution path so verb-specific endpoints do not drift from YAML definitions.
+    /// </summary>
     [HttpPost]
     public Task<IActionResult> Post(string? path)
     {
         return HandleRequest(HttpMethods.Post, path);
     }
 
+    /// <summary>
+    /// Handles PUT requests through the shared stub resolution path so verb-specific endpoints do not drift from YAML definitions.
+    /// </summary>
     [HttpPut]
     public Task<IActionResult> Put(string? path)
     {
         return HandleRequest(HttpMethods.Put, path);
     }
 
+    /// <summary>
+    /// Handles PATCH requests through the shared stub resolution path so verb-specific endpoints do not drift from YAML definitions.
+    /// </summary>
     [HttpPatch]
     public Task<IActionResult> Patch(string? path)
     {
         return HandleRequest(HttpMethods.Patch, path);
     }
 
+    /// <summary>
+    /// Handles DELETE requests through the shared stub resolution path so verb-specific endpoints do not drift from YAML definitions.
+    /// </summary>
     [HttpDelete]
     public Task<IActionResult> Delete(string? path)
     {

--- a/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionLoader.cs
+++ b/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionLoader.cs
@@ -5,6 +5,9 @@ using YamlDotNet.Serialization.NamingConventions;
 
 namespace SemanticStub.Api.Infrastructure.Yaml;
 
+/// <summary>
+/// Loads OpenAPI-based stub definitions from disk so the runtime can execute mock behavior directly from YAML without duplicating route metadata in code.
+/// </summary>
 public sealed class StubDefinitionLoader
 {
     private const string DefaultStubFileName = "basic-routing.yaml";
@@ -33,6 +36,9 @@ public sealed class StubDefinitionLoader
         normalizer = new StubDefinitionNormalizer();
     }
 
+    /// <summary>
+    /// Discovers the default stub files, validates them, and merges them into one document so matching can run against a single deterministic view.
+    /// </summary>
     public StubDocument LoadDefaultDefinition()
     {
         var definitionsRootPath = ResolveDefinitionsDirectory();
@@ -61,6 +67,9 @@ public sealed class StubDefinitionLoader
         return normalizer.NormalizeDocument(document, definitionDirectory);
     }
 
+    /// <summary>
+    /// Resolves file-based response payloads relative to the definitions root so YAML response-file references behave consistently across environments.
+    /// </summary>
     public string LoadResponseFileContent(string fileName)
     {
         if (Path.IsPathRooted(fileName))

--- a/src/SemanticStub.Api/Services/MatcherService.cs
+++ b/src/SemanticStub.Api/Services/MatcherService.cs
@@ -5,8 +5,14 @@ using SemanticStub.Api.Utilities;
 
 namespace SemanticStub.Api.Services;
 
+/// <summary>
+/// Chooses the most specific conditional match so YAML-defined query, header, and body refinements remain deterministic.
+/// </summary>
 public sealed class MatcherService
 {
+    /// <summary>
+    /// Preserves the existing query-and-body matching entry point while delegating to the full matcher implementation.
+    /// </summary>
     public QueryMatchDefinition? FindBestMatch(
         OperationDefinition operation,
         IReadOnlyDictionary<string, string> query,
@@ -19,6 +25,10 @@ public sealed class MatcherService
             body);
     }
 
+    /// <summary>
+    /// Filters candidates by every configured condition and prefers the most constrained definition so explicit matches win over broad fallbacks.
+    /// </summary>
+    /// <returns>The best matching conditional definition, or <see langword="null"/> when none satisfy the request.</returns>
     public QueryMatchDefinition? FindBestMatch(
         OperationDefinition operation,
         IReadOnlyDictionary<string, string> query,

--- a/src/SemanticStub.Api/Services/StubService.cs
+++ b/src/SemanticStub.Api/Services/StubService.cs
@@ -7,6 +7,9 @@ using System.Globalization;
 
 namespace SemanticStub.Api.Services;
 
+/// <summary>
+/// Converts matched stub definitions into concrete HTTP responses so controllers can delegate routing, matching, and payload assembly to one place.
+/// </summary>
 public sealed class StubService
 {
     private const string JsonContentType = "application/json";
@@ -43,6 +46,11 @@ public sealed class StubService
         this.matcherService = matcherService;
     }
 
+    /// <summary>
+    /// Resolves a response for callers that only need method and path matching.
+    /// </summary>
+    /// <param name="response">Receives the assembled response when a matching stub is found.</param>
+    /// <returns>A result that distinguishes between no route, unsupported method, invalid configuration, and a successful match.</returns>
     public StubMatchResult TryGetResponse(string method, string path, out StubResponse response)
     {
         return TryGetResponse(
@@ -54,6 +62,11 @@ public sealed class StubService
             out response);
     }
 
+    /// <summary>
+    /// Resolves a response while considering query-based match conditions so more specific stubs can override broad defaults.
+    /// </summary>
+    /// <param name="response">Receives the assembled response when a matching stub is found.</param>
+    /// <returns>A result that distinguishes between no route, unsupported method, invalid configuration, and a successful match.</returns>
     public StubMatchResult TryGetResponse(string method, string path, IReadOnlyDictionary<string, string> query, out StubResponse response)
     {
         return TryGetResponse(
@@ -65,6 +78,11 @@ public sealed class StubService
             out response);
     }
 
+    /// <summary>
+    /// Resolves a response while considering query and body match conditions so structured request payloads can select a narrower stub.
+    /// </summary>
+    /// <param name="response">Receives the assembled response when a matching stub is found.</param>
+    /// <returns>A result that distinguishes between no route, unsupported method, invalid configuration, and a successful match.</returns>
     public StubMatchResult TryGetResponse(string method, string path, IReadOnlyDictionary<string, string> query, string? body, out StubResponse response)
     {
         return TryGetResponse(
@@ -76,6 +94,11 @@ public sealed class StubService
             out response);
     }
 
+    /// <summary>
+    /// Resolves the most specific stub response by evaluating path, method, query, headers, and body through the same matching pipeline.
+    /// </summary>
+    /// <param name="response">Receives the assembled response when a matching stub is found.</param>
+    /// <returns>A result that distinguishes between no route, unsupported method, invalid configuration, and a successful match.</returns>
     public StubMatchResult TryGetResponse(
         string method,
         string path,

--- a/src/SemanticStub.Api/Utilities/StubExampleSerializer.cs
+++ b/src/SemanticStub.Api/Utilities/StubExampleSerializer.cs
@@ -2,8 +2,14 @@ using System.Text.Json;
 
 namespace SemanticStub.Api.Utilities;
 
+/// <summary>
+/// Normalizes YAML-deserialized example values into JSON-friendly shapes so matching and response generation can compare values consistently.
+/// </summary>
 public static class StubExampleSerializer
 {
+    /// <summary>
+    /// Serializes example data into canonical JSON so downstream matching logic is not coupled to YAML-specific runtime types.
+    /// </summary>
     public static string Serialize(object? example)
     {
         var normalized = NormalizeValue(example);
@@ -11,6 +17,9 @@ public static class StubExampleSerializer
         return JsonSerializer.Serialize(normalized);
     }
 
+    /// <summary>
+    /// Rewrites YAML-native collections into predictable CLR objects so serialization and header formatting produce stable results.
+    /// </summary>
     public static object? NormalizeValue(object? value)
     {
         if (value is null)


### PR DESCRIPTION
## Summary
- add XML documentation comments to public service, controller, loader, matcher, and utility APIs
- keep DTOs and obvious data holders unchanged to avoid noisy documentation
- document intent-focused behavior and only add `param`/`returns` tags where they clarify outputs

## Validation
- `dotnet build SemanticStub.sln`
- `dotnet test SemanticStub.sln`

## Impact
- no runtime behavior changes
- no YAML compatibility changes