### PR TITLE
feat: add typed query comparison

### DIFF
--- a/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionNormalizer.cs
+++ b/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionNormalizer.cs
@@ -24,7 +24,13 @@ internal sealed class StubDefinitionNormalizer
             Parameters = [.. pathItem.Parameters.Select(parameter => new ParameterDefinition
             {
                 Name = parameter.Name,
-                In = parameter.In
+                In = parameter.In,
+                Schema = parameter.Schema is null
+                    ? null
+                    : new ParameterSchemaDefinition
+                    {
+                        Type = parameter.Schema.Type
+                    }
             })],
             Get = NormalizeOperation(pathItem.Get, definitionDirectory),
             Post = NormalizeOperation(pathItem.Post, definitionDirectory),
@@ -47,13 +53,22 @@ internal sealed class StubDefinitionNormalizer
             Parameters = [.. operation.Parameters.Select(parameter => new ParameterDefinition
             {
                 Name = parameter.Name,
-                In = parameter.In
+                In = parameter.In,
+                Schema = parameter.Schema is null
+                    ? null
+                    : new ParameterSchemaDefinition
+                    {
+                        Type = parameter.Schema.Type
+                    }
             })],
             Matches =
             [
                 .. operation.Matches.Select(match => new QueryMatchDefinition
                 {
-                    Query = new Dictionary<string, string>(match.Query, StringComparer.Ordinal),
+                    Query = match.Query.ToDictionary(
+                        entry => entry.Key,
+                        entry => StubExampleSerializer.NormalizeValue(entry.Value),
+                        StringComparer.Ordinal),
                     Headers = new Dictionary<string, string>(match.Headers, StringComparer.OrdinalIgnoreCase),
                     Body = StubExampleSerializer.NormalizeValue(match.Body),
                     Response = new QueryMatchResponseDefinition

--- a/src/SemanticStub.Api/Models/ParameterDefinition.cs
+++ b/src/SemanticStub.Api/Models/ParameterDefinition.cs
@@ -5,4 +5,6 @@ public sealed class ParameterDefinition
     public string Name { get; init; } = string.Empty;
 
     public string In { get; init; } = string.Empty;
+
+    public ParameterSchemaDefinition? Schema { get; init; }
 }

--- a/src/SemanticStub.Api/Models/ParameterSchemaDefinition.cs
+++ b/src/SemanticStub.Api/Models/ParameterSchemaDefinition.cs
@@ -1,0 +1,6 @@
+namespace SemanticStub.Api.Models;
+
+public sealed class ParameterSchemaDefinition
+{
+    public string Type { get; init; } = string.Empty;
+}

--- a/src/SemanticStub.Api/Models/QueryMatchDefinition.cs
+++ b/src/SemanticStub.Api/Models/QueryMatchDefinition.cs
@@ -4,7 +4,7 @@ namespace SemanticStub.Api.Models;
 
 public sealed class QueryMatchDefinition
 {
-    public Dictionary<string, string> Query { get; init; } = new(StringComparer.Ordinal);
+    public Dictionary<string, object?> Query { get; init; } = new(StringComparer.Ordinal);
 
     public Dictionary<string, string> Headers { get; init; } = new(StringComparer.OrdinalIgnoreCase);
 

--- a/src/SemanticStub.Api/Services/MatcherService.cs
+++ b/src/SemanticStub.Api/Services/MatcherService.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Globalization;
 using System.Text.Json;
 using SemanticStub.Api.Models;
 using SemanticStub.Api.Utilities;
@@ -35,33 +36,194 @@ public sealed class MatcherService
         IReadOnlyDictionary<string, string> headers,
         string? body)
     {
+        return FindBestMatch(
+            operation.Parameters,
+            operation,
+            query,
+            headers,
+            body);
+    }
+
+    /// <summary>
+    /// Filters candidates by every configured condition and prefers the most constrained definition so explicit matches win over broad fallbacks.
+    /// </summary>
+    /// <returns>The best matching conditional definition, or <see langword="null"/> when none satisfy the request.</returns>
+    public QueryMatchDefinition? FindBestMatch(
+        IReadOnlyCollection<ParameterDefinition> pathParameters,
+        OperationDefinition operation,
+        IReadOnlyDictionary<string, string> query,
+        IReadOnlyDictionary<string, string> headers,
+        string? body)
+    {
         if (operation.Matches.Count == 0)
         {
             return null;
         }
 
         using var bodyDocument = ParseRequestBody(body);
+        var queryParameterTypes = BuildQueryParameterTypes(pathParameters, operation.Parameters);
 
         // Match conditions are conjunctive; after filtering, prefer the candidate with the most explicit constraints.
         return operation.Matches
-            .Where(candidate => IsExactQueryMatch(candidate.Query, query))
+            .Where(candidate => IsExactQueryMatch(candidate.Query, query, queryParameterTypes))
             .Where(candidate => IsExactHeaderMatch(candidate.Headers, headers))
             .Where(candidate => IsBodyMatch(candidate.Body, bodyDocument?.RootElement))
             .OrderByDescending(GetMatchSpecificity)
             .FirstOrDefault();
     }
 
-    private static bool IsExactQueryMatch(IReadOnlyDictionary<string, string> expected, IReadOnlyDictionary<string, string> actual)
+    private static Dictionary<string, string> BuildQueryParameterTypes(
+        IReadOnlyCollection<ParameterDefinition> pathParameters,
+        IReadOnlyCollection<ParameterDefinition> operationParameters)
+    {
+        var queryParameterTypes = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        AddQueryParameterTypes(pathParameters, queryParameterTypes);
+        AddQueryParameterTypes(operationParameters, queryParameterTypes);
+
+        return queryParameterTypes;
+    }
+
+    private static void AddQueryParameterTypes(
+        IReadOnlyCollection<ParameterDefinition> parameters,
+        IDictionary<string, string> queryParameterTypes)
+    {
+        foreach (var parameter in parameters)
+        {
+            if (!string.Equals(parameter.In, "query", StringComparison.OrdinalIgnoreCase) ||
+                string.IsNullOrWhiteSpace(parameter.Name) ||
+                string.IsNullOrWhiteSpace(parameter.Schema?.Type))
+            {
+                continue;
+            }
+
+            queryParameterTypes[parameter.Name] = parameter.Schema.Type;
+        }
+    }
+
+    private static bool IsExactQueryMatch(
+        IReadOnlyDictionary<string, object?> expected,
+        IReadOnlyDictionary<string, string> actual,
+        IReadOnlyDictionary<string, string> queryParameterTypes)
     {
         foreach (var pair in expected)
         {
-            if (!actual.TryGetValue(pair.Key, out var value) || value != pair.Value)
+            if (!actual.TryGetValue(pair.Key, out var value) ||
+                !IsTypedQueryValueMatch(pair.Value, value, queryParameterTypes.GetValueOrDefault(pair.Key)))
             {
                 return false;
             }
         }
 
         return true;
+    }
+
+    private static bool IsTypedQueryValueMatch(object? expected, string actual, string? parameterType)
+    {
+        if (string.Equals(parameterType, "integer", StringComparison.OrdinalIgnoreCase))
+        {
+            return TryConvertInteger(expected, out var expectedInteger) &&
+                   TryConvertInteger(actual, out var actualInteger) &&
+                   expectedInteger == actualInteger;
+        }
+
+        if (string.Equals(parameterType, "number", StringComparison.OrdinalIgnoreCase))
+        {
+            return TryConvertNumber(expected, out var expectedNumber) &&
+                   TryConvertNumber(actual, out var actualNumber) &&
+                   expectedNumber == actualNumber;
+        }
+
+        if (string.Equals(parameterType, "boolean", StringComparison.OrdinalIgnoreCase))
+        {
+            return TryConvertBoolean(expected, out var expectedBoolean) &&
+                   TryConvertBoolean(actual, out var actualBoolean) &&
+                   expectedBoolean == actualBoolean;
+        }
+
+        return string.Equals(ConvertQueryValueToString(expected), actual, StringComparison.Ordinal);
+    }
+
+    private static bool TryConvertInteger(object? value, out decimal integer)
+    {
+        if (TryConvertNumber(value, out integer))
+        {
+            return decimal.Truncate(integer) == integer;
+        }
+
+        integer = default;
+        return false;
+    }
+
+    private static bool TryConvertNumber(object? value, out decimal number)
+    {
+        switch (value)
+        {
+            case byte byteValue:
+                number = byteValue;
+                return true;
+            case sbyte sbyteValue:
+                number = sbyteValue;
+                return true;
+            case short shortValue:
+                number = shortValue;
+                return true;
+            case ushort ushortValue:
+                number = ushortValue;
+                return true;
+            case int intValue:
+                number = intValue;
+                return true;
+            case uint uintValue:
+                number = uintValue;
+                return true;
+            case long longValue:
+                number = longValue;
+                return true;
+            case ulong ulongValue:
+                return decimal.TryParse(ulongValue.ToString(CultureInfo.InvariantCulture), NumberStyles.Integer, CultureInfo.InvariantCulture, out number);
+            case float floatValue:
+                return decimal.TryParse(floatValue.ToString(CultureInfo.InvariantCulture), NumberStyles.Float, CultureInfo.InvariantCulture, out number);
+            case double doubleValue:
+                return decimal.TryParse(doubleValue.ToString(CultureInfo.InvariantCulture), NumberStyles.Float, CultureInfo.InvariantCulture, out number);
+            case decimal decimalValue:
+                number = decimalValue;
+                return true;
+            case string text:
+                return decimal.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out number);
+            default:
+                number = default;
+                return false;
+        }
+    }
+
+    private static bool TryConvertBoolean(object? value, out bool boolean)
+    {
+        switch (value)
+        {
+            case bool boolValue:
+                boolean = boolValue;
+                return true;
+            case string text:
+                return bool.TryParse(text, out boolean);
+            default:
+                boolean = default;
+                return false;
+        }
+    }
+
+    private static string ConvertQueryValueToString(object? value)
+    {
+        return value switch
+        {
+            null => string.Empty,
+            string text => text,
+            bool boolean => boolean ? "true" : "false",
+            byte or sbyte or short or ushort or int or uint or long or ulong or float or double or decimal
+                => Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty,
+            IFormattable formattable => formattable.ToString(format: null, CultureInfo.InvariantCulture),
+            _ => value.ToString() ?? string.Empty
+        };
     }
 
     private static bool IsExactHeaderMatch(IReadOnlyDictionary<string, string> expected, IReadOnlyDictionary<string, string> actual)

--- a/src/SemanticStub.Api/Services/StubService.cs
+++ b/src/SemanticStub.Api/Services/StubService.cs
@@ -123,7 +123,7 @@ public sealed class StubService
             return StubMatchResult.MethodNotAllowed;
         }
 
-        var queryMatchResult = TryBuildMatchedQueryResponse(operation, query, headers, body, out response);
+        var queryMatchResult = TryBuildMatchedQueryResponse(pathItem, operation, query, headers, body, out response);
 
         if (queryMatchResult == QueryMatchEvaluationResult.Matched)
         {
@@ -265,6 +265,7 @@ public sealed class StubService
     }
 
     private QueryMatchEvaluationResult TryBuildMatchedQueryResponse(
+        PathItemDefinition pathItem,
         OperationDefinition operation,
         IReadOnlyDictionary<string, string> query,
         IReadOnlyDictionary<string, string> headers,
@@ -279,7 +280,7 @@ public sealed class StubService
         }
 
         // Query/header/body conditions are combined, then the most specific surviving candidate wins.
-        var matchedCandidate = matcherService.FindBestMatch(operation, query, headers, body);
+        var matchedCandidate = matcherService.FindBestMatch(pathItem.Parameters, operation, query, headers, body);
 
         if (matchedCandidate is null)
         {

--- a/tests/SemanticStub.Api.Tests/Unit/MatcherServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/MatcherServiceTests.cs
@@ -15,7 +15,7 @@ public sealed class MatcherServiceTests
             [
                 new QueryMatchDefinition
                 {
-                    Query = new Dictionary<string, string>(StringComparer.Ordinal)
+                    Query = new Dictionary<string, object?>(StringComparer.Ordinal)
                     {
                         ["role"] = "admin"
                     },
@@ -26,7 +26,7 @@ public sealed class MatcherServiceTests
                 },
                 new QueryMatchDefinition
                 {
-                    Query = new Dictionary<string, string>(StringComparer.Ordinal)
+                    Query = new Dictionary<string, object?>(StringComparer.Ordinal)
                     {
                         ["role"] = "admin",
                         ["view"] = "summary"
@@ -124,7 +124,7 @@ public sealed class MatcherServiceTests
             [
                 new QueryMatchDefinition
                 {
-                    Query = new Dictionary<string, string>(StringComparer.Ordinal)
+                    Query = new Dictionary<string, object?>(StringComparer.Ordinal)
                     {
                         ["role"] = "admin"
                     }
@@ -171,6 +171,220 @@ public sealed class MatcherServiceTests
             {
                 ["x-env"] = "staging"
             },
+            body: null);
+
+        Assert.NotNull(match);
+    }
+
+    [Fact]
+    public void FindBestMatch_MatchesIntegerQueryUsingDeclaredSchemaType()
+    {
+        var operation = new OperationDefinition
+        {
+            Parameters =
+            [
+                new ParameterDefinition
+                {
+                    Name = "page",
+                    In = "query",
+                    Schema = new ParameterSchemaDefinition
+                    {
+                        Type = "integer"
+                    }
+                }
+            ],
+            Matches =
+            [
+                new QueryMatchDefinition
+                {
+                    Query = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    {
+                        ["page"] = 1
+                    }
+                }
+            ]
+        };
+
+        var matcher = new MatcherService();
+
+        var match = matcher.FindBestMatch(
+            operation,
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["page"] = "1"
+            },
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            body: null);
+
+        Assert.NotNull(match);
+    }
+
+    [Fact]
+    public void FindBestMatch_MatchesNumberQueryUsingDeclaredSchemaType()
+    {
+        var operation = new OperationDefinition
+        {
+            Parameters =
+            [
+                new ParameterDefinition
+                {
+                    Name = "ratio",
+                    In = "query",
+                    Schema = new ParameterSchemaDefinition
+                    {
+                        Type = "number"
+                    }
+                }
+            ],
+            Matches =
+            [
+                new QueryMatchDefinition
+                {
+                    Query = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    {
+                        ["ratio"] = 1.5m
+                    }
+                }
+            ]
+        };
+
+        var matcher = new MatcherService();
+
+        var match = matcher.FindBestMatch(
+            operation,
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["ratio"] = "1.5"
+            },
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            body: null);
+
+        Assert.NotNull(match);
+    }
+
+    [Fact]
+    public void FindBestMatch_MatchesBooleanQueryUsingDeclaredSchemaType()
+    {
+        var operation = new OperationDefinition
+        {
+            Parameters =
+            [
+                new ParameterDefinition
+                {
+                    Name = "enabled",
+                    In = "query",
+                    Schema = new ParameterSchemaDefinition
+                    {
+                        Type = "boolean"
+                    }
+                }
+            ],
+            Matches =
+            [
+                new QueryMatchDefinition
+                {
+                    Query = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    {
+                        ["enabled"] = true
+                    }
+                }
+            ]
+        };
+
+        var matcher = new MatcherService();
+
+        var match = matcher.FindBestMatch(
+            operation,
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["enabled"] = "true"
+            },
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            body: null);
+
+        Assert.NotNull(match);
+    }
+
+    [Fact]
+    public void FindBestMatch_ReturnsNullWhenTypedQueryValueDoesNotMatch()
+    {
+        var operation = new OperationDefinition
+        {
+            Parameters =
+            [
+                new ParameterDefinition
+                {
+                    Name = "page",
+                    In = "query",
+                    Schema = new ParameterSchemaDefinition
+                    {
+                        Type = "integer"
+                    }
+                }
+            ],
+            Matches =
+            [
+                new QueryMatchDefinition
+                {
+                    Query = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    {
+                        ["page"] = 1
+                    }
+                }
+            ]
+        };
+
+        var matcher = new MatcherService();
+
+        var match = matcher.FindBestMatch(
+            operation,
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["page"] = "1.5"
+            },
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            body: null);
+
+        Assert.Null(match);
+    }
+
+    [Fact]
+    public void FindBestMatch_UsesPathLevelQueryParameterType()
+    {
+        var operation = new OperationDefinition
+        {
+            Matches =
+            [
+                new QueryMatchDefinition
+                {
+                    Query = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    {
+                        ["page"] = 1
+                    }
+                }
+            ]
+        };
+
+        var matcher = new MatcherService();
+
+        var match = matcher.FindBestMatch(
+            [
+                new ParameterDefinition
+                {
+                    Name = "page",
+                    In = "query",
+                    Schema = new ParameterSchemaDefinition
+                    {
+                        Type = "integer"
+                    }
+                }
+            ],
+            operation,
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["page"] = "1"
+            },
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
             body: null);
 
         Assert.NotNull(match);

--- a/tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs
@@ -400,6 +400,49 @@ public sealed class StubDefinitionLoaderTests
     }
 
     [Fact]
+    public void LoadDefaultDefinition_PreservesQueryParameterSchemaTypeAndTypedMatchValue()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+              /users:
+                get:
+                  parameters:
+                    - name: page
+                      in: query
+                      schema:
+                        type: integer
+                  x-match:
+                    - query:
+                        page: 1
+                      response:
+                        statusCode: 200
+                        content:
+                          application/json:
+                            example:
+                              users: []
+                  responses:
+                    "200":
+                      description: ok
+                      content:
+                        application/json:
+                          example:
+                            users: []
+            """);
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var document = loader.LoadDefaultDefinition();
+        var operation = Assert.IsType<OperationDefinition>(document.Paths["/users"].Get);
+        var parameter = Assert.Single(operation.Parameters);
+        var match = Assert.Single(operation.Matches);
+
+        Assert.Equal("integer", parameter.Schema?.Type);
+        Assert.Equal("1", Assert.IsType<string>(match.Query["page"]));
+    }
+
+    [Fact]
     public void LoadDefaultDefinition_AllowsMatchedQueryDefinedOnPathParameters()
     {
         using var workspace = TestWorkspace.Create(

--- a/tests/SemanticStub.Api.Tests/Unit/StubServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubServiceTests.cs
@@ -104,7 +104,7 @@ public sealed class StubServiceTests
                         [
                             new QueryMatchDefinition
                             {
-                                Query = new Dictionary<string, string>(StringComparer.Ordinal)
+                                Query = new Dictionary<string, object?>(StringComparer.Ordinal)
                                 {
                                     ["role"] = "admin"
                                 },
@@ -395,7 +395,7 @@ public sealed class StubServiceTests
                         [
                             new QueryMatchDefinition
                             {
-                                Query = new Dictionary<string, string>(StringComparer.Ordinal)
+                                Query = new Dictionary<string, object?>(StringComparer.Ordinal)
                                 {
                                     ["role"] = "admin"
                                 },
@@ -534,7 +534,7 @@ public sealed class StubServiceTests
                         [
                             new QueryMatchDefinition
                             {
-                                Query = new Dictionary<string, string>(StringComparer.Ordinal)
+                                Query = new Dictionary<string, object?>(StringComparer.Ordinal)
                                 {
                                     ["role"] = "admin"
                                 },
@@ -555,7 +555,7 @@ public sealed class StubServiceTests
                             },
                             new QueryMatchDefinition
                             {
-                                Query = new Dictionary<string, string>(StringComparer.Ordinal)
+                                Query = new Dictionary<string, object?>(StringComparer.Ordinal)
                                 {
                                     ["role"] = "admin",
                                     ["view"] = "summary"
@@ -609,7 +609,7 @@ public sealed class StubServiceTests
                         [
                             new QueryMatchDefinition
                             {
-                                Query = new Dictionary<string, string>(StringComparer.Ordinal)
+                                Query = new Dictionary<string, object?>(StringComparer.Ordinal)
                                 {
                                     ["role"] = "admin"
                                 },
@@ -677,7 +677,7 @@ public sealed class StubServiceTests
                         [
                             new QueryMatchDefinition
                             {
-                                Query = new Dictionary<string, string>(StringComparer.Ordinal)
+                                Query = new Dictionary<string, object?>(StringComparer.Ordinal)
                                 {
                                     ["role"] = "admin"
                                 },
@@ -818,7 +818,7 @@ public sealed class StubServiceTests
                         [
                             new QueryMatchDefinition
                             {
-                                Query = new Dictionary<string, string>(StringComparer.Ordinal)
+                                Query = new Dictionary<string, object?>(StringComparer.Ordinal)
                                 {
                                     ["format"] = "csv"
                                 },
@@ -865,7 +865,7 @@ public sealed class StubServiceTests
                         [
                             new QueryMatchDefinition
                             {
-                                Query = new Dictionary<string, string>(StringComparer.Ordinal)
+                                Query = new Dictionary<string, object?>(StringComparer.Ordinal)
                                 {
                                     ["role"] = "admin"
                                 },


### PR DESCRIPTION
## Purpose
Add typed query comparison for `x-match.query` so declared OpenAPI query parameter types can be compared without breaking existing string-based behavior.

## Changes
- preserve query parameter `schema.type` in the loaded stub definition
- compare `x-match.query` values as typed values for `integer`, `number`, and `boolean`
- keep existing string comparison when no supported query type is declared
- add unit tests for typed query matching, path-level query parameter types, and compatibility cases

## Validation
- `dotnet build SemanticStub.sln`
- `dotnet test SemanticStub.sln`

## Impact
- existing YAML remains compatible
- existing matching priority and fallback behavior are unchanged
- typed query comparison now works when the query parameter is declared with an OpenAPI schema type