### PR TITLE
feat: support multi-value query parameters

### DIFF
--- a/SemanticStub.http
+++ b/SemanticStub.http
@@ -12,11 +12,28 @@ Accept: application/json
 GET {{host}}/users?role=admin
 Accept: application/json
 
+### Users stub prefers the more specific query match
+GET {{host}}/users?role=admin&view=summary
+Accept: application/json
+
 ### Users stub filtered by another exact query match
 GET {{host}}/users?role=guest
 Accept: application/json
 
-### Login stub
+### Search stub filtered by ordered repeated query values
+GET {{host}}/search?tag=alpha&tag=beta
+Accept: application/json
+
+### Search stub falls back when repeated query value order differs
+GET {{host}}/search?tag=beta&tag=alpha
+Accept: application/json
+
+### Environment users stub filtered by request header
+GET {{host}}/environment-users
+X-Env: staging
+Accept: application/json
+
+### Login stub with matching body
 POST {{host}}/login
 Content-Type: application/json
 Accept: application/json
@@ -25,6 +42,55 @@ Accept: application/json
   "username": "demo",
   "password": "secret"
 }
+
+### Login stub falls back when body does not match
+POST {{host}}/login
+Content-Type: application/json
+Accept: application/json
+
+{
+  "username": "other",
+  "password": "wrong"
+}
+
+### Replace profile
+PUT {{host}}/profile
+Content-Type: application/json
+Accept: application/json
+
+{
+  "displayName": "Updated User"
+}
+
+### Patch profile with matching body
+PATCH {{host}}/profile
+Content-Type: application/json
+Accept: application/json
+
+{
+  "nickname": "stubby"
+}
+
+### Patch profile fallback response
+PATCH {{host}}/profile
+Content-Type: application/json
+Accept: application/json
+
+{
+  "nickname": "other"
+}
+
+### Delete profile
+DELETE {{host}}/profile
+Accept: application/json
+
+### Template path order route
+GET {{host}}/orders/123
+Accept: application/json
+
+### Exact path order route
+GET {{host}}/orders/special
+Accept: application/json
 
 ### Unknown route returns 404
 GET {{host}}/missing

--- a/samples/basic-routing.yaml
+++ b/samples/basic-routing.yaml
@@ -30,6 +30,17 @@ paths:
 
   /users:
     get:
+      parameters:
+        - name: role
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: view
+          in: query
+          required: false
+          schema:
+            type: string
       operationId: listUsers
       x-match:
         - query:
@@ -99,6 +110,34 @@ paths:
                         - name
                 required:
                   - users
+
+  /search:
+    get:
+      operationId: searchUsers
+      parameters:
+        - name: tag
+          in: query
+          required: false
+          schema:
+            type: string
+      x-match:
+        - query:
+            tag:
+              - alpha
+              - beta
+          response:
+            statusCode: 200
+            content:
+              application/json:
+                example:
+                  result: ordered-tags
+      responses:
+        '200':
+          description: Default search response
+          content:
+            application/json:
+              example:
+                result: default-search
 
   /environment-users:
     get:

--- a/src/SemanticStub.Api/Controllers/StubController.cs
+++ b/src/SemanticStub.Api/Controllers/StubController.cs
@@ -66,7 +66,7 @@ public sealed class StubController : ControllerBase
     private async Task<IActionResult> HandleRequest(string method, string? path)
     {
         var requestPath = string.IsNullOrEmpty(path) ? "/" : "/" + path;
-        var query = Request.Query.ToDictionary(entry => entry.Key, entry => entry.Value.ToString(), StringComparer.Ordinal);
+        var query = Request.Query.ToDictionary(entry => entry.Key, entry => entry.Value, StringComparer.Ordinal);
         var headers = Request.Headers.ToDictionary(entry => entry.Key, entry => entry.Value.ToString(), StringComparer.OrdinalIgnoreCase);
         var requestBody = await ReadRequestBodyAsync();
         var matchResult = stubService.TryGetResponse(method, requestPath, query, headers, requestBody, out var response);

--- a/src/SemanticStub.Api/Services/MatcherService.cs
+++ b/src/SemanticStub.Api/Services/MatcherService.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Globalization;
 using System.Text.Json;
+using Microsoft.Extensions.Primitives;
 using SemanticStub.Api.Models;
 using SemanticStub.Api.Utilities;
 
@@ -21,6 +22,20 @@ public sealed class MatcherService
     {
         return FindBestMatch(
             operation,
+            ConvertQueryValues(query),
+            body);
+    }
+
+    /// <summary>
+    /// Preserves the existing query-and-body matching entry point while delegating to the full matcher implementation.
+    /// </summary>
+    public QueryMatchDefinition? FindBestMatch(
+        OperationDefinition operation,
+        IReadOnlyDictionary<string, StringValues> query,
+        string? body)
+    {
+        return FindBestMatch(
+            operation,
             query,
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
             body);
@@ -33,6 +48,23 @@ public sealed class MatcherService
     public QueryMatchDefinition? FindBestMatch(
         OperationDefinition operation,
         IReadOnlyDictionary<string, string> query,
+        IReadOnlyDictionary<string, string> headers,
+        string? body)
+    {
+        return FindBestMatch(
+            operation,
+            ConvertQueryValues(query),
+            headers,
+            body);
+    }
+
+    /// <summary>
+    /// Filters candidates by every configured condition and prefers the most constrained definition so explicit matches win over broad fallbacks.
+    /// </summary>
+    /// <returns>The best matching conditional definition, or <see langword="null"/> when none satisfy the request.</returns>
+    public QueryMatchDefinition? FindBestMatch(
+        OperationDefinition operation,
+        IReadOnlyDictionary<string, StringValues> query,
         IReadOnlyDictionary<string, string> headers,
         string? body)
     {
@@ -51,7 +83,7 @@ public sealed class MatcherService
     public QueryMatchDefinition? FindBestMatch(
         IReadOnlyCollection<ParameterDefinition> pathParameters,
         OperationDefinition operation,
-        IReadOnlyDictionary<string, string> query,
+        IReadOnlyDictionary<string, StringValues> query,
         IReadOnlyDictionary<string, string> headers,
         string? body)
     {
@@ -103,7 +135,7 @@ public sealed class MatcherService
 
     private static bool IsExactQueryMatch(
         IReadOnlyDictionary<string, object?> expected,
-        IReadOnlyDictionary<string, string> actual,
+        IReadOnlyDictionary<string, StringValues> actual,
         IReadOnlyDictionary<string, string> queryParameterTypes)
     {
         foreach (var pair in expected)
@@ -118,7 +150,41 @@ public sealed class MatcherService
         return true;
     }
 
-    private static bool IsTypedQueryValueMatch(object? expected, string actual, string? parameterType)
+    private static bool IsTypedQueryValueMatch(object? expected, StringValues actual, string? parameterType)
+    {
+        if (expected is IEnumerable expectedSequence && expected is not string)
+        {
+            return IsTypedQuerySequenceMatch(expectedSequence, actual, parameterType);
+        }
+
+        return actual.Count == 1 &&
+               actual[0] is not null &&
+               IsTypedSingleQueryValueMatch(expected, actual[0]!, parameterType);
+    }
+
+    private static bool IsTypedQuerySequenceMatch(IEnumerable expectedSequence, StringValues actual, string? parameterType)
+    {
+        var expectedValues = expectedSequence.Cast<object?>().ToArray();
+        var actualValues = actual.ToArray();
+
+        if (expectedValues.Length != actualValues.Length)
+        {
+            return false;
+        }
+
+        for (var index = 0; index < expectedValues.Length; index++)
+        {
+            if (actualValues[index] is null ||
+                !IsTypedSingleQueryValueMatch(expectedValues[index], actualValues[index]!, parameterType))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsTypedSingleQueryValueMatch(object? expected, string actual, string? parameterType)
     {
         if (string.Equals(parameterType, "integer", StringComparison.OrdinalIgnoreCase))
         {
@@ -142,6 +208,14 @@ public sealed class MatcherService
         }
 
         return string.Equals(ConvertQueryValueToString(expected), actual, StringComparison.Ordinal);
+    }
+
+    private static IReadOnlyDictionary<string, StringValues> ConvertQueryValues(IReadOnlyDictionary<string, string> query)
+    {
+        return query.ToDictionary(
+            entry => entry.Key,
+            entry => new StringValues(entry.Value),
+            StringComparer.Ordinal);
     }
 
     private static bool TryConvertInteger(object? value, out decimal integer)

--- a/src/SemanticStub.Api/Services/StubService.cs
+++ b/src/SemanticStub.Api/Services/StubService.cs
@@ -56,7 +56,7 @@ public sealed class StubService
         return TryGetResponse(
             method,
             path,
-            new Dictionary<string, string>(StringComparer.Ordinal),
+            new Dictionary<string, StringValues>(StringComparer.Ordinal),
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
             body: null,
             out response);
@@ -68,6 +68,22 @@ public sealed class StubService
     /// <param name="response">Receives the assembled response when a matching stub is found.</param>
     /// <returns>A result that distinguishes between no route, unsupported method, invalid configuration, and a successful match.</returns>
     public StubMatchResult TryGetResponse(string method, string path, IReadOnlyDictionary<string, string> query, out StubResponse response)
+    {
+        return TryGetResponse(
+            method,
+            path,
+            ConvertQueryValues(query),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            body: null,
+            out response);
+    }
+
+    /// <summary>
+    /// Resolves a response while considering query-based match conditions so more specific stubs can override broad defaults.
+    /// </summary>
+    /// <param name="response">Receives the assembled response when a matching stub is found.</param>
+    /// <returns>A result that distinguishes between no route, unsupported method, invalid configuration, and a successful match.</returns>
+    public StubMatchResult TryGetResponse(string method, string path, IReadOnlyDictionary<string, StringValues> query, out StubResponse response)
     {
         return TryGetResponse(
             method,
@@ -88,6 +104,22 @@ public sealed class StubService
         return TryGetResponse(
             method,
             path,
+            ConvertQueryValues(query),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            body,
+            out response);
+    }
+
+    /// <summary>
+    /// Resolves a response while considering query and body match conditions so structured request payloads can select a narrower stub.
+    /// </summary>
+    /// <param name="response">Receives the assembled response when a matching stub is found.</param>
+    /// <returns>A result that distinguishes between no route, unsupported method, invalid configuration, and a successful match.</returns>
+    public StubMatchResult TryGetResponse(string method, string path, IReadOnlyDictionary<string, StringValues> query, string? body, out StubResponse response)
+    {
+        return TryGetResponse(
+            method,
+            path,
             query,
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
             body,
@@ -102,7 +134,7 @@ public sealed class StubService
     public StubMatchResult TryGetResponse(
         string method,
         string path,
-        IReadOnlyDictionary<string, string> query,
+        IReadOnlyDictionary<string, StringValues> query,
         IReadOnlyDictionary<string, string> headers,
         string? body,
         out StubResponse response)
@@ -163,6 +195,14 @@ public sealed class StubService
         };
 
         return StubMatchResult.Matched;
+    }
+
+    private static IReadOnlyDictionary<string, StringValues> ConvertQueryValues(IReadOnlyDictionary<string, string> query)
+    {
+        return query.ToDictionary(
+            entry => entry.Key,
+            entry => new StringValues(entry.Value),
+            StringComparer.Ordinal);
     }
 
     private PathItemDefinition? ResolvePathItem(string requestPath)
@@ -267,7 +307,7 @@ public sealed class StubService
     private QueryMatchEvaluationResult TryBuildMatchedQueryResponse(
         PathItemDefinition pathItem,
         OperationDefinition operation,
-        IReadOnlyDictionary<string, string> query,
+        IReadOnlyDictionary<string, StringValues> query,
         IReadOnlyDictionary<string, string> headers,
         string? body,
         out StubResponse response)

--- a/tests/SemanticStub.Api.Tests/Integration/BasicRoutingStubTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/BasicRoutingStubTests.cs
@@ -135,6 +135,28 @@ public sealed class BasicRoutingStubTests : IClassFixture<WebApplicationFactory<
     }
 
     [Fact]
+    public async Task GetSearchWithOrderedRepeatedTagQuery_ReturnsSpecificResponse()
+    {
+        var response = await client.GetAsync("/search?tag=alpha&tag=beta");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var payload = await response.Content.ReadFromJsonAsync<SearchResponse>();
+        Assert.NotNull(payload);
+        Assert.Equal("ordered-tags", payload.Result);
+    }
+
+    [Fact]
+    public async Task GetSearchWithDifferentRepeatedTagQueryOrder_UsesFallbackResponse()
+    {
+        var response = await client.GetAsync("/search?tag=beta&tag=alpha");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var payload = await response.Content.ReadFromJsonAsync<SearchResponse>();
+        Assert.NotNull(payload);
+        Assert.Equal("default-search", payload.Result);
+    }
+
+    [Fact]
     public async Task GetUsersWithEnvironmentHeader_ReturnsHeaderSpecificUsers()
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, "/environment-users");
@@ -348,6 +370,11 @@ public sealed class BasicRoutingStubTests : IClassFixture<WebApplicationFactory<
     }
 
     public sealed class MutationResponse
+    {
+        public string Result { get; init; } = string.Empty;
+    }
+
+    public sealed class SearchResponse
     {
         public string Result { get; init; } = string.Empty;
     }

--- a/tests/SemanticStub.Api.Tests/Unit/MatcherServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/MatcherServiceTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Primitives;
 using SemanticStub.Api.Models;
 using SemanticStub.Api.Services;
 using Xunit;
@@ -380,14 +381,107 @@ public sealed class MatcherServiceTests
                 }
             ],
             operation,
-            new Dictionary<string, string>(StringComparer.Ordinal)
+            new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>(StringComparer.Ordinal)
             {
-                ["page"] = "1"
+                ["page"] = new("1")
             },
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
             body: null);
 
         Assert.NotNull(match);
+    }
+
+    [Fact]
+    public void FindBestMatch_MatchesMultiValueQueryInOrder()
+    {
+        var operation = new OperationDefinition
+        {
+            Matches =
+            [
+                new QueryMatchDefinition
+                {
+                    Query = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    {
+                        ["tag"] = new List<object?> { "alpha", "beta" }
+                    }
+                }
+            ]
+        };
+
+        var matcher = new MatcherService();
+
+        var match = matcher.FindBestMatch(
+            operation,
+            new Dictionary<string, StringValues>(StringComparer.Ordinal)
+            {
+                ["tag"] = new StringValues(["alpha", "beta"])
+            },
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            body: null);
+
+        Assert.NotNull(match);
+    }
+
+    [Fact]
+    public void FindBestMatch_ReturnsNullWhenMultiValueQueryOrderDiffers()
+    {
+        var operation = new OperationDefinition
+        {
+            Matches =
+            [
+                new QueryMatchDefinition
+                {
+                    Query = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    {
+                        ["tag"] = new List<object?> { "alpha", "beta" }
+                    }
+                }
+            ]
+        };
+
+        var matcher = new MatcherService();
+
+        var match = matcher.FindBestMatch(
+            operation,
+            new Dictionary<string, StringValues>(StringComparer.Ordinal)
+            {
+                ["tag"] = new StringValues(["beta", "alpha"])
+            },
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            body: null);
+
+        Assert.Null(match);
+    }
+
+    [Fact]
+    public void FindBestMatch_ReturnsNullWhenSingleValueMatchReceivesMultipleActualValues()
+    {
+        var operation = new OperationDefinition
+        {
+            Matches =
+            [
+                new QueryMatchDefinition
+                {
+                    Query = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    {
+                        ["tag"] = "alpha"
+                    }
+                }
+            ]
+        };
+
+        var matcher = new MatcherService();
+
+        var match = matcher.FindBestMatch(
+            operation,
+            new Dictionary<string, StringValues>(StringComparer.Ordinal)
+            {
+                ["tag"] = new StringValues(["alpha", "beta"])
+            },
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            body: null);
+
+        Assert.Null(match);
     }
 
     [Fact]

--- a/tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs
@@ -443,6 +443,50 @@ public sealed class StubDefinitionLoaderTests
     }
 
     [Fact]
+    public void LoadDefaultDefinition_PreservesMultiValueQueryMatch()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+              /search:
+                get:
+                  parameters:
+                    - name: tag
+                      in: query
+                      schema:
+                        type: string
+                  x-match:
+                    - query:
+                        tag:
+                          - alpha
+                          - beta
+                      response:
+                        statusCode: 200
+                        content:
+                          application/json:
+                            example:
+                              result: ordered
+                  responses:
+                    "200":
+                      description: ok
+                      content:
+                        application/json:
+                          example:
+                            result: fallback
+            """);
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var document = loader.LoadDefaultDefinition();
+        var operation = Assert.IsType<OperationDefinition>(document.Paths["/search"].Get);
+        var match = Assert.Single(operation.Matches);
+        var values = Assert.IsAssignableFrom<IEnumerable<object?>>(match.Query["tag"]);
+
+        Assert.Equal(["alpha", "beta"], values.Cast<string>().ToArray());
+    }
+
+    [Fact]
     public void LoadDefaultDefinition_AllowsMatchedQueryDefinedOnPathParameters()
     {
         using var workspace = TestWorkspace.Create(

--- a/tests/SemanticStub.Api.Tests/Unit/StubServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubServiceTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
 using SemanticStub.Api.Models;
 using SemanticStub.Api.Services;
 using Xunit;
@@ -140,6 +141,74 @@ public sealed class StubServiceTests
 
         Assert.Equal(StubMatchResult.Matched, matched);
         Assert.Equal(125, response.DelayMilliseconds);
+    }
+
+    [Fact]
+    public void TryGetResponse_MatchesMultiValueQueryParameter()
+    {
+        var document = new StubDocument
+        {
+            Paths = new Dictionary<string, PathItemDefinition>(StringComparer.Ordinal)
+            {
+                ["/search"] = new()
+                {
+                    Get = new OperationDefinition
+                    {
+                        Matches =
+                        [
+                            new QueryMatchDefinition
+                            {
+                                Query = new Dictionary<string, object?>(StringComparer.Ordinal)
+                                {
+                                    ["tag"] = new List<object?> { "alpha", "beta" }
+                                },
+                                Response = new QueryMatchResponseDefinition
+                                {
+                                    StatusCode = 200,
+                                    Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+                                    {
+                                        ["application/json"] = new()
+                                        {
+                                            Example = new Dictionary<object, object>
+                                            {
+                                                ["result"] = "ordered"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        Responses = new Dictionary<string, ResponseDefinition>(StringComparer.Ordinal)
+                        {
+                            ["200"] = new()
+                            {
+                                Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+                                {
+                                    ["application/json"] = new()
+                                    {
+                                        Example = new Dictionary<object, object>
+                                        {
+                                            ["result"] = "fallback"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        var service = new StubService(document);
+        var query = new Dictionary<string, StringValues>(StringComparer.Ordinal)
+        {
+            ["tag"] = new StringValues(["alpha", "beta"])
+        };
+
+        var matched = service.TryGetResponse(HttpMethods.Get, "/search", query, out var response);
+
+        Assert.Equal(StubMatchResult.Matched, matched);
+        Assert.Equal("{\"result\":\"ordered\"}", response.Body);
     }
 
     [Fact]
@@ -1186,7 +1255,7 @@ public sealed class StubServiceTests
         var matched = service.TryGetResponse(
             HttpMethods.Get,
             "/users",
-            new Dictionary<string, string>(StringComparer.Ordinal),
+            new Dictionary<string, StringValues>(StringComparer.Ordinal),
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
                 ["x-env"] = "staging"


### PR DESCRIPTION
## Purpose
Support repeated query parameters without losing values during request matching.

## Changes
- preserve repeated query values from ASP.NET Core requests by passing `StringValues` through the stub matching pipeline
- allow `x-match.query` to define multi-value query expectations as arrays while keeping existing single-value matching behavior
- match repeated query values in request order and keep fallback behavior unchanged when values do not match
- add unit and integration tests for multi-value query matching, loader normalization, and HTTP-level behavior
- extend `SemanticStub.http` with sample requests so the new behavior and existing basic-routing samples can be verified manually

## Validation
- `dotnet build SemanticStub.sln`
- `dotnet test SemanticStub.sln`

## Impact
- existing YAML remains compatible
- repeated query keys such as `?tag=alpha&tag=beta` can now be matched predictably
- single-value query matching and existing route fallback behavior remain unchanged