### PR TITLE
docs: document YAML extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ Notes:
 - A response must define `content` or `x-response-file`.
 - `x-response-file` keeps the media type declaration in `content`, while the
   payload comes from the referenced file.
+- `x-response-file` paths are resolved relative to the YAML file that declares
+  them.
+- File-backed responses preserve the declared media type, including binary
+  types such as `application/octet-stream`.
+- When multiple media types are declared, SemanticStub prefers a JSON media
+  type for deterministic response selection and otherwise uses the first
+  declared type.
 
 ### Supported operation extensions
 
@@ -80,6 +87,7 @@ paths:
 Each `x-match` entry may contain:
 
 - `query`: exact query-string matches.
+- `x-query-partial`: partial query-string matches.
 - `headers`: exact header matches.
 - `body`: exact body match data.
 - `response`: the response returned when the match succeeds.
@@ -89,8 +97,44 @@ Notes:
 - `response.statusCode` is required and must be a positive integer.
 - `x-match` responses support the same `content`, `headers`, `x-delay`, and
   `x-response-file` fields as normal responses.
+- Query, header, and body conditions are combined with AND semantics inside a
+  single `x-match` entry.
+- Query and header keys used by `x-match` must reference parameters declared in
+  OpenAPI when those parameters are present on the path or operation.
+- `query` supports exact single-value matches, ordered repeated values, and
+  typed comparison for declared OpenAPI query parameter types such as
+  `integer`, `number`, and `boolean`.
+- `x-query-partial` performs substring matching. Exact `query` matches are
+  preferred over partial matches when multiple candidates succeed.
+- `body` matching currently applies to JSON request bodies. Body matching is
+  partial for objects, so a request may contain additional properties and still
+  match.
+- Invalid JSON request bodies do not satisfy `body` match conditions.
 - When no `x-match` entry succeeds, SemanticStub falls back to the standard
   `responses` section.
+- When multiple `x-match` entries succeed, SemanticStub chooses the most
+  specific candidate so narrower conditions win over broader ones.
+
+### Matching precedence
+
+Request handling follows these precedence rules:
+
+1. Exact path match over template path match.
+2. Matching HTTP method on the selected path.
+3. Matching `x-match` candidate on the operation, preferring more specific
+   exact query conditions before broader candidates.
+4. Fallback to the standard OpenAPI `responses` section when no `x-match`
+   candidate succeeds.
+
+This keeps routing deterministic for the current feature set.
+
+### Current limitations
+
+- Regex query matching is not supported yet.
+- Scenario and semantic matching appear only in sample files today; they are
+  not part of the current runtime behavior.
+- `body` matching is intended for structured JSON request payloads rather than
+  arbitrary binary request bodies.
 
 ### Sample-only extensions
 


### PR DESCRIPTION
## Summary
- document the currently supported YAML extensions in more detail
- clarify matching precedence, fallback behavior, and current limitations
- add guidance for response-file media types and current query/body matching behavior

## Changes
- expand the README section for response extensions with file resolution and media type selection notes
- document `x-query-partial` alongside existing `x-match` conditions
- add concise precedence and limitation sections so current runtime behavior is easier to understand before adding more features

## Validation
- reviewed the updated README against the current implementation in `StubService`, `MatcherService`, and the existing samples/tests
- no build or test run; documentation-only change

## Impact
- no runtime behavior changes
- improves discoverability of the existing YAML contract and current feature boundaries

Closes #10