### PR TITLE
fix: add allow header for method not allowed

### DIFF
--- a/src/SemanticStub.Api/Controllers/StubController.cs
+++ b/src/SemanticStub.Api/Controllers/StubController.cs
@@ -79,6 +79,13 @@ public sealed class StubController : ControllerBase
 
         if (matchResult == StubMatchResult.MethodNotAllowed)
         {
+            var allowedMethods = stubService.GetAllowedMethods(requestPath);
+
+            if (allowedMethods.Count > 0)
+            {
+                Response.Headers.Allow = string.Join(", ", allowedMethods);
+            }
+
             return StatusCode(StatusCodes.Status405MethodNotAllowed);
         }
 

--- a/src/SemanticStub.Api/Services/IStubService.cs
+++ b/src/SemanticStub.Api/Services/IStubService.cs
@@ -9,6 +9,16 @@ namespace SemanticStub.Api.Services;
 public interface IStubService
 {
     /// <summary>
+    /// Returns the HTTP methods currently configured for the supplied path so callers can emit protocol details such as the <c>Allow</c> header on <c>405 Method Not Allowed</c> responses.
+    /// </summary>
+    /// <param name="path">The absolute request path such as <c>/users</c>.</param>
+    /// <returns>The configured methods for the resolved path, or an empty list when no path matches.</returns>
+    IReadOnlyList<string> GetAllowedMethods(string path)
+    {
+        return Array.Empty<string>();
+    }
+
+    /// <summary>
     /// Resolves a response for callers that only need method and path matching.
     /// </summary>
     /// <param name="response">Receives the assembled response only when the return value is <see cref="StubMatchResult.Matched"/>.</param>

--- a/src/SemanticStub.Api/Services/StubService.cs
+++ b/src/SemanticStub.Api/Services/StubService.cs
@@ -13,6 +13,7 @@ namespace SemanticStub.Api.Services;
 public sealed class StubService : IStubService
 {
     private const string JsonContentType = "application/json";
+    private static readonly string[] SupportedMethodOrder = [HttpMethods.Get, HttpMethods.Post, HttpMethods.Put, HttpMethods.Patch, HttpMethods.Delete];
     private readonly StubDocument document;
     private readonly Func<string, string> responseFileReader;
     private readonly MatcherService matcherService;
@@ -104,6 +105,25 @@ public sealed class StubService : IStubService
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
             body: null,
             out response);
+    }
+
+    /// <summary>
+    /// Returns the configured HTTP methods for the supplied path in a stable order suitable for the <c>Allow</c> response header.
+    /// </summary>
+    /// <param name="path">The absolute request path such as <c>/users</c>.</param>
+    /// <returns>The configured methods for the resolved path, or an empty list when no path matches.</returns>
+    public IReadOnlyList<string> GetAllowedMethods(string path)
+    {
+        var pathItem = ResolvePathItem(path);
+
+        if (pathItem is null)
+        {
+            return Array.Empty<string>();
+        }
+
+        return SupportedMethodOrder
+            .Where(method => GetOperation(method, pathItem) is not null)
+            .ToArray();
     }
 
     /// <summary>

--- a/tests/SemanticStub.Api.Tests/Integration/BasicRoutingStubTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/BasicRoutingStubTests.cs
@@ -344,6 +344,7 @@ public sealed class BasicRoutingStubTests : IClassFixture<WebApplicationFactory<
         var response = await client.GetAsync("/login");
 
         Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+        Assert.Equal("POST", string.Join(", ", response.Content.Headers.Allow));
     }
 
     [Fact]
@@ -360,6 +361,7 @@ public sealed class BasicRoutingStubTests : IClassFixture<WebApplicationFactory<
         var response = await client.GetAsync("/profile");
 
         Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+        Assert.Equal("PUT, PATCH, DELETE", string.Join(", ", response.Content.Headers.Allow));
     }
 
     [Fact]
@@ -390,6 +392,7 @@ public sealed class BasicRoutingStubTests : IClassFixture<WebApplicationFactory<
         var response = await client.PostAsync("/orders/123", content: null);
 
         Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+        Assert.Equal("GET", string.Join(", ", response.Content.Headers.Allow));
     }
 
     public sealed class HelloResponse

--- a/tests/SemanticStub.Api.Tests/Unit/StubControllerTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubControllerTests.cs
@@ -64,7 +64,10 @@ public sealed class StubControllerTests
     [Fact]
     public async Task Delete_ReturnsMethodNotAllowed_WhenMethodNotAllowed()
     {
-        var stubService = new RecordingStubService(StubMatchResult.MethodNotAllowed, new StubResponse());
+        var stubService = new RecordingStubService(
+            StubMatchResult.MethodNotAllowed,
+            new StubResponse(),
+            allowedMethods: [HttpMethods.Get, HttpMethods.Post]);
         var controller = CreateController(stubService);
 
         var result = await controller.Delete("users/1");
@@ -72,6 +75,7 @@ public sealed class StubControllerTests
         var statusResult = Assert.IsType<StatusCodeResult>(result);
         Assert.Equal(StatusCodes.Status405MethodNotAllowed, statusResult.StatusCode);
         Assert.Equal(HttpMethods.Delete, stubService.Method);
+        Assert.Equal("GET, POST", controller.Response.Headers.Allow.ToString());
     }
 
     [Fact]
@@ -230,10 +234,11 @@ public sealed class StubControllerTests
         private readonly StubMatchResult matchResult;
         private readonly StubResponse response;
 
-        public RecordingStubService(StubMatchResult matchResult, StubResponse response)
+        public RecordingStubService(StubMatchResult matchResult, StubResponse response, IReadOnlyList<string>? allowedMethods = null)
         {
             this.matchResult = matchResult;
             this.response = response;
+            AllowedMethods = allowedMethods ?? Array.Empty<string>();
         }
 
         public string Method { get; private set; } = string.Empty;
@@ -247,6 +252,13 @@ public sealed class StubControllerTests
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         public string? Body { get; private set; }
+
+        public IReadOnlyList<string> AllowedMethods { get; }
+
+        public IReadOnlyList<string> GetAllowedMethods(string path)
+        {
+            return AllowedMethods;
+        }
 
         public StubMatchResult TryGetResponse(
             string method,

--- a/tests/SemanticStub.Api.Tests/Unit/StubServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubServiceTests.cs
@@ -1635,6 +1635,51 @@ public sealed class StubServiceTests
         Assert.Equal(StubMatchResult.MethodNotAllowed, matched);
     }
 
+    [Fact]
+    public void GetAllowedMethods_ReturnsConfiguredMethodsForExactPathInStableOrder()
+    {
+        var document = new StubDocument
+        {
+            Paths = new Dictionary<string, PathItemDefinition>(StringComparer.Ordinal)
+            {
+                ["/users"] = new()
+                {
+                    Post = new OperationDefinition(),
+                    Get = new OperationDefinition(),
+                    Delete = new OperationDefinition()
+                }
+            }
+        };
+
+        var service = new StubService(document);
+
+        var allowedMethods = service.GetAllowedMethods("/users");
+
+        Assert.Equal([HttpMethods.Get, HttpMethods.Post, HttpMethods.Delete], allowedMethods);
+    }
+
+    [Fact]
+    public void GetAllowedMethods_ReturnsConfiguredMethodsForTemplatePath()
+    {
+        var document = new StubDocument
+        {
+            Paths = new Dictionary<string, PathItemDefinition>(StringComparer.Ordinal)
+            {
+                ["/orders/{orderId}"] = new()
+                {
+                    Get = new OperationDefinition(),
+                    Patch = new OperationDefinition()
+                }
+            }
+        };
+
+        var service = new StubService(document);
+
+        var allowedMethods = service.GetAllowedMethods("/orders/123");
+
+        Assert.Equal([HttpMethods.Get, HttpMethods.Patch], allowedMethods);
+    }
+
     private sealed class TestStubDefinitionLoader(StubDocument document) : IStubDefinitionLoader
     {
         public StubDocument LoadDefaultDefinition()


### PR DESCRIPTION
## Purpose
Refine HTTP behavior details by returning an `Allow` header on `405 Method Not Allowed` responses without changing existing routing behavior.

## Changes
- added a minimal `IStubService.GetAllowedMethods` helper with a safe default implementation
- returned configured methods in stable order from `StubService` for exact and template path matches
- set the `Allow` header in `StubController` when a request resolves to `405 Method Not Allowed`
- added unit and integration coverage for `Allow` header behavior

## Validation
- `dotnet build SemanticStub.sln`
- `dotnet test SemanticStub.sln`

## Impact
- existing route matching and response behavior are preserved
- `405` responses now include protocol details that help clients understand which methods are supported