### PR TITLE
feat: add HTTP compression middleware support

### DIFF
--- a/src/SemanticStub.Api/Program.cs
+++ b/src/SemanticStub.Api/Program.cs
@@ -1,4 +1,7 @@
+using System.IO.Compression;
 using Microsoft.AspNetCore.HttpLogging;
+using Microsoft.AspNetCore.RequestDecompression;
+using Microsoft.AspNetCore.ResponseCompression;
 using SemanticStub.Api.Infrastructure.Yaml;
 using SemanticStub.Api.Services;
 
@@ -10,6 +13,15 @@ builder.Services.AddHttpLogging(options =>
     ConfigureHttpLoggingDefaults(options);
     builder.Configuration.GetSection("HttpLogging").Bind(options);
     ConfigureHttpLoggingMediaTypes(options);
+});
+builder.Services.AddRequestDecompression();
+builder.Services.AddResponseCompression(options =>
+{
+    options.EnableForHttps = true;
+});
+builder.Services.Configure<GzipCompressionProviderOptions>(options =>
+{
+    options.Level = CompressionLevel.Fastest;
 });
 builder.Services.Configure<StubSettings>(builder.Configuration.GetSection("StubSettings"));
 builder.Services.AddSingleton<StubDefinitionLoader>();
@@ -28,6 +40,8 @@ var app = builder.Build();
 // Fail fast during startup when stub definitions are invalid instead of deferring configuration errors until the first request.
 app.Services.GetRequiredService<StubDefinitionState>();
 
+app.UseRequestDecompression();
+app.UseResponseCompression();
 app.UseHttpLogging();
 app.MapControllers();
 

--- a/tests/SemanticStub.Api.Tests/Integration/BasicRoutingStubTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/BasicRoutingStubTests.cs
@@ -1,6 +1,8 @@
+using System.IO.Compression;
 using System.Net;
 using System.Net.Http.Json;
 using System.Diagnostics;
+using System.Text;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 
@@ -30,6 +32,23 @@ public sealed class BasicRoutingStubTests : IClassFixture<WebApplicationFactory<
         var payload = await response.Content.ReadFromJsonAsync<HelloResponse>();
         Assert.NotNull(payload);
         Assert.Equal("Hello from SemanticStub", payload.Message);
+    }
+
+    [Fact]
+    public async Task GetHello_WithAcceptEncodingGzip_ReturnsGzipCompressedResponse()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/hello");
+        request.Headers.AcceptEncoding.ParseAdd("gzip");
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("gzip", response.Content.Headers.ContentEncoding);
+
+        var compressedBody = await response.Content.ReadAsByteArrayAsync();
+        var payload = DecompressGzip(compressedBody);
+
+        Assert.Contains("Hello from SemanticStub", payload, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -309,6 +328,24 @@ public sealed class BasicRoutingStubTests : IClassFixture<WebApplicationFactory<
     }
 
     [Fact]
+    public async Task PatchProfile_WithGzipCompressedBody_ReturnsSpecificResponse()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Patch, "/profile")
+        {
+            Content = new ByteArrayContent(CompressGzip("""{"nickname":"stubby"}"""))
+        };
+        request.Content.Headers.ContentType = new("application/json");
+        request.Content.Headers.ContentEncoding.Add("gzip");
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var payload = await response.Content.ReadFromJsonAsync<MutationResponse>();
+        Assert.NotNull(payload);
+        Assert.Equal("patched-specific", payload.Result);
+    }
+
+    [Fact]
     public async Task PatchProfile_WithNonMatchingBody_ReturnsFallbackResponse()
     {
         var request = new HttpRequestMessage(HttpMethod.Patch, "/profile")
@@ -448,5 +485,27 @@ public sealed class BasicRoutingStubTests : IClassFixture<WebApplicationFactory<
     public sealed class SearchResponse
     {
         public string Result { get; init; } = string.Empty;
+    }
+
+    private static byte[] CompressGzip(string content)
+    {
+        var input = Encoding.UTF8.GetBytes(content);
+        using var output = new MemoryStream();
+
+        using (var gzipStream = new GZipStream(output, CompressionLevel.SmallestSize, leaveOpen: true))
+        {
+            gzipStream.Write(input, 0, input.Length);
+        }
+
+        return output.ToArray();
+    }
+
+    private static string DecompressGzip(byte[] content)
+    {
+        using var input = new MemoryStream(content);
+        using var gzipStream = new GZipStream(input, CompressionMode.Decompress);
+        using var reader = new StreamReader(gzipStream, Encoding.UTF8);
+
+        return reader.ReadToEnd();
     }
 }


### PR DESCRIPTION
## Summary
Add standard ASP.NET Core request decompression and response compression to SemanticStub.

This keeps the change localized to application startup and adds integration coverage for gzip-compressed requests and gzip-compressed responses.

## Files Changed
- `src/SemanticStub.Api/Program.cs`
- `tests/SemanticStub.Api.Tests/Integration/BasicRoutingStubTests.cs`

## Tests
- `dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter "FullyQualifiedName~GetHello_WithAcceptEncodingGzip_ReturnsGzipCompressedResponse|FullyQualifiedName~PatchProfile_WithGzipCompressedBody_ReturnsSpecificResponse|FullyQualifiedName~HttpLoggingTests"`
- `dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj`

## Notes
- Uses ASP.NET Core standard middleware for request decompression and response compression.
- Keeps YAML structure and existing stub behavior unchanged.
- Relies on framework default response compression MIME types after confirming `application/json` is already covered in this environment.
