### PR TITLE
feat: add Visual Studio-compatible Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+WORKDIR /app
+EXPOSE 8080
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+COPY ["Directory.Packages.props", "."]
+COPY ["src/SemanticStub.Api/SemanticStub.Api.csproj", "src/SemanticStub.Api/"]
+RUN dotnet restore "./src/SemanticStub.Api/SemanticStub.Api.csproj"
+COPY . .
+WORKDIR "/src/src/SemanticStub.Api"
+RUN dotnet build "./SemanticStub.Api.csproj" -c $BUILD_CONFIGURATION -o /app/build
+
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish "./SemanticStub.Api.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+COPY --from=build /src/samples ./samples
+ENTRYPOINT ["dotnet", "SemanticStub.Api.dll"]


### PR DESCRIPTION
## Summary
- add a Visual Studio-compatible multi-stage Dockerfile at the repository root
- publish `SemanticStub.Api` with official .NET 10 SDK/ASP.NET runtime images
- include the `samples` directory in the final image so the default stub definition path works in containers

## Files Changed
- `Dockerfile`

## Tests
- `dotnet test SemanticStub.sln`
- `docker build -t semanticstub-issue78-test .`
- `docker run --rm -d --name semanticstub-issue78-smoke -p 18080:8080 semanticstub-issue78-test`
- `curl -i http://127.0.0.1:18080/hello`
- `curl -i 'http://127.0.0.1:18080/users?role=admin'`

## Notes
- keeps existing application behavior and YAML compatibility unchanged
- limits the change to the container build path required by Issue #78
