### PR TITLE
fix: avoid scenario reset deadlock on reload

### DIFF
--- a/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionState.cs
+++ b/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionState.cs
@@ -39,7 +39,7 @@ internal sealed class StubDefinitionState
                 scenarioService.ExecuteLocked(() =>
                 {
                     Volatile.Write(ref currentDocument, reloadedDocument);
-                    scenarioService.Reset();
+                    scenarioService.ResetWithinLock();
                     return 0;
                 });
                 logger.LogInformation("Reloaded stub definitions from disk.");

--- a/src/SemanticStub.Api/Services/ScenarioService.cs
+++ b/src/SemanticStub.Api/Services/ScenarioService.cs
@@ -49,9 +49,14 @@ public sealed class ScenarioService
     {
         ExecuteLocked(() =>
         {
-            currentStates.Clear();
+            ResetWithinLock();
             return 0;
         });
+    }
+
+    internal void ResetWithinLock()
+    {
+        currentStates.Clear();
     }
 
     /// <summary>

--- a/tests/SemanticStub.Api.Tests/Unit/ScenarioServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/ScenarioServiceTests.cs
@@ -51,6 +51,28 @@ public sealed class ScenarioServiceTests
         Assert.True(service.IsMatch(scenario));
     }
 
+    [Fact]
+    public void ResetWithinLock_ClearsAdvancedScenarioStateWithoutDeadlock()
+    {
+        var service = new ScenarioService();
+        var scenario = new ScenarioDefinition
+        {
+            Name = "checkout-flow",
+            State = "initial",
+            Next = "confirmed"
+        };
+
+        service.Advance(scenario);
+
+        service.ExecuteLocked(() =>
+        {
+            service.ResetWithinLock();
+            return 0;
+        });
+
+        Assert.True(service.IsMatch(scenario));
+    }
+
     private static void UpdateMax(ref int target, int candidate)
     {
         while (true)


### PR DESCRIPTION
## Summary
- avoid re-entering the scenario lock while reloading stub definitions
- reuse an internal reset path when the caller already holds the scenario lock
- add regression coverage for lock-safe scenario reset behavior

## Testing
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter `FullyQualifiedName~ScenarioServiceTests|FullyQualifiedName~AutomaticReloadTests.PostCheckout_ResetsScenarioStateAfterReload`