### PR TITLE
feat: add scenario runtime inspection and reset

### DIFF
--- a/src/SemanticStub.Api/Controllers/StubInspectionController.cs
+++ b/src/SemanticStub.Api/Controllers/StubInspectionController.cs
@@ -29,4 +29,25 @@ public sealed class StubInspectionController : ControllerBase
     /// <summary>Returns the list of all routes currently defined in the loaded stub definitions.</summary>
     [HttpGet("routes")]
     public IActionResult GetRoutes() => Ok(inspectionService.GetRoutes());
+
+    /// <summary>Returns the current runtime state for all configured scenarios.</summary>
+    [HttpGet("scenarios")]
+    public IActionResult GetScenarios() => Ok(inspectionService.GetScenarioStates());
+
+    /// <summary>Resets all configured scenarios back to their initial state.</summary>
+    [HttpPost("scenarios/reset")]
+    public IActionResult ResetScenarios()
+    {
+        inspectionService.ResetScenarioStates();
+        return NoContent();
+    }
+
+    /// <summary>Resets a configured scenario back to its initial state.</summary>
+    [HttpPost("scenarios/{name}/reset")]
+    public IActionResult ResetScenario(string name)
+    {
+        return inspectionService.ResetScenarioState(name)
+            ? NoContent()
+            : NotFound();
+    }
 }

--- a/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionState.cs
+++ b/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionState.cs
@@ -39,7 +39,7 @@ internal sealed class StubDefinitionState
                 scenarioService.ExecuteLocked(() =>
                 {
                     Volatile.Write(ref currentDocument, reloadedDocument);
-                    scenarioService.ResetWithinLock();
+                    scenarioService.ResetScenariosWithinLock(GetScenarioNames(reloadedDocument), DateTimeOffset.UtcNow);
                     return 0;
                 });
                 logger.LogInformation("Reloaded stub definitions from disk.");
@@ -49,6 +49,46 @@ internal sealed class StubDefinitionState
             {
                 logger.LogError(ex, "Failed to reload stub definitions. Continuing with the last successfully loaded definitions.");
                 return false;
+            }
+        }
+    }
+
+    private static IReadOnlyList<string> GetScenarioNames(StubDocument document)
+    {
+        var scenarioNames = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var pathItem in document.Paths.Values)
+        {
+            AddScenarioNames(pathItem.Get, scenarioNames);
+            AddScenarioNames(pathItem.Post, scenarioNames);
+            AddScenarioNames(pathItem.Put, scenarioNames);
+            AddScenarioNames(pathItem.Patch, scenarioNames);
+            AddScenarioNames(pathItem.Delete, scenarioNames);
+        }
+
+        return scenarioNames.ToList();
+    }
+
+    private static void AddScenarioNames(OperationDefinition? operation, ISet<string> scenarioNames)
+    {
+        if (operation is null)
+        {
+            return;
+        }
+
+        foreach (var response in operation.Responses.Values)
+        {
+            if (response.Scenario is not null)
+            {
+                scenarioNames.Add(response.Scenario.Name);
+            }
+        }
+
+        foreach (var match in operation.Matches)
+        {
+            if (match.Response.Scenario is not null)
+            {
+                scenarioNames.Add(match.Response.Scenario.Name);
             }
         }
     }

--- a/src/SemanticStub.Api/Inspection/ScenarioStateInfo.cs
+++ b/src/SemanticStub.Api/Inspection/ScenarioStateInfo.cs
@@ -1,0 +1,16 @@
+namespace SemanticStub.Api.Inspection;
+
+/// <summary>
+/// Describes the current runtime state for a configured scenario.
+/// </summary>
+public sealed class ScenarioStateInfo
+{
+    /// <summary>Gets the scenario name defined in YAML.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Gets the scenario's current state value.</summary>
+    public required string CurrentState { get; init; }
+
+    /// <summary>Gets the UTC timestamp when the current state was last established, when available.</summary>
+    public DateTimeOffset? LastUpdatedTimestamp { get; init; }
+}

--- a/src/SemanticStub.Api/Services/IStubInspectionService.cs
+++ b/src/SemanticStub.Api/Services/IStubInspectionService.cs
@@ -16,4 +16,21 @@ public interface IStubInspectionService
     /// Returns the list of all routes (path + method combinations) currently defined.
     /// </summary>
     IReadOnlyList<StubRouteInfo> GetRoutes();
+
+    /// <summary>
+    /// Returns the current runtime state for all configured scenarios.
+    /// </summary>
+    IReadOnlyList<ScenarioStateInfo> GetScenarioStates();
+
+    /// <summary>
+    /// Resets all configured scenarios back to their initial state.
+    /// </summary>
+    void ResetScenarioStates();
+
+    /// <summary>
+    /// Resets the supplied configured scenario back to its initial state.
+    /// </summary>
+    /// <param name="scenarioName">The scenario name defined in YAML.</param>
+    /// <returns><see langword="true"/> when the scenario exists in the active configuration; otherwise <see langword="false"/>.</returns>
+    bool ResetScenarioState(string scenarioName);
 }

--- a/src/SemanticStub.Api/Services/ScenarioService.cs
+++ b/src/SemanticStub.Api/Services/ScenarioService.cs
@@ -9,7 +9,7 @@ namespace SemanticStub.Api.Services;
 public sealed class ScenarioService
 {
     private const string InitialState = "initial";
-    private readonly ConcurrentDictionary<string, string> currentStates = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, ScenarioStateSnapshot> currentStates = new(StringComparer.Ordinal);
     private readonly SemaphoreSlim semaphore = new(1, 1);
 
     /// <summary>
@@ -23,7 +23,9 @@ public sealed class ScenarioService
             return true;
         }
 
-        var currentState = currentStates.GetValueOrDefault(scenario.Name, InitialState);
+        var currentState = currentStates.TryGetValue(scenario.Name, out var snapshot)
+            ? snapshot.State
+            : InitialState;
 
         return string.Equals(currentState, scenario.State, StringComparison.Ordinal);
     }
@@ -39,7 +41,7 @@ public sealed class ScenarioService
             return;
         }
 
-        currentStates[scenario.Name] = scenario.Next;
+        currentStates[scenario.Name] = new ScenarioStateSnapshot(scenario.Next, DateTimeOffset.UtcNow);
     }
 
     /// <summary>
@@ -57,6 +59,84 @@ public sealed class ScenarioService
     internal void ResetWithinLock()
     {
         currentStates.Clear();
+    }
+
+    /// <summary>
+    /// Returns the point-in-time snapshot for the supplied scenario.
+    /// </summary>
+    /// <param name="scenarioName">The scenario name defined in YAML.</param>
+    public ScenarioStateSnapshot GetSnapshot(string scenarioName)
+    {
+        return ExecuteLocked(() => GetSnapshotWithinLock(scenarioName));
+    }
+
+    /// <summary>
+    /// Returns point-in-time snapshots for the supplied scenarios.
+    /// </summary>
+    /// <param name="scenarioNames">The scenario names defined in YAML.</param>
+    public IReadOnlyDictionary<string, ScenarioStateSnapshot> GetSnapshots(IEnumerable<string> scenarioNames)
+    {
+        return ExecuteLocked(() =>
+        {
+            var snapshots = new Dictionary<string, ScenarioStateSnapshot>(StringComparer.Ordinal);
+
+            foreach (var scenarioName in scenarioNames)
+            {
+                snapshots[scenarioName] = GetSnapshotWithinLock(scenarioName);
+            }
+
+            return snapshots;
+        });
+    }
+
+    /// <summary>
+    /// Resets the supplied scenario back to its initial state.
+    /// </summary>
+    /// <param name="scenarioName">The scenario name defined in YAML.</param>
+    public void ResetScenario(string scenarioName)
+    {
+        ExecuteLocked(() =>
+        {
+            ResetScenarioWithinLock(scenarioName, DateTimeOffset.UtcNow);
+            return 0;
+        });
+    }
+
+    /// <summary>
+    /// Resets the supplied scenarios back to their initial state.
+    /// </summary>
+    /// <param name="scenarioNames">The scenario names defined in YAML.</param>
+    public void ResetScenarios(IEnumerable<string> scenarioNames)
+    {
+        ExecuteLocked(() =>
+        {
+            ResetScenariosWithinLock(scenarioNames, DateTimeOffset.UtcNow);
+            return 0;
+        });
+    }
+
+    internal ScenarioStateSnapshot GetSnapshotWithinLock(string scenarioName)
+    {
+        return currentStates.TryGetValue(scenarioName, out var snapshot)
+            ? snapshot
+            : new ScenarioStateSnapshot(InitialState, null);
+    }
+
+    internal void ResetScenarioWithinLock(string scenarioName, DateTimeOffset timestamp)
+    {
+        currentStates[scenarioName] = new ScenarioStateSnapshot(InitialState, timestamp);
+    }
+
+    internal void ResetScenariosWithinLock(IEnumerable<string> scenarioNames, DateTimeOffset timestamp)
+    {
+        var scenarioNameSet = new HashSet<string>(scenarioNames, StringComparer.Ordinal);
+
+        currentStates.Clear();
+
+        foreach (var scenarioName in scenarioNameSet)
+        {
+            currentStates[scenarioName] = new ScenarioStateSnapshot(InitialState, timestamp);
+        }
     }
 
     /// <summary>
@@ -93,3 +173,8 @@ public sealed class ScenarioService
         }
     }
 }
+
+/// <summary>
+/// Describes a scenario's current runtime state and when it last changed.
+/// </summary>
+public sealed record ScenarioStateSnapshot(string State, DateTimeOffset? LastUpdatedTimestamp);

--- a/src/SemanticStub.Api/Services/StubInspectionService.cs
+++ b/src/SemanticStub.Api/Services/StubInspectionService.cs
@@ -13,15 +13,18 @@ internal sealed class StubInspectionService : IStubInspectionService
     private readonly StubDefinitionState state;
     private readonly IStubDefinitionLoader loader;
     private readonly IOptions<StubSettings> settings;
+    private readonly ScenarioService scenarioService;
 
     public StubInspectionService(
         StubDefinitionState state,
         IStubDefinitionLoader loader,
-        IOptions<StubSettings> settings)
+        IOptions<StubSettings> settings,
+        ScenarioService scenarioService)
     {
         this.state = state;
         this.loader = loader;
         this.settings = settings;
+        this.scenarioService = scenarioService;
     }
 
     /// <inheritdoc/>
@@ -45,6 +48,58 @@ internal sealed class StubInspectionService : IStubInspectionService
     {
         var document = state.GetCurrentDocument();
         return BuildRoutes(document);
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<ScenarioStateInfo> GetScenarioStates()
+    {
+        return scenarioService.ExecuteLocked(() =>
+        {
+            var document = state.GetCurrentDocument();
+            var scenarioNames = GetScenarioNames(document);
+
+            return scenarioNames
+                .Select(name =>
+                {
+                    var snapshot = scenarioService.GetSnapshotWithinLock(name);
+                    return new ScenarioStateInfo
+                    {
+                        Name = name,
+                        CurrentState = snapshot.State,
+                        LastUpdatedTimestamp = snapshot.LastUpdatedTimestamp,
+                    };
+                })
+                .ToList();
+        });
+    }
+
+    /// <inheritdoc/>
+    public void ResetScenarioStates()
+    {
+        scenarioService.ExecuteLocked(() =>
+        {
+            var document = state.GetCurrentDocument();
+            scenarioService.ResetScenariosWithinLock(GetScenarioNames(document), DateTimeOffset.UtcNow);
+            return 0;
+        });
+    }
+
+    /// <inheritdoc/>
+    public bool ResetScenarioState(string scenarioName)
+    {
+        return scenarioService.ExecuteLocked(() =>
+        {
+            var document = state.GetCurrentDocument();
+            var scenarioNames = GetScenarioNames(document);
+
+            if (!scenarioNames.Contains(scenarioName, StringComparer.Ordinal))
+            {
+                return false;
+            }
+
+            scenarioService.ResetScenarioWithinLock(scenarioName, DateTimeOffset.UtcNow);
+            return true;
+        });
     }
 
     private static IReadOnlyList<StubRouteInfo> BuildRoutes(StubDocument document)
@@ -89,6 +144,46 @@ internal sealed class StubInspectionService : IStubInspectionService
     private static bool HasScenario(OperationDefinition op)
         => op.Responses.Values.Any(r => r.Scenario is not null)
         || op.Matches.Any(m => m.Response.Scenario is not null);
+
+    private static IReadOnlyList<string> GetScenarioNames(StubDocument document)
+    {
+        var scenarioNames = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var pathItem in document.Paths.Values)
+        {
+            AddScenarioNames(pathItem.Get, scenarioNames);
+            AddScenarioNames(pathItem.Post, scenarioNames);
+            AddScenarioNames(pathItem.Put, scenarioNames);
+            AddScenarioNames(pathItem.Patch, scenarioNames);
+            AddScenarioNames(pathItem.Delete, scenarioNames);
+        }
+
+        return scenarioNames.OrderBy(name => name, StringComparer.Ordinal).ToList();
+    }
+
+    private static void AddScenarioNames(OperationDefinition? operation, ISet<string> scenarioNames)
+    {
+        if (operation is null)
+        {
+            return;
+        }
+
+        foreach (var response in operation.Responses.Values)
+        {
+            if (response.Scenario is not null)
+            {
+                scenarioNames.Add(response.Scenario.Name);
+            }
+        }
+
+        foreach (var match in operation.Matches)
+        {
+            if (match.Response.Scenario is not null)
+            {
+                scenarioNames.Add(match.Response.Scenario.Name);
+            }
+        }
+    }
 
     private static string ComputeDocumentHash(StubDocument document)
     {

--- a/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
@@ -89,4 +89,40 @@ public sealed class StubInspectionEndpointTests : IClassFixture<WebApplicationFa
             Assert.NotEmpty(route.PathPattern);
         }
     }
+
+    [Fact]
+    public async Task GetScenarios_ReturnsOk()
+    {
+        var response = await client.GetAsync("/_semanticstub/runtime/scenarios");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetScenarios_ResponseDeserializesToScenarioStateInfoArray()
+    {
+        var response = await client.GetAsync("/_semanticstub/runtime/scenarios");
+        response.EnsureSuccessStatusCode();
+
+        var scenarios = await response.Content.ReadFromJsonAsync<ScenarioStateInfo[]>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.NotNull(scenarios);
+    }
+
+    [Fact]
+    public async Task ResetScenarios_ReturnsNoContent()
+    {
+        var response = await client.PostAsync("/_semanticstub/runtime/scenarios/reset", content: null);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ResetScenario_ReturnsNotFound_WhenScenarioDoesNotExist()
+    {
+        var response = await client.PostAsync("/_semanticstub/runtime/scenarios/does-not-exist/reset", content: null);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
 }

--- a/tests/SemanticStub.Api.Tests/Unit/ScenarioServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/ScenarioServiceTests.cs
@@ -52,6 +52,78 @@ public sealed class ScenarioServiceTests
     }
 
     [Fact]
+    public void GetSnapshot_ReturnsInitialStateWithNullTimestamp_WhenScenarioHasNotAdvanced()
+    {
+        var service = new ScenarioService();
+
+        var snapshot = service.GetSnapshot("checkout-flow");
+
+        Assert.Equal("initial", snapshot.State);
+        Assert.Null(snapshot.LastUpdatedTimestamp);
+    }
+
+    [Fact]
+    public void Advance_StoresCurrentStateTimestamp()
+    {
+        var service = new ScenarioService();
+        var scenario = new ScenarioDefinition
+        {
+            Name = "checkout-flow",
+            State = "initial",
+            Next = "confirmed"
+        };
+        var before = DateTimeOffset.UtcNow;
+
+        service.Advance(scenario);
+
+        var after = DateTimeOffset.UtcNow;
+        var snapshot = service.GetSnapshot("checkout-flow");
+
+        Assert.Equal("confirmed", snapshot.State);
+        Assert.NotNull(snapshot.LastUpdatedTimestamp);
+        Assert.True(snapshot.LastUpdatedTimestamp >= before);
+        Assert.True(snapshot.LastUpdatedTimestamp <= after);
+    }
+
+    [Fact]
+    public void ResetScenario_RestoresInitialStateWithTimestamp()
+    {
+        var service = new ScenarioService();
+        var scenario = new ScenarioDefinition
+        {
+            Name = "checkout-flow",
+            State = "initial",
+            Next = "confirmed"
+        };
+
+        service.Advance(scenario);
+
+        service.ResetScenario("checkout-flow");
+
+        var snapshot = service.GetSnapshot("checkout-flow");
+        Assert.Equal("initial", snapshot.State);
+        Assert.NotNull(snapshot.LastUpdatedTimestamp);
+    }
+
+    [Fact]
+    public void ResetScenarios_ResetsOnlyTheSuppliedScenarioSet()
+    {
+        var service = new ScenarioService();
+        service.Advance(new ScenarioDefinition { Name = "checkout-flow", State = "initial", Next = "confirmed" });
+        service.Advance(new ScenarioDefinition { Name = "payment-flow", State = "initial", Next = "authorized" });
+
+        service.ResetScenarios(["checkout-flow"]);
+
+        var checkoutSnapshot = service.GetSnapshot("checkout-flow");
+        var paymentSnapshot = service.GetSnapshot("payment-flow");
+
+        Assert.Equal("initial", checkoutSnapshot.State);
+        Assert.NotNull(checkoutSnapshot.LastUpdatedTimestamp);
+        Assert.Equal("initial", paymentSnapshot.State);
+        Assert.Null(paymentSnapshot.LastUpdatedTimestamp);
+    }
+
+    [Fact]
     public void ResetWithinLock_ClearsAdvancedScenarioStateWithoutDeadlock()
     {
         var service = new ScenarioService();

--- a/tests/SemanticStub.Api.Tests/Unit/StubInspectionServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubInspectionServiceTests.cs
@@ -32,12 +32,13 @@ public sealed class StubInspectionServiceTests
         bool semanticMatchingEnabled = false)
     {
         var loader = new TestStubDefinitionLoader(document, directoryPath);
-        var state = new StubDefinitionState(loader, new ScenarioService(), NullLogger<StubDefinitionState>.Instance);
+        var scenarioService = new ScenarioService();
+        var state = new StubDefinitionState(loader, scenarioService, NullLogger<StubDefinitionState>.Instance);
         var settings = Options.Create(new StubSettings
         {
             SemanticMatching = new SemanticMatchingSettings { Enabled = semanticMatchingEnabled },
         });
-        return new StubInspectionService(state, loader, settings);
+        return new StubInspectionService(state, loader, settings, scenarioService);
     }
 
     private static StubDocument EmptyDocument() => new StubDocument
@@ -545,5 +546,164 @@ public sealed class StubInspectionServiceTests
 
         var route = Assert.Single(CreateService(document).GetRoutes());
         Assert.Equal(0, route.ResponseCount);
+    }
+
+    // ---------------------------------------------------------------------------
+    // GetScenarioStates / ResetScenarioStates
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void GetScenarioStates_ReturnsConfiguredScenarios_WithInitialStateByDefault()
+    {
+        var document = new StubDocument
+        {
+            Paths = new Dictionary<string, PathItemDefinition>(StringComparer.Ordinal)
+            {
+                ["/checkout"] = new()
+                {
+                    Post = new OperationDefinition
+                    {
+                        Responses = new Dictionary<string, ResponseDefinition>(StringComparer.Ordinal)
+                        {
+                            ["409"] = new()
+                            {
+                                Scenario = new ScenarioDefinition
+                                {
+                                    Name = "checkout-flow",
+                                    State = "initial",
+                                    Next = "confirmed"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        var scenario = Assert.Single(CreateService(document).GetScenarioStates());
+
+        Assert.Equal("checkout-flow", scenario.Name);
+        Assert.Equal("initial", scenario.CurrentState);
+        Assert.Null(scenario.LastUpdatedTimestamp);
+    }
+
+    [Fact]
+    public void GetScenarioStates_ReflectsAdvancedScenarioStateAndTimestamp()
+    {
+        var document = new StubDocument
+        {
+            Paths = new Dictionary<string, PathItemDefinition>(StringComparer.Ordinal)
+            {
+                ["/checkout"] = new()
+                {
+                    Post = new OperationDefinition
+                    {
+                        Responses = new Dictionary<string, ResponseDefinition>(StringComparer.Ordinal)
+                        {
+                            ["409"] = new()
+                            {
+                                Scenario = new ScenarioDefinition
+                                {
+                                    Name = "checkout-flow",
+                                    State = "initial",
+                                    Next = "confirmed"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        var loader = new TestStubDefinitionLoader(document);
+        var scenarioService = new ScenarioService();
+        var state = new StubDefinitionState(loader, scenarioService, NullLogger<StubDefinitionState>.Instance);
+        var settings = Options.Create(new StubSettings());
+        var service = new StubInspectionService(state, loader, settings, scenarioService);
+
+        scenarioService.Advance(new ScenarioDefinition
+        {
+            Name = "checkout-flow",
+            State = "initial",
+            Next = "confirmed"
+        });
+
+        var scenario = Assert.Single(service.GetScenarioStates());
+
+        Assert.Equal("confirmed", scenario.CurrentState);
+        Assert.NotNull(scenario.LastUpdatedTimestamp);
+    }
+
+    [Fact]
+    public void ResetScenarioState_ReturnsFalse_WhenScenarioDoesNotExist()
+    {
+        var service = CreateService(EmptyDocument());
+
+        var reset = service.ResetScenarioState("missing");
+
+        Assert.False(reset);
+    }
+
+    [Fact]
+    public void ResetScenarioStates_ResetsAllConfiguredScenariosWithTimestamp()
+    {
+        var document = new StubDocument
+        {
+            Paths = new Dictionary<string, PathItemDefinition>(StringComparer.Ordinal)
+            {
+                ["/checkout"] = new()
+                {
+                    Post = new OperationDefinition
+                    {
+                        Responses = new Dictionary<string, ResponseDefinition>(StringComparer.Ordinal)
+                        {
+                            ["409"] = new()
+                            {
+                                Scenario = new ScenarioDefinition
+                                {
+                                    Name = "checkout-flow",
+                                    State = "initial",
+                                    Next = "confirmed"
+                                }
+                            }
+                        },
+                        Matches =
+                        [
+                            new QueryMatchDefinition
+                            {
+                                Response = new QueryMatchResponseDefinition
+                                {
+                                    StatusCode = 200,
+                                    Scenario = new ScenarioDefinition
+                                    {
+                                        Name = "payment-flow",
+                                        State = "initial",
+                                        Next = "authorized"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        };
+        var loader = new TestStubDefinitionLoader(document);
+        var scenarioService = new ScenarioService();
+        var state = new StubDefinitionState(loader, scenarioService, NullLogger<StubDefinitionState>.Instance);
+        var settings = Options.Create(new StubSettings());
+        var service = new StubInspectionService(state, loader, settings, scenarioService);
+
+        scenarioService.Advance(new ScenarioDefinition { Name = "checkout-flow", State = "initial", Next = "confirmed" });
+        scenarioService.Advance(new ScenarioDefinition { Name = "payment-flow", State = "initial", Next = "authorized" });
+
+        service.ResetScenarioStates();
+
+        var scenarios = service.GetScenarioStates();
+
+        Assert.Equal(2, scenarios.Count);
+        Assert.All(scenarios, scenario =>
+        {
+            Assert.Equal("initial", scenario.CurrentState);
+            Assert.NotNull(scenario.LastUpdatedTimestamp);
+        });
     }
 }


### PR DESCRIPTION
## Summary
- add runtime scenario inspection at `GET /_semanticstub/runtime/scenarios`
- add safe scenario reset endpoints for all scenarios and a single named scenario
- track nullable `LastUpdatedTimestamp` for scenario state transitions and resets without changing YAML compatibility

## Files Changed
- runtime inspection controller and service contracts for scenario inspection/reset
- scenario state tracking and reload reset handling
- unit and integration tests covering scenario state snapshots, reset behavior, and endpoint contracts

## Tests
- `dotnet test SemanticStub.sln --filter "FullyQualifiedName~ScenarioServiceTests|FullyQualifiedName~StubInspectionServiceTests|FullyQualifiedName~StubInspectionEndpointTests|FullyQualifiedName~AutomaticReloadTests"`
- `dotnet test SemanticStub.sln`

## Notes
- refs #89
- reset endpoints return `204 No Content`; unknown scenario names return `404 Not Found`
- `LastUpdatedTimestamp` stays nullable and is populated when a scenario enters its current state through advance, reset, or reload
