### PR TITLE
feat(runtime): add route detail inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ prefix `/_semanticstub/runtime`.
 
 - `GET /_semanticstub/runtime/config` returns metadata for the active effective configuration snapshot.
 - `GET /_semanticstub/runtime/routes` returns the active normalized route list.
+- `GET /_semanticstub/runtime/routes/{routeId}` returns the effective runtime details for one active route.
 - `GET /_semanticstub/runtime/scenarios` returns the current scenario state snapshot.
 - `POST /_semanticstub/runtime/test-match` evaluates a virtual request without executing a real response or mutating scenario state.
 - `POST /_semanticstub/runtime/explain` returns structured match details for a virtual request, including deterministic and semantic evaluation when applicable.
@@ -266,10 +267,11 @@ Inspection notes:
 
 - `/_semanticstub/runtime/config` is a summary view. It currently returns snapshot metadata such as timestamp, configuration hash, definitions directory, route count, and whether semantic matching is enabled.
 - `/_semanticstub/runtime/routes` returns one item per active path and HTTP method with stable external fields such as route id, normalized path pattern, semantic matching usage, scenario usage, and response count.
+- `/_semanticstub/runtime/routes/{routeId}` expands a single route into a stable detail view with top-level responses and normalized conditional match metadata.
 - `/_semanticstub/runtime/scenarios` returns one item per known scenario with its current state and whether it is active.
 - `/_semanticstub/runtime/test-match` and `/_semanticstub/runtime/explain` accept a virtual request payload with method, path, optional query/header/body values, and optional candidate-detail flags.
 - `/_semanticstub/runtime/explain/last` is process-local and only updates after a real request produces a matched stub response.
-- These endpoints do not currently expose full per-route response definitions, raw YAML, or detailed `x-match` conditions.
+- These endpoints do not expose raw YAML, internal domain objects, or full response payload bodies.
 
 Example request body for `POST /_semanticstub/runtime/test-match` and
 `POST /_semanticstub/runtime/explain`:
@@ -282,6 +284,45 @@ Example request body for `POST /_semanticstub/runtime/test-match` and
     "role": ["admin"]
   },
   "includeCandidates": true
+}
+```
+
+Example response body for `GET /_semanticstub/runtime/routes/listUsers`:
+
+```json
+{
+  "routeId": "listUsers",
+  "method": "GET",
+  "pathPattern": "/users",
+  "usesSemanticMatching": false,
+  "usesScenario": false,
+  "responseCount": 1,
+  "hasConditionalMatches": true,
+  "responses": [
+    {
+      "responseId": "200",
+      "usesScenario": false,
+      "scenario": null
+    }
+  ],
+  "conditionalMatches": [
+    {
+      "candidateIndex": 0,
+      "hasExactQuery": true,
+      "exactQueryKeys": ["role"],
+      "hasPartialQuery": false,
+      "partialQueryKeys": [],
+      "hasRegexQuery": false,
+      "regexQueryKeys": [],
+      "headerKeys": [],
+      "hasBody": false,
+      "usesSemanticMatching": false,
+      "semanticMatch": null,
+      "responseStatusCode": 200,
+      "usesScenario": false,
+      "scenario": null
+    }
+  ]
 }
 ```
 

--- a/SemanticStub.http
+++ b/SemanticStub.http
@@ -8,6 +8,14 @@ Accept: application/json
 GET {{host}}/_semanticstub/runtime/routes
 Accept: application/json
 
+### Runtime inspection route detail by operationId
+GET {{host}}/_semanticstub/runtime/routes/listUsers
+Accept: application/json
+
+### Runtime inspection route detail with scenario metadata
+GET {{host}}/_semanticstub/runtime/routes/checkout
+Accept: application/json
+
 ### Runtime inspection scenario state
 GET {{host}}/_semanticstub/runtime/scenarios
 Accept: application/json

--- a/src/SemanticStub.Api/Controllers/StubInspectionController.cs
+++ b/src/SemanticStub.Api/Controllers/StubInspectionController.cs
@@ -31,6 +31,14 @@ public sealed class StubInspectionController : ControllerBase
     [HttpGet("routes")]
     public IActionResult GetRoutes() => Ok(inspectionService.GetRoutes());
 
+    /// <summary>Returns the effective runtime details for a single active route.</summary>
+    [HttpGet("routes/{**routeId}")]
+    public IActionResult GetRoute(string routeId)
+    {
+        var route = inspectionService.GetRoute(routeId);
+        return route is null ? NotFound() : Ok(route);
+    }
+
     /// <summary>Returns the current runtime state for all configured scenarios.</summary>
     [HttpGet("scenarios")]
     public IActionResult GetScenarios() => Ok(inspectionService.GetScenarioStates());

--- a/src/SemanticStub.Api/Inspection/StubRouteConditionInfo.cs
+++ b/src/SemanticStub.Api/Inspection/StubRouteConditionInfo.cs
@@ -1,0 +1,49 @@
+namespace SemanticStub.Api.Inspection;
+
+/// <summary>
+/// Describes normalized metadata for one conditional <c>x-match</c> candidate.
+/// </summary>
+public sealed class StubRouteConditionInfo
+{
+    /// <summary>Gets the candidate index within the route's <c>x-match</c> list.</summary>
+    public int CandidateIndex { get; init; }
+
+    /// <summary>Gets whether the candidate defines exact query constraints.</summary>
+    public bool HasExactQuery { get; init; }
+
+    /// <summary>Gets the exact query parameter names constrained by the candidate.</summary>
+    public IReadOnlyList<string> ExactQueryKeys { get; init; } = [];
+
+    /// <summary>Gets whether the candidate defines partial query constraints.</summary>
+    public bool HasPartialQuery { get; init; }
+
+    /// <summary>Gets the partial query parameter names constrained by the candidate.</summary>
+    public IReadOnlyList<string> PartialQueryKeys { get; init; } = [];
+
+    /// <summary>Gets whether the candidate defines regex query constraints.</summary>
+    public bool HasRegexQuery { get; init; }
+
+    /// <summary>Gets the regex query parameter names constrained by the candidate.</summary>
+    public IReadOnlyList<string> RegexQueryKeys { get; init; } = [];
+
+    /// <summary>Gets the header names constrained by the candidate.</summary>
+    public IReadOnlyList<string> HeaderKeys { get; init; } = [];
+
+    /// <summary>Gets whether the candidate defines a body constraint.</summary>
+    public bool HasBody { get; init; }
+
+    /// <summary>Gets whether the candidate uses semantic matching.</summary>
+    public bool UsesSemanticMatching { get; init; }
+
+    /// <summary>Gets the configured semantic prompt when present.</summary>
+    public string? SemanticMatch { get; init; }
+
+    /// <summary>Gets the response status code selected by the candidate.</summary>
+    public int ResponseStatusCode { get; init; }
+
+    /// <summary>Gets whether the candidate response participates in a scenario state machine.</summary>
+    public bool UsesScenario { get; init; }
+
+    /// <summary>Gets the configured scenario metadata when present.</summary>
+    public StubRouteScenarioInfo? Scenario { get; init; }
+}

--- a/src/SemanticStub.Api/Inspection/StubRouteDetailInfo.cs
+++ b/src/SemanticStub.Api/Inspection/StubRouteDetailInfo.cs
@@ -1,0 +1,38 @@
+namespace SemanticStub.Api.Inspection;
+
+/// <summary>
+/// Describes the effective runtime details for one active route.
+/// </summary>
+public sealed class StubRouteDetailInfo
+{
+    /// <summary>
+    /// Gets the stable identifier for this route.
+    /// Equal to the operation's <c>operationId</c> when present; otherwise formatted as
+    /// <c>METHOD:/path</c>.
+    /// </summary>
+    public required string RouteId { get; init; }
+
+    /// <summary>Gets the HTTP method in upper-case (e.g. <c>GET</c>, <c>POST</c>).</summary>
+    public required string Method { get; init; }
+
+    /// <summary>Gets the normalized path pattern as defined in the active configuration.</summary>
+    public required string PathPattern { get; init; }
+
+    /// <summary>Gets whether any conditional match on this route uses semantic matching.</summary>
+    public required bool UsesSemanticMatching { get; init; }
+
+    /// <summary>Gets whether any response on this route participates in a scenario state machine.</summary>
+    public required bool UsesScenario { get; init; }
+
+    /// <summary>Gets the number of top-level response definitions on this route.</summary>
+    public required int ResponseCount { get; init; }
+
+    /// <summary>Gets whether this route defines any conditional <c>x-match</c> candidates.</summary>
+    public required bool HasConditionalMatches { get; init; }
+
+    /// <summary>Gets the top-level responses defined on this route.</summary>
+    public IReadOnlyList<StubRouteResponseInfo> Responses { get; init; } = [];
+
+    /// <summary>Gets normalized metadata for each conditional <c>x-match</c> candidate.</summary>
+    public IReadOnlyList<StubRouteConditionInfo> ConditionalMatches { get; init; } = [];
+}

--- a/src/SemanticStub.Api/Inspection/StubRouteResponseInfo.cs
+++ b/src/SemanticStub.Api/Inspection/StubRouteResponseInfo.cs
@@ -1,0 +1,16 @@
+namespace SemanticStub.Api.Inspection;
+
+/// <summary>
+/// Describes one top-level response configured for a route.
+/// </summary>
+public sealed class StubRouteResponseInfo
+{
+    /// <summary>Gets the stable response identifier from the OpenAPI <c>responses</c> map key.</summary>
+    public required string ResponseId { get; init; }
+
+    /// <summary>Gets whether the response participates in a scenario state machine.</summary>
+    public bool UsesScenario { get; init; }
+
+    /// <summary>Gets the configured scenario metadata when present.</summary>
+    public StubRouteScenarioInfo? Scenario { get; init; }
+}

--- a/src/SemanticStub.Api/Inspection/StubRouteScenarioInfo.cs
+++ b/src/SemanticStub.Api/Inspection/StubRouteScenarioInfo.cs
@@ -1,0 +1,16 @@
+namespace SemanticStub.Api.Inspection;
+
+/// <summary>
+/// Describes scenario metadata exposed through route inspection.
+/// </summary>
+public sealed class StubRouteScenarioInfo
+{
+    /// <summary>Gets the scenario name defined in YAML.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Gets the required current scenario state.</summary>
+    public required string State { get; init; }
+
+    /// <summary>Gets the next scenario state persisted after a match, when configured.</summary>
+    public string? Next { get; init; }
+}

--- a/src/SemanticStub.Api/Services/IStubInspectionService.cs
+++ b/src/SemanticStub.Api/Services/IStubInspectionService.cs
@@ -18,6 +18,12 @@ public interface IStubInspectionService
     IReadOnlyList<StubRouteInfo> GetRoutes();
 
     /// <summary>
+    /// Returns the effective runtime details for a single active route when it exists.
+    /// </summary>
+    /// <param name="routeId">The stable route identifier.</param>
+    StubRouteDetailInfo? GetRoute(string routeId);
+
+    /// <summary>
     /// Returns the current runtime state for all configured scenarios.
     /// </summary>
     IReadOnlyList<ScenarioStateInfo> GetScenarioStates();

--- a/src/SemanticStub.Api/Services/StubInspectionService.cs
+++ b/src/SemanticStub.Api/Services/StubInspectionService.cs
@@ -56,6 +56,15 @@ internal sealed class StubInspectionService : IStubInspectionService
     }
 
     /// <inheritdoc/>
+    public StubRouteDetailInfo? GetRoute(string routeId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(routeId);
+
+        var document = state.GetCurrentDocument();
+        return FindRoute(document, routeId);
+    }
+
+    /// <inheritdoc/>
     public IReadOnlyList<ScenarioStateInfo> GetScenarioStates()
     {
         return scenarioService.ExecuteLocked(() =>
@@ -143,14 +152,7 @@ internal sealed class StubInspectionService : IStubInspectionService
 
         foreach (var (path, pathItem) in document.Paths)
         {
-            var operations = new (string Method, OperationDefinition? Op)[]
-            {
-                ("GET", pathItem.Get),
-                ("POST", pathItem.Post),
-                ("PUT", pathItem.Put),
-                ("PATCH", pathItem.Patch),
-                ("DELETE", pathItem.Delete),
-            };
+            var operations = EnumerateOperations(pathItem);
 
             foreach (var (method, op) in operations)
             {
@@ -158,9 +160,7 @@ internal sealed class StubInspectionService : IStubInspectionService
 
                 routes.Add(new StubRouteInfo
                 {
-                    RouteId = string.IsNullOrEmpty(op.OperationId)
-                        ? $"{method}:{path}"
-                        : op.OperationId,
+                    RouteId = GetRouteId(method, path, op),
                     Method = method,
                     PathPattern = path,
                     UsesSemanticMatching = HasSemanticMatch(op),
@@ -171,6 +171,108 @@ internal sealed class StubInspectionService : IStubInspectionService
         }
 
         return routes;
+    }
+
+    private static StubRouteDetailInfo? FindRoute(StubDocument document, string routeId)
+    {
+        foreach (var (path, pathItem) in document.Paths)
+        {
+            foreach (var (method, op) in EnumerateOperations(pathItem))
+            {
+                if (op is null)
+                {
+                    continue;
+                }
+
+                if (!string.Equals(GetRouteId(method, path, op), routeId, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                return new StubRouteDetailInfo
+                {
+                    RouteId = routeId,
+                    Method = method,
+                    PathPattern = path,
+                    UsesSemanticMatching = HasSemanticMatch(op),
+                    UsesScenario = HasScenario(op),
+                    ResponseCount = op.Responses.Count,
+                    HasConditionalMatches = op.Matches.Count > 0,
+                    Responses = BuildResponses(op),
+                    ConditionalMatches = BuildConditionalMatches(op),
+                };
+            }
+        }
+
+        return null;
+    }
+
+    private static IReadOnlyList<StubRouteResponseInfo> BuildResponses(OperationDefinition operation)
+    {
+        return operation.Responses
+            .OrderBy(entry => entry.Key, StringComparer.Ordinal)
+            .Select(entry => new StubRouteResponseInfo
+            {
+                ResponseId = entry.Key,
+                UsesScenario = entry.Value.Scenario is not null,
+                Scenario = BuildScenario(entry.Value.Scenario),
+            })
+            .ToList();
+    }
+
+    private static IReadOnlyList<StubRouteConditionInfo> BuildConditionalMatches(OperationDefinition operation)
+    {
+        return operation.Matches
+            .Select((match, index) => new StubRouteConditionInfo
+            {
+                CandidateIndex = index,
+                HasExactQuery = match.Query.Count > 0,
+                ExactQueryKeys = OrderKeys(match.Query.Keys),
+                HasPartialQuery = match.PartialQuery.Count > 0,
+                PartialQueryKeys = OrderKeys(match.PartialQuery.Keys),
+                HasRegexQuery = match.RegexQuery.Count > 0,
+                RegexQueryKeys = OrderKeys(match.RegexQuery.Keys),
+                HeaderKeys = OrderKeys(match.Headers.Keys),
+                HasBody = match.Body is not null,
+                UsesSemanticMatching = match.SemanticMatch is not null,
+                SemanticMatch = match.SemanticMatch,
+                ResponseStatusCode = match.Response.StatusCode,
+                UsesScenario = match.Response.Scenario is not null,
+                Scenario = BuildScenario(match.Response.Scenario),
+            })
+            .ToList();
+    }
+
+    private static StubRouteScenarioInfo? BuildScenario(ScenarioDefinition? scenario)
+    {
+        return scenario is null
+            ? null
+            : new StubRouteScenarioInfo
+            {
+                Name = scenario.Name,
+                State = scenario.State,
+                Next = scenario.Next,
+            };
+    }
+
+    private static IReadOnlyList<string> OrderKeys(IEnumerable<string> keys)
+        => keys.OrderBy(key => key, StringComparer.Ordinal).ToList();
+
+    private static string GetRouteId(string method, string path, OperationDefinition operation)
+        => string.IsNullOrEmpty(operation.OperationId)
+            ? $"{method}:{path}"
+            : operation.OperationId;
+
+    private static (string Method, OperationDefinition? Op)[] EnumerateOperations(PathItemDefinition pathItem)
+    {
+        return
+        [
+            ("GET", pathItem.Get),
+            ("POST", pathItem.Post),
+            ("PUT", pathItem.Put),
+            ("PATCH", pathItem.Patch),
+            ("DELETE", pathItem.Delete),
+        ];
     }
 
     private static bool HasSemanticMatch(OperationDefinition op)
@@ -242,16 +344,7 @@ internal sealed class StubInspectionService : IStubInspectionService
 
     private static IEnumerable<object> GetOperationSummaries(PathItemDefinition pathItem)
     {
-        var methods = new (string Method, OperationDefinition? Op)[]
-        {
-            ("GET", pathItem.Get),
-            ("POST", pathItem.Post),
-            ("PUT", pathItem.Put),
-            ("PATCH", pathItem.Patch),
-            ("DELETE", pathItem.Delete),
-        };
-
-        foreach (var (method, op) in methods)
+        foreach (var (method, op) in EnumerateOperations(pathItem))
         {
             if (op is null) continue;
 

--- a/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
@@ -91,6 +91,56 @@ public sealed class StubInspectionEndpointTests : IClassFixture<WebApplicationFa
     }
 
     [Fact]
+    public async Task GetRoute_ReturnsDetailedRoutePayload()
+    {
+        var response = await client.GetAsync("/_semanticstub/runtime/routes/listUsers");
+        response.EnsureSuccessStatusCode();
+
+        var route = await response.Content.ReadFromJsonAsync<StubRouteDetailInfo>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.NotNull(route);
+        Assert.Equal("listUsers", route!.RouteId);
+        Assert.Equal("GET", route.Method);
+        Assert.Equal("/users", route.PathPattern);
+        Assert.True(route.HasConditionalMatches);
+        Assert.True(route.ResponseCount >= 1);
+        Assert.Contains(route.Responses, response => response.ResponseId == "200");
+        Assert.Contains(route.ConditionalMatches, candidate => candidate.HasExactQuery);
+        Assert.Contains(route.ConditionalMatches, candidate => candidate.HasPartialQuery);
+    }
+
+    [Fact]
+    public async Task GetRoute_ReturnsScenarioMetadata_WhenConfigured()
+    {
+        var response = await client.GetAsync("/_semanticstub/runtime/routes/checkout");
+        response.EnsureSuccessStatusCode();
+
+        var route = await response.Content.ReadFromJsonAsync<StubRouteDetailInfo>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.NotNull(route);
+        Assert.Equal("checkout", route!.RouteId);
+        Assert.True(route.UsesScenario);
+        Assert.False(route.HasConditionalMatches);
+        Assert.Contains(route.Responses, response =>
+            response.ResponseId == "409"
+            && response.UsesScenario
+            && response.Scenario is not null
+            && response.Scenario.Name == "checkout-flow"
+            && response.Scenario.State == "initial"
+            && response.Scenario.Next == "confirmed");
+    }
+
+    [Fact]
+    public async Task GetRoute_ReturnsNotFound_WhenRouteDoesNotExist()
+    {
+        var response = await client.GetAsync("/_semanticstub/runtime/routes/does-not-exist");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
     public async Task GetScenarios_ReturnsOk()
     {
         var response = await client.GetAsync("/_semanticstub/runtime/scenarios");

--- a/tests/SemanticStub.Api.Tests/Unit/StubControllerTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubControllerTests.cs
@@ -286,6 +286,8 @@ public sealed class StubControllerTests
 
         public IReadOnlyList<StubRouteInfo> GetRoutes() => throw new NotSupportedException();
 
+        public StubRouteDetailInfo? GetRoute(string routeId) => throw new NotSupportedException();
+
         public IReadOnlyList<ScenarioStateInfo> GetScenarioStates() => throw new NotSupportedException();
 
         public Task<MatchSimulationInfo> TestMatchAsync(MatchRequestInfo request) => throw new NotSupportedException();

--- a/tests/SemanticStub.Api.Tests/Unit/StubInspectionServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubInspectionServiceTests.cs
@@ -21,6 +21,17 @@ public sealed class StubInspectionServiceTests
         public string LoadResponseFileContent(string fileName) => throw new InvalidOperationException("Not used in inspection tests");
     }
 
+    private sealed class ReloadingStubDefinitionLoader(StubDocument document, string directoryPath = "/test/definitions") : IStubDefinitionLoader
+    {
+        public StubDocument CurrentDocument { get; set; } = document;
+
+        public string GetDefinitionsDirectoryPath() => directoryPath;
+
+        public StubDocument LoadDefaultDefinition() => CurrentDocument;
+
+        public string LoadResponseFileContent(string fileName) => throw new InvalidOperationException("Not used in inspection tests");
+    }
+
     private static StubDefinitionState CreateState(StubDocument document, string directoryPath = "/test/definitions")
     {
         var loader = new TestStubDefinitionLoader(document, directoryPath);
@@ -616,6 +627,221 @@ public sealed class StubInspectionServiceTests
 
         var route = Assert.Single(CreateService(document).GetRoutes());
         Assert.Equal(0, route.ResponseCount);
+    }
+
+    // ---------------------------------------------------------------------------
+    // GetRoute — detail lookup
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void GetRoute_ReturnsNull_WhenRouteIdDoesNotExist()
+    {
+        var service = CreateService(SingleGetDocument());
+
+        var route = service.GetRoute("does-not-exist");
+
+        Assert.Null(route);
+    }
+
+    [Fact]
+    public void GetRoute_ReturnsDetailedRouteSnapshot()
+    {
+        var document = new StubDocument
+        {
+            Paths = new Dictionary<string, PathItemDefinition>(StringComparer.Ordinal)
+            {
+                ["/users"] = new()
+                {
+                    Get = new OperationDefinition
+                    {
+                        OperationId = "listUsers",
+                        Matches =
+                        [
+                            new QueryMatchDefinition
+                            {
+                                Query = new Dictionary<string, object?>(StringComparer.Ordinal)
+                                {
+                                    ["role"] = "admin",
+                                },
+                                PartialQuery = new Dictionary<string, object?>(StringComparer.Ordinal)
+                                {
+                                    ["view"] = "summary",
+                                },
+                                RegexQuery = new Dictionary<string, object?>(StringComparer.Ordinal)
+                                {
+                                    ["region"] = "^ap-.*$",
+                                },
+                                Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                                {
+                                    ["X-Env"] = "staging",
+                                },
+                                Body = new { enabled = true },
+                                Response = new QueryMatchResponseDefinition
+                                {
+                                    StatusCode = 202,
+                                    Scenario = new ScenarioDefinition
+                                    {
+                                        Name = "checkout",
+                                        State = "pending",
+                                        Next = "complete",
+                                    },
+                                },
+                            },
+                            new QueryMatchDefinition
+                            {
+                                SemanticMatch = "find administrator user accounts",
+                                Response = new QueryMatchResponseDefinition
+                                {
+                                    StatusCode = 200,
+                                },
+                            },
+                        ],
+                        Responses = new Dictionary<string, ResponseDefinition>(StringComparer.Ordinal)
+                        {
+                            ["200"] = new()
+                            {
+                                Description = "Default users",
+                            },
+                            ["409"] = new()
+                            {
+                                Description = "Pending approval",
+                                Scenario = new ScenarioDefinition
+                                {
+                                    Name = "checkout",
+                                    State = "initial",
+                                    Next = "pending",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        var route = CreateService(document).GetRoute("listUsers");
+
+        Assert.NotNull(route);
+        Assert.Equal("listUsers", route!.RouteId);
+        Assert.Equal("GET", route.Method);
+        Assert.Equal("/users", route.PathPattern);
+        Assert.True(route.UsesSemanticMatching);
+        Assert.True(route.UsesScenario);
+        Assert.Equal(2, route.ResponseCount);
+        Assert.True(route.HasConditionalMatches);
+
+        Assert.Collection(
+            route.Responses,
+            response =>
+            {
+                Assert.Equal("200", response.ResponseId);
+                Assert.False(response.UsesScenario);
+                Assert.Null(response.Scenario);
+            },
+            response =>
+            {
+                Assert.Equal("409", response.ResponseId);
+                Assert.True(response.UsesScenario);
+                Assert.NotNull(response.Scenario);
+                Assert.Equal("checkout", response.Scenario!.Name);
+                Assert.Equal("initial", response.Scenario.State);
+                Assert.Equal("pending", response.Scenario.Next);
+            });
+
+        Assert.Collection(
+            route.ConditionalMatches,
+            candidate =>
+            {
+                Assert.Equal(0, candidate.CandidateIndex);
+                Assert.True(candidate.HasExactQuery);
+                Assert.Equal(["role"], candidate.ExactQueryKeys);
+                Assert.True(candidate.HasPartialQuery);
+                Assert.Equal(["view"], candidate.PartialQueryKeys);
+                Assert.True(candidate.HasRegexQuery);
+                Assert.Equal(["region"], candidate.RegexQueryKeys);
+                Assert.Equal(["X-Env"], candidate.HeaderKeys);
+                Assert.True(candidate.HasBody);
+                Assert.False(candidate.UsesSemanticMatching);
+                Assert.Null(candidate.SemanticMatch);
+                Assert.Equal(202, candidate.ResponseStatusCode);
+                Assert.True(candidate.UsesScenario);
+                Assert.NotNull(candidate.Scenario);
+                Assert.Equal("checkout", candidate.Scenario!.Name);
+                Assert.Equal("pending", candidate.Scenario.State);
+                Assert.Equal("complete", candidate.Scenario.Next);
+            },
+            candidate =>
+            {
+                Assert.Equal(1, candidate.CandidateIndex);
+                Assert.False(candidate.HasExactQuery);
+                Assert.Empty(candidate.ExactQueryKeys);
+                Assert.False(candidate.HasPartialQuery);
+                Assert.Empty(candidate.PartialQueryKeys);
+                Assert.False(candidate.HasRegexQuery);
+                Assert.Empty(candidate.RegexQueryKeys);
+                Assert.Empty(candidate.HeaderKeys);
+                Assert.False(candidate.HasBody);
+                Assert.True(candidate.UsesSemanticMatching);
+                Assert.Equal("find administrator user accounts", candidate.SemanticMatch);
+                Assert.Equal(200, candidate.ResponseStatusCode);
+                Assert.False(candidate.UsesScenario);
+                Assert.Null(candidate.Scenario);
+            });
+    }
+
+    [Fact]
+    public void GetRoute_UsesMethodColonPath_WhenOperationIdIsEmpty()
+    {
+        var document = new StubDocument
+        {
+            Paths = new Dictionary<string, PathItemDefinition>(StringComparer.Ordinal)
+            {
+                ["/users"] = new()
+                {
+                    Get = new OperationDefinition
+                    {
+                        OperationId = string.Empty,
+                        Responses = new Dictionary<string, ResponseDefinition>(StringComparer.Ordinal)
+                        {
+                            ["200"] = new(),
+                        },
+                    },
+                },
+            },
+        };
+
+        var route = CreateService(document).GetRoute("GET:/users");
+
+        Assert.NotNull(route);
+        Assert.Equal("GET:/users", route!.RouteId);
+    }
+
+    [Fact]
+    public void GetRoute_ReflectsReloadedActiveDocument()
+    {
+        var initialDocument = SingleGetDocument("/initial", operationId: "initialRoute");
+        var reloadedDocument = SingleGetDocument("/reloaded", operationId: "reloadedRoute");
+        var loader = new ReloadingStubDefinitionLoader(initialDocument);
+        var scenarioService = new ScenarioService();
+        var state = new StubDefinitionState(loader, scenarioService, NullLogger<StubDefinitionState>.Instance);
+        var settings = Options.Create(new StubSettings());
+        var stubService = new StubService(
+            initialDocument,
+            _ => throw new InvalidOperationException("Not used in inspection tests"),
+            new MatcherService(),
+            scenarioService,
+            new NoOpSemanticMatcherService());
+        var service = new StubInspectionService(state, loader, settings, scenarioService, stubService);
+
+        Assert.NotNull(service.GetRoute("initialRoute"));
+        Assert.Null(service.GetRoute("reloadedRoute"));
+
+        loader.CurrentDocument = reloadedDocument;
+        Assert.True(state.TryReload());
+
+        Assert.Null(service.GetRoute("initialRoute"));
+        var route = service.GetRoute("reloadedRoute");
+        Assert.NotNull(route);
+        Assert.Equal("/reloaded", route!.PathPattern);
     }
 
     // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a read-only runtime inspection endpoint for route detail at `GET /_semanticstub/runtime/routes/{routeId}`
- expose stable DTOs for top-level responses, conditional match metadata, and scenario usage without returning raw YAML
- document the new endpoint and add `.http` samples for local verification

## Files Changed
- inspection controller and inspection service for route detail lookup and routeId handling
- new inspection DTOs for route detail, response metadata, conditional match metadata, and scenario metadata
- unit and integration tests covering route detail payloads, not-found handling, and reload behavior
- README and `SemanticStub.http` examples for the new runtime inspection endpoint

## Tests
- `dotnet test SemanticStub.sln`
- local endpoint verification against the running app:
  - `GET /_semanticstub/runtime/routes/listUsers`
  - `GET /_semanticstub/runtime/routes/checkout`
  - `GET /_semanticstub/runtime/routes/does-not-exist`

## Notes
- preserves existing YAML compatibility and existing runtime matching behavior
- route detail uses the same stable routeId rules as the existing route list endpoint