### PR TITLE
feat: add recent request history

### DIFF
--- a/src/SemanticStub.Api/Controllers/StubController.cs
+++ b/src/SemanticStub.Api/Controllers/StubController.cs
@@ -155,6 +155,13 @@ public sealed class StubController : ControllerBase
             if (statusCode.HasValue)
             {
                 inspectionService.RecordRequestMetrics(dispatch.Explanation, statusCode.Value, stopwatch.Elapsed);
+                inspectionService.RecordRecentRequest(
+                    DateTimeOffset.UtcNow,
+                    method,
+                    requestPath,
+                    dispatch.Explanation,
+                    statusCode.Value,
+                    stopwatch.Elapsed);
             }
         }
     }

--- a/src/SemanticStub.Api/Controllers/StubInspectionController.cs
+++ b/src/SemanticStub.Api/Controllers/StubInspectionController.cs
@@ -47,6 +47,10 @@ public sealed class StubInspectionController : ControllerBase
     [HttpGet("metrics")]
     public IActionResult GetMetrics() => Ok(inspectionService.GetRuntimeMetrics());
 
+    /// <summary>Returns the bounded recent request history for real requests handled by the current process.</summary>
+    [HttpGet("requests")]
+    public IActionResult GetRecentRequests([FromQuery] int limit = 20) => Ok(inspectionService.GetRecentRequests(limit));
+
     /// <summary>Simulates how the runtime would match a virtual request without executing a response.</summary>
     [HttpPost("test-match")]
     public async Task<IActionResult> TestMatch([FromBody] MatchRequestInfo request)

--- a/src/SemanticStub.Api/Inspection/RecentRequestInfo.cs
+++ b/src/SemanticStub.Api/Inspection/RecentRequestInfo.cs
@@ -1,0 +1,47 @@
+namespace SemanticStub.Api.Inspection;
+
+/// <summary>
+/// Describes one recently handled real request observed by the runtime.
+/// </summary>
+public sealed class RecentRequestInfo
+{
+    /// <summary>
+    /// Gets the UTC timestamp when the request observation was recorded.
+    /// </summary>
+    public DateTimeOffset Timestamp { get; init; }
+
+    /// <summary>
+    /// Gets the HTTP method used by the request.
+    /// </summary>
+    public required string Method { get; init; }
+
+    /// <summary>
+    /// Gets the absolute request path handled by the runtime.
+    /// </summary>
+    public required string Path { get; init; }
+
+    /// <summary>
+    /// Gets the resolved route identifier when the request matched a configured route.
+    /// </summary>
+    public string? RouteId { get; init; }
+
+    /// <summary>
+    /// Gets the final HTTP status code returned to the caller.
+    /// </summary>
+    public int StatusCode { get; init; }
+
+    /// <summary>
+    /// Gets the observed end-to-end elapsed time in milliseconds.
+    /// </summary>
+    public double ElapsedMilliseconds { get; init; }
+
+    /// <summary>
+    /// Gets the match mode when a response was selected.
+    /// </summary>
+    public string? MatchMode { get; init; }
+
+    /// <summary>
+    /// Gets the failure reason when the request did not produce a matched response.
+    /// </summary>
+    public string? FailureReason { get; init; }
+}

--- a/src/SemanticStub.Api/Services/IStubInspectionService.cs
+++ b/src/SemanticStub.Api/Services/IStubInspectionService.cs
@@ -34,6 +34,12 @@ public interface IStubInspectionService
     RuntimeMetricsSummaryInfo GetRuntimeMetrics();
 
     /// <summary>
+    /// Returns the bounded recent request history captured for real requests handled by the current process.
+    /// </summary>
+    /// <param name="limit">The maximum number of recent requests to return.</param>
+    IReadOnlyList<RecentRequestInfo> GetRecentRequests(int limit);
+
+    /// <summary>
     /// Simulates how the runtime would match the supplied virtual request without executing a response or mutating scenario state.
     /// </summary>
     /// <param name="request">The virtual request to evaluate.</param>
@@ -63,6 +69,17 @@ public interface IStubInspectionService
     /// <param name="statusCode">The final HTTP status code returned to the caller.</param>
     /// <param name="elapsed">The end-to-end elapsed time observed by the controller for the request.</param>
     void RecordRequestMetrics(MatchExplanationInfo explanation, int statusCode, TimeSpan elapsed);
+
+    /// <summary>
+    /// Records one recent real request handled by the active runtime pipeline.
+    /// </summary>
+    /// <param name="timestamp">The time when the request observation was recorded.</param>
+    /// <param name="method">The HTTP method used by the request.</param>
+    /// <param name="path">The request path handled by the runtime.</param>
+    /// <param name="explanation">The explanation captured from the same dispatch evaluation.</param>
+    /// <param name="statusCode">The final HTTP status code returned to the caller.</param>
+    /// <param name="elapsed">The end-to-end elapsed time observed by the controller for the request.</param>
+    void RecordRecentRequest(DateTimeOffset timestamp, string method, string path, MatchExplanationInfo explanation, int statusCode, TimeSpan elapsed);
 
     /// <summary>
     /// Resets all configured scenarios back to their initial state.

--- a/src/SemanticStub.Api/Services/StubInspectionService.cs
+++ b/src/SemanticStub.Api/Services/StubInspectionService.cs
@@ -10,6 +10,7 @@ namespace SemanticStub.Api.Services;
 
 internal sealed class StubInspectionService : IStubInspectionService
 {
+    private const int MaxRecentRequestCount = 100;
     private readonly StubDefinitionState state;
     private readonly IStubDefinitionLoader loader;
     private readonly IOptions<StubSettings> settings;
@@ -19,6 +20,7 @@ internal sealed class StubInspectionService : IStubInspectionService
     private readonly object metricsSyncRoot = new();
     private readonly Dictionary<int, long> statusCodeCounts = [];
     private readonly Dictionary<string, long> routeRequestCounts = new(StringComparer.Ordinal);
+    private readonly Queue<RecentRequestInfo> recentRequests = [];
     private MatchExplanationInfo? lastMatchExplanation;
     private long totalRequestCount;
     private long matchedRequestCount;
@@ -134,6 +136,25 @@ internal sealed class StubInspectionService : IStubInspectionService
     }
 
     /// <inheritdoc/>
+    public IReadOnlyList<RecentRequestInfo> GetRecentRequests(int limit)
+    {
+        lock (metricsSyncRoot)
+        {
+            var normalizedLimit = Math.Clamp(limit, 0, MaxRecentRequestCount);
+
+            if (normalizedLimit == 0)
+            {
+                return [];
+            }
+
+            return recentRequests
+                .Reverse()
+                .Take(normalizedLimit)
+                .ToList();
+        }
+    }
+
+    /// <inheritdoc/>
     public async Task<MatchSimulationInfo> TestMatchAsync(MatchRequestInfo request)
     {
         return (await stubService.ExplainMatchAsync(request).ConfigureAwait(false)).Result;
@@ -199,6 +220,36 @@ internal sealed class StubInspectionService : IStubInspectionService
             {
                 routeRequestCounts[explanation.Result.RouteId] = routeRequestCounts.GetValueOrDefault(explanation.Result.RouteId) + 1;
             }
+        }
+    }
+
+    /// <inheritdoc/>
+    public void RecordRecentRequest(DateTimeOffset timestamp, string method, string path, MatchExplanationInfo explanation, int statusCode, TimeSpan elapsed)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(method);
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        ArgumentNullException.ThrowIfNull(explanation);
+
+        lock (metricsSyncRoot)
+        {
+            if (recentRequests.Count >= MaxRecentRequestCount)
+            {
+                recentRequests.Dequeue();
+            }
+
+            recentRequests.Enqueue(new RecentRequestInfo
+            {
+                Timestamp = timestamp,
+                Method = method,
+                Path = path,
+                RouteId = explanation.Result.RouteId,
+                StatusCode = statusCode,
+                ElapsedMilliseconds = Math.Max(0, elapsed.TotalMilliseconds),
+                MatchMode = explanation.Result.MatchMode,
+                FailureReason = explanation.Result.Matched || string.IsNullOrWhiteSpace(explanation.SelectionReason)
+                    ? null
+                    : explanation.SelectionReason,
+            });
         }
     }
 

--- a/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SemanticStub.Api.Inspection;
 using Xunit;
@@ -205,6 +206,46 @@ public sealed class StubInspectionEndpointTests : IClassFixture<WebApplicationFa
         Assert.True(after.MatchedRequestCount >= before.MatchedRequestCount + 1);
         Assert.Contains(after.StatusCodes, entry => entry.StatusCode == (int)HttpStatusCode.OK);
         Assert.Contains(after.TopRoutes, entry => entry.RouteId == "getHello");
+    }
+
+    [Fact]
+    public async Task GetRecentRequests_ReturnsOk()
+    {
+        var response = await client.GetAsync("/_semanticstub/runtime/requests");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetRecentRequests_ResponseDeserializesToRecentRequestInfoArray()
+    {
+        var response = await client.GetAsync("/_semanticstub/runtime/requests");
+        response.EnsureSuccessStatusCode();
+
+        var requests = await response.Content.ReadFromJsonAsync<RecentRequestInfo[]>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.NotNull(requests);
+    }
+
+    [Fact]
+    public async Task GetRecentRequests_ReflectsNewestRealRequest_AndRespectsLimit()
+    {
+        var routedResponse = await client.GetAsync("/users?role=admin");
+        routedResponse.EnsureSuccessStatusCode();
+
+        var response = await client.GetAsync("/_semanticstub/runtime/requests?limit=1");
+        response.EnsureSuccessStatusCode();
+
+        var requests = await response.Content.ReadFromJsonAsync<RecentRequestInfo[]>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.NotNull(requests);
+        var request = Assert.Single(requests!);
+        Assert.Equal(HttpMethods.Get, request.Method);
+        Assert.Equal("/users", request.Path);
+        Assert.Equal("listUsers", request.RouteId);
+        Assert.Equal((int)HttpStatusCode.OK, request.StatusCode);
     }
 
     [Fact]

--- a/tests/SemanticStub.Api.Tests/Unit/StubControllerTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubControllerTests.cs
@@ -262,6 +262,9 @@ public sealed class StubControllerTests
         Assert.True(inspectionService.LastRecordedElapsed.Value >= TimeSpan.Zero);
         Assert.NotNull(inspectionService.LastRecordedMetricsExplanation);
         Assert.Equal("Matched", inspectionService.LastRecordedMetricsExplanation!.Result.MatchResult);
+        Assert.Equal(1, inspectionService.RecordRecentRequestCallCount);
+        Assert.Equal(HttpMethods.Get, inspectionService.LastRecentRequestMethod);
+        Assert.Equal("/users", inspectionService.LastRecentRequestPath);
     }
 
     [Fact]
@@ -303,6 +306,8 @@ public sealed class StubControllerTests
         Assert.Equal(StatusCodes.Status202Accepted, inspectionService.LastRecordedStatusCode);
         Assert.NotNull(inspectionService.LastRecordedMetricsExplanation);
         Assert.Equal("Matched", inspectionService.LastRecordedMetricsExplanation!.Result.MatchResult);
+        Assert.Equal(1, inspectionService.RecordRecentRequestCallCount);
+        Assert.Equal("/users", inspectionService.LastRecentRequestPath);
     }
 
     [Fact]
@@ -336,6 +341,10 @@ public sealed class StubControllerTests
         controllerInspectionService.RecordRequestMetricsCallCount = 0;
         controllerInspectionService.LastRecordedMetricsExplanation = null;
         controllerInspectionService.LastRecordedElapsed = null;
+        controllerInspectionService.RecordRecentRequestCallCount = 0;
+        controllerInspectionService.LastRecentRequest = null;
+        controllerInspectionService.LastRecentRequestMethod = null;
+        controllerInspectionService.LastRecentRequestPath = null;
 
         return new StubController(stubService, inspectionService ?? controllerInspectionService)
         {
@@ -358,6 +367,14 @@ public sealed class StubControllerTests
 
         public int RecordRequestMetricsCallCount { get; set; }
 
+        public int RecordRecentRequestCallCount { get; set; }
+
+        public RecentRequestInfo? LastRecentRequest { get; set; }
+
+        public string? LastRecentRequestMethod { get; set; }
+
+        public string? LastRecentRequestPath { get; set; }
+
         public StubConfigSnapshot GetConfigSnapshot() => throw new NotSupportedException();
 
         public IReadOnlyList<StubRouteInfo> GetRoutes() => throw new NotSupportedException();
@@ -367,6 +384,8 @@ public sealed class StubControllerTests
         public IReadOnlyList<ScenarioStateInfo> GetScenarioStates() => throw new NotSupportedException();
 
         public RuntimeMetricsSummaryInfo GetRuntimeMetrics() => throw new NotSupportedException();
+
+        public IReadOnlyList<RecentRequestInfo> GetRecentRequests(int limit) => throw new NotSupportedException();
 
         public Task<MatchSimulationInfo> TestMatchAsync(MatchRequestInfo request) => throw new NotSupportedException();
 
@@ -385,6 +404,24 @@ public sealed class StubControllerTests
             LastRecordedStatusCode = statusCode;
             LastRecordedElapsed = elapsed;
             RecordRequestMetricsCallCount++;
+        }
+
+        public void RecordRecentRequest(DateTimeOffset timestamp, string method, string path, MatchExplanationInfo explanation, int statusCode, TimeSpan elapsed)
+        {
+            LastRecentRequestMethod = method;
+            LastRecentRequestPath = path;
+            LastRecentRequest = new RecentRequestInfo
+            {
+                Timestamp = timestamp,
+                Method = method,
+                Path = path,
+                RouteId = explanation.Result.RouteId,
+                StatusCode = statusCode,
+                ElapsedMilliseconds = elapsed.TotalMilliseconds,
+                MatchMode = explanation.Result.MatchMode,
+                FailureReason = explanation.SelectionReason,
+            };
+            RecordRecentRequestCallCount++;
         }
 
         public void ResetScenarioStates() => throw new NotSupportedException();

--- a/tests/SemanticStub.Api.Tests/Unit/StubInspectionServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubInspectionServiceTests.cs
@@ -360,6 +360,86 @@ public sealed class StubInspectionServiceTests
     }
 
     // ---------------------------------------------------------------------------
+    // GetRecentRequests
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void GetRecentRequests_ReturnsEmpty_WhenNothingHasBeenRecorded()
+    {
+        var service = CreateService(EmptyDocument());
+
+        var requests = service.GetRecentRequests(20);
+
+        Assert.Empty(requests);
+    }
+
+    [Fact]
+    public void RecordRecentRequest_ReturnsNewestFirst_AndCapturesFailureReason()
+    {
+        var service = CreateService(EmptyDocument());
+
+        service.RecordRecentRequest(
+            DateTimeOffset.Parse("2026-04-07T00:00:00Z"),
+            HttpMethods.Get,
+            "/users",
+            new MatchExplanationInfo
+            {
+                SelectionReason = "No configured route matched the supplied request path.",
+                Result = new MatchSimulationInfo
+                {
+                    Matched = false,
+                    MatchResult = "PathNotFound",
+                }
+            },
+            StatusCodes.Status404NotFound,
+            TimeSpan.FromMilliseconds(15));
+        service.RecordRecentRequest(
+            DateTimeOffset.Parse("2026-04-07T00:00:01Z"),
+            HttpMethods.Post,
+            "/orders",
+            CreateRecordedExplanation(matched: true, matchResult: "Matched", routeId: "createOrder", matchMode: "fallback"),
+            StatusCodes.Status201Created,
+            TimeSpan.FromMilliseconds(25));
+
+        var requests = service.GetRecentRequests(20);
+
+        Assert.Equal(2, requests.Count);
+        Assert.Equal("/orders", requests[0].Path);
+        Assert.Equal("createOrder", requests[0].RouteId);
+        Assert.Equal("fallback", requests[0].MatchMode);
+        Assert.Null(requests[0].FailureReason);
+        Assert.Equal("/users", requests[1].Path);
+        Assert.Equal("No configured route matched the supplied request path.", requests[1].FailureReason);
+    }
+
+    [Fact]
+    public void GetRecentRequests_RespectsLimit_AndRetentionBound()
+    {
+        var service = CreateService(EmptyDocument());
+
+        for (var index = 0; index < 105; index++)
+        {
+            service.RecordRecentRequest(
+                DateTimeOffset.UtcNow.AddSeconds(index),
+                HttpMethods.Get,
+                $"/requests/{index}",
+                CreateRecordedExplanation(matched: true, matchResult: "Matched", routeId: $"route-{index}"),
+                StatusCodes.Status200OK,
+                TimeSpan.FromMilliseconds(index));
+        }
+
+        var limited = service.GetRecentRequests(3);
+        var all = service.GetRecentRequests(200);
+
+        Assert.Equal(3, limited.Count);
+        Assert.Equal("/requests/104", limited[0].Path);
+        Assert.Equal("/requests/102", limited[2].Path);
+        Assert.Equal(100, all.Count);
+        Assert.Equal("/requests/104", all[0].Path);
+        Assert.Equal("/requests/5", all[^1].Path);
+    }
+
+    // ---------------------------------------------------------------------------
     // GetConfigSnapshot — snapshot timestamp
     // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- add bounded read-only recent request history on the existing runtime inspection surface
- record recent real requests from the shared `StubController` request path, including cancelled delayed requests when a status code has already been selected
- expose timestamp, method, path, route id, status code, elapsed time, match mode, and failure reason for recent requests

## Files Changed
- extend the inspection service contract and implementation to store and return recent request history with bounded retention
- add the `RecentRequestInfo` DTO for external recent-request responses
- add `GET /_semanticstub/runtime/requests?limit=20` to the inspection controller
- update unit and integration tests for recent request recording, retention, ordering, and endpoint behavior

## Tests
- `dotnet test SemanticStub.sln`
- 262 tests passed

## Notes
- this PR covers the recent request history half of issue #88
- retention is fixed at 100 entries and responses are returned newest first
- p95 latency and persistent storage remain out of scope