### PR TITLE
refactor: extract matcher specificity and query parameter helpers

### DIFF
--- a/src/SemanticStub.Api/Services/MatcherService.cs
+++ b/src/SemanticStub.Api/Services/MatcherService.cs
@@ -16,6 +16,7 @@ public sealed class MatcherService : IMatcherService
 {
     private static readonly TimeSpan RegexMatchTimeout = TimeSpan.FromMilliseconds(100);
     private static readonly IReadOnlyDictionary<string, string> EmptyHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    private static readonly QueryMatchSpecificityComparer MatchSpecificityComparer = QueryMatchSpecificityComparer.Instance;
     private readonly ILogger<MatcherService>? logger;
 
     /// <summary>
@@ -130,7 +131,7 @@ public sealed class MatcherService : IMatcherService
         }
 
         using var bodyDocument = ParseRequestBody(body);
-        var queryParameterTypes = BuildQueryParameterTypes(pathParameters, operation.Parameters);
+        var queryParameterTypes = QueryParameterTypeMapBuilder.Build(pathParameters, operation.Parameters);
 
         // Match conditions are conjunctive; after filtering, prefer the candidate with the most explicit constraints.
         return GetCandidatesMatchingRequest(
@@ -140,9 +141,7 @@ public sealed class MatcherService : IMatcherService
                 queryParameterTypes,
                 bodyDocument?.RootElement,
                 candidateFilter)
-            .OrderByDescending(GetExactQuerySpecificity)
-            .ThenByDescending(GetMatchSpecificity)
-            .ThenByDescending(GetRegexQuerySpecificity)
+            .OrderBy(match => match, MatchSpecificityComparer)
             .FirstOrDefault();
     }
 
@@ -155,7 +154,7 @@ public sealed class MatcherService : IMatcherService
         string? body)
     {
         using var bodyDocument = ParseRequestBody(body);
-        var queryParameterTypes = BuildQueryParameterTypes(pathParameters, operation.Parameters);
+        var queryParameterTypes = QueryParameterTypeMapBuilder.Build(pathParameters, operation.Parameters);
         var evaluations = new List<QueryMatchCandidateEvaluation>(operation.Matches.Count);
 
         foreach (var candidate in operation.Matches)
@@ -218,35 +217,6 @@ public sealed class MatcherService : IMatcherService
         return IsQueryMatch(candidate, query, queryParameterTypes) &&
                IsExactHeaderMatch(candidate.Headers, headers) &&
                IsBodyMatch(candidate.Body, requestBody);
-    }
-
-    private static Dictionary<string, string> BuildQueryParameterTypes(
-        IReadOnlyCollection<ParameterDefinition> pathParameters,
-        IReadOnlyCollection<ParameterDefinition> operationParameters)
-    {
-        var queryParameterTypes = new Dictionary<string, string>(StringComparer.Ordinal);
-
-        AddQueryParameterTypes(pathParameters, queryParameterTypes);
-        AddQueryParameterTypes(operationParameters, queryParameterTypes);
-
-        return queryParameterTypes;
-    }
-
-    private static void AddQueryParameterTypes(
-        IReadOnlyCollection<ParameterDefinition> parameters,
-        IDictionary<string, string> queryParameterTypes)
-    {
-        foreach (var parameter in parameters)
-        {
-            if (!string.Equals(parameter.In, "query", StringComparison.OrdinalIgnoreCase) ||
-                string.IsNullOrWhiteSpace(parameter.Name) ||
-                string.IsNullOrWhiteSpace(parameter.Schema?.Type))
-            {
-                continue;
-            }
-
-            queryParameterTypes[parameter.Name] = parameter.Schema.Type;
-        }
     }
 
     private static bool IsExactQueryMatch(
@@ -708,30 +678,4 @@ public sealed class MatcherService : IMatcherService
         };
     }
 
-    private static int GetMatchSpecificity(QueryMatchDefinition match)
-    {
-        return match.Query.Count + match.RegexQuery.Count + match.PartialQuery.Count + match.Headers.Count + GetBodySpecificity(match.Body);
-    }
-
-    private static int GetExactQuerySpecificity(QueryMatchDefinition match)
-    {
-        return match.Query.Count;
-    }
-
-    private static int GetRegexQuerySpecificity(QueryMatchDefinition match)
-    {
-        return match.RegexQuery.Count;
-    }
-
-    private static int GetBodySpecificity(object? body)
-    {
-        // Nested body shapes should outrank shallower ones so more concrete matches win.
-        return body switch
-        {
-            null => 0,
-            IDictionary dictionary => dictionary.Count + dictionary.Values.Cast<object?>().Sum(GetBodySpecificity),
-            IEnumerable list when body is not string => list.Cast<object?>().Sum(GetBodySpecificity),
-            _ => 1
-        };
-    }
 }

--- a/src/SemanticStub.Api/Services/QueryMatchSpecificityComparer.cs
+++ b/src/SemanticStub.Api/Services/QueryMatchSpecificityComparer.cs
@@ -1,0 +1,64 @@
+using System.Collections;
+using SemanticStub.Api.Models;
+
+namespace SemanticStub.Api.Services;
+
+internal sealed class QueryMatchSpecificityComparer : IComparer<QueryMatchDefinition>
+{
+    public static QueryMatchSpecificityComparer Instance { get; } = new();
+
+    private QueryMatchSpecificityComparer()
+    {
+    }
+
+    public int Compare(QueryMatchDefinition? x, QueryMatchDefinition? y)
+    {
+        if (ReferenceEquals(x, y))
+        {
+            return 0;
+        }
+
+        if (x is null)
+        {
+            return 1;
+        }
+
+        if (y is null)
+        {
+            return -1;
+        }
+
+        var exactQueryComparison = y.Query.Count.CompareTo(x.Query.Count);
+
+        if (exactQueryComparison != 0)
+        {
+            return exactQueryComparison;
+        }
+
+        var overallComparison = GetOverallSpecificity(y).CompareTo(GetOverallSpecificity(x));
+
+        if (overallComparison != 0)
+        {
+            return overallComparison;
+        }
+
+        return y.RegexQuery.Count.CompareTo(x.RegexQuery.Count);
+    }
+
+    private static int GetOverallSpecificity(QueryMatchDefinition match)
+    {
+        return match.Query.Count + match.RegexQuery.Count + match.PartialQuery.Count + match.Headers.Count + GetBodySpecificity(match.Body);
+    }
+
+    private static int GetBodySpecificity(object? body)
+    {
+        // Nested body shapes should outrank shallower ones so more concrete matches win.
+        return body switch
+        {
+            null => 0,
+            IDictionary dictionary => dictionary.Count + dictionary.Values.Cast<object?>().Sum(GetBodySpecificity),
+            IEnumerable list when body is not string => list.Cast<object?>().Sum(GetBodySpecificity),
+            _ => 1
+        };
+    }
+}

--- a/src/SemanticStub.Api/Services/QueryParameterTypeMapBuilder.cs
+++ b/src/SemanticStub.Api/Services/QueryParameterTypeMapBuilder.cs
@@ -1,0 +1,35 @@
+using SemanticStub.Api.Models;
+
+namespace SemanticStub.Api.Services;
+
+internal static class QueryParameterTypeMapBuilder
+{
+    public static IReadOnlyDictionary<string, string> Build(
+        IReadOnlyCollection<ParameterDefinition> pathParameters,
+        IReadOnlyCollection<ParameterDefinition> operationParameters)
+    {
+        var queryParameterTypes = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        Add(pathParameters, queryParameterTypes);
+        Add(operationParameters, queryParameterTypes);
+
+        return queryParameterTypes;
+    }
+
+    private static void Add(
+        IReadOnlyCollection<ParameterDefinition> parameters,
+        IDictionary<string, string> queryParameterTypes)
+    {
+        foreach (var parameter in parameters)
+        {
+            if (!string.Equals(parameter.In, "query", StringComparison.OrdinalIgnoreCase) ||
+                string.IsNullOrWhiteSpace(parameter.Name) ||
+                string.IsNullOrWhiteSpace(parameter.Schema?.Type))
+            {
+                continue;
+            }
+
+            queryParameterTypes[parameter.Name] = parameter.Schema.Type;
+        }
+    }
+}

--- a/tests/SemanticStub.Api.Tests/Unit/QueryMatchSpecificityComparerTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/QueryMatchSpecificityComparerTests.cs
@@ -1,0 +1,68 @@
+using SemanticStub.Api.Models;
+using SemanticStub.Api.Services;
+using Xunit;
+
+namespace SemanticStub.Api.Tests.Unit;
+
+public sealed class QueryMatchSpecificityComparerTests
+{
+    [Fact]
+    public void Compare_PrefersExactQuerySpecificityBeforeOverallSpecificity()
+    {
+        var broaderOverallMatch = new QueryMatchDefinition
+        {
+            PartialQuery = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["role"] = "admin"
+            },
+            Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["x-tenant"] = "alpha"
+            }
+        };
+
+        var exactQueryMatch = new QueryMatchDefinition
+        {
+            Query = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["role"] = "admin"
+            }
+        };
+
+        var ordered = new[] { broaderOverallMatch, exactQueryMatch }
+            .OrderBy(match => match, QueryMatchSpecificityComparer.Instance)
+            .ToArray();
+
+        Assert.Same(exactQueryMatch, ordered[0]);
+    }
+
+    [Fact]
+    public void Compare_PrefersRegexQuerySpecificityOnlyAfterOverallSpecificityTie()
+    {
+        var specificHeaderMatch = new QueryMatchDefinition
+        {
+            PartialQuery = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["role"] = "admin"
+            },
+            Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["x-tenant"] = "alpha"
+            }
+        };
+
+        var broaderRegexMatch = new QueryMatchDefinition
+        {
+            RegexQuery = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["role"] = "^admin-[0-9]+$"
+            }
+        };
+
+        var ordered = new[] { broaderRegexMatch, specificHeaderMatch }
+            .OrderBy(match => match, QueryMatchSpecificityComparer.Instance)
+            .ToArray();
+
+        Assert.Same(specificHeaderMatch, ordered[0]);
+    }
+}

--- a/tests/SemanticStub.Api.Tests/Unit/QueryParameterTypeMapBuilderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/QueryParameterTypeMapBuilderTests.cs
@@ -1,0 +1,77 @@
+using SemanticStub.Api.Models;
+using SemanticStub.Api.Services;
+using Xunit;
+
+namespace SemanticStub.Api.Tests.Unit;
+
+public sealed class QueryParameterTypeMapBuilderTests
+{
+    [Fact]
+    public void Build_IncludesQueryParameterTypesFromPathAndOperationLevels()
+    {
+        var pathParameters = new[]
+        {
+            new ParameterDefinition
+            {
+                Name = "page",
+                In = "query",
+                Schema = new ParameterSchemaDefinition
+                {
+                    Type = "integer"
+                }
+            }
+        };
+
+        var operationParameters = new[]
+        {
+            new ParameterDefinition
+            {
+                Name = "enabled",
+                In = "query",
+                Schema = new ParameterSchemaDefinition
+                {
+                    Type = "boolean"
+                }
+            }
+        };
+
+        var result = QueryParameterTypeMapBuilder.Build(pathParameters, operationParameters);
+
+        Assert.Equal("integer", result["page"]);
+        Assert.Equal("boolean", result["enabled"]);
+    }
+
+    [Fact]
+    public void Build_PrefersOperationLevelQueryTypeWhenNamesOverlap()
+    {
+        var pathParameters = new[]
+        {
+            new ParameterDefinition
+            {
+                Name = "page",
+                In = "query",
+                Schema = new ParameterSchemaDefinition
+                {
+                    Type = "string"
+                }
+            }
+        };
+
+        var operationParameters = new[]
+        {
+            new ParameterDefinition
+            {
+                Name = "page",
+                In = "query",
+                Schema = new ParameterSchemaDefinition
+                {
+                    Type = "integer"
+                }
+            }
+        };
+
+        var result = QueryParameterTypeMapBuilder.Build(pathParameters, operationParameters);
+
+        Assert.Equal("integer", result["page"]);
+    }
+}


### PR DESCRIPTION
## Summary
- extract query parameter type map building from `MatcherService` into `QueryParameterTypeMapBuilder`
- extract candidate specificity and tie-break ordering from `MatcherService` into `QueryMatchSpecificityComparer`
- keep `IMatcherService`, routing behavior, and YAML compatibility unchanged

## Files Changed
- `src/SemanticStub.Api/Services/MatcherService.cs`
- `src/SemanticStub.Api/Services/QueryParameterTypeMapBuilder.cs`
- `src/SemanticStub.Api/Services/QueryMatchSpecificityComparer.cs`
- `tests/SemanticStub.Api.Tests/Unit/QueryParameterTypeMapBuilderTests.cs`
- `tests/SemanticStub.Api.Tests/Unit/QueryMatchSpecificityComparerTests.cs`

## Tests
- `dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter "FullyQualifiedName~MatcherServiceTests|FullyQualifiedName~QueryParameterTypeMapBuilderTests|FullyQualifiedName~QueryMatchSpecificityComparerTests"`
- `dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj`

## Notes
- issue #117 only
- no API contract, routing, or YAML structure changes