### PR TITLE
refactor: extract JSON body matcher

### DIFF
--- a/src/SemanticStub.Api/Extensions/StubServiceCollectionExtensions.cs
+++ b/src/SemanticStub.Api/Extensions/StubServiceCollectionExtensions.cs
@@ -26,7 +26,11 @@ public static class StubServiceCollectionExtensions
         services.AddSingleton<StubDefinitionState>();
         services.AddSingleton<IStubInspectionService, StubInspectionService>();
         services.AddHostedService<StubDefinitionWatcher>();
-        services.AddSingleton<IMatcherService, MatcherService>();
+        services.AddSingleton(serviceProvider => new JsonBodyMatcher(
+            serviceProvider.GetRequiredService<ILogger<JsonBodyMatcher>>()));
+        services.AddSingleton<IMatcherService>(serviceProvider => new MatcherService(
+            serviceProvider.GetRequiredService<JsonBodyMatcher>(),
+            serviceProvider.GetRequiredService<ILogger<MatcherService>>()));
         services.AddSingleton<ScenarioService>();
         services.AddSingleton<IStubService>(serviceProvider => new StubService(
             serviceProvider.GetRequiredService<StubDefinitionState>(),

--- a/src/SemanticStub.Api/Services/JsonBodyMatcher.cs
+++ b/src/SemanticStub.Api/Services/JsonBodyMatcher.cs
@@ -1,0 +1,133 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using SemanticStub.Api.Utilities;
+
+namespace SemanticStub.Api.Services;
+
+/// <summary>
+/// Parses request bodies and compares structured JSON body expectations without changing matcher orchestration behavior.
+/// </summary>
+internal sealed class JsonBodyMatcher
+{
+    private readonly ILogger<JsonBodyMatcher>? logger;
+
+    /// <summary>
+    /// Creates a body matcher with optional warning logging for invalid stub body definitions.
+    /// </summary>
+    internal JsonBodyMatcher(ILogger<JsonBodyMatcher>? logger = null)
+    {
+        this.logger = logger;
+    }
+
+    internal JsonDocument? ParseRequestBody(string? body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonDocument.Parse(body);
+        }
+        catch (JsonException)
+        {
+            // Invalid JSON should behave like "no structured body match" rather than failing the whole request.
+            return null;
+        }
+    }
+
+    internal bool IsMatch(object? expectedBody, JsonElement? actualBody)
+    {
+        if (expectedBody is null)
+        {
+            return true;
+        }
+
+        if (actualBody is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            var expectedJson = StubExampleSerializer.Serialize(expectedBody);
+            using var expectedDocument = JsonDocument.Parse(expectedJson);
+
+            return IsJsonMatch(expectedDocument.RootElement, actualBody.Value);
+        }
+        catch (JsonException ex)
+        {
+            logger?.LogWarning(ex, "Invalid body match definition in stub YAML — treating as non-match.");
+            return false;
+        }
+        catch (NotSupportedException ex)
+        {
+            logger?.LogWarning(ex, "Unsupported body match definition in stub YAML — treating as non-match.");
+            return false;
+        }
+    }
+
+    private static bool IsJsonMatch(JsonElement expected, JsonElement actual)
+    {
+        if (expected.ValueKind == JsonValueKind.Object)
+        {
+            if (actual.ValueKind != JsonValueKind.Object)
+            {
+                return false;
+            }
+
+            // Object matches are partial: every expected property must exist and match, but extra actual properties are allowed.
+            foreach (var property in expected.EnumerateObject())
+            {
+                if (!actual.TryGetProperty(property.Name, out var actualProperty) ||
+                    !IsJsonMatch(property.Value, actualProperty))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        if (expected.ValueKind == JsonValueKind.Array)
+        {
+            if (actual.ValueKind != JsonValueKind.Array)
+            {
+                return false;
+            }
+
+            var expectedItems = expected.EnumerateArray().ToArray();
+            var actualItems = actual.EnumerateArray().ToArray();
+
+            if (expectedItems.Length != actualItems.Length)
+            {
+                return false;
+            }
+
+            for (var index = 0; index < expectedItems.Length; index++)
+            {
+                if (!IsJsonMatch(expectedItems[index], actualItems[index]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        if (expected.ValueKind != actual.ValueKind)
+        {
+            return false;
+        }
+
+        return expected.ValueKind switch
+        {
+            JsonValueKind.String => expected.GetString() == actual.GetString(),
+            JsonValueKind.Number => expected.GetRawText() == actual.GetRawText(),
+            JsonValueKind.True or JsonValueKind.False => expected.GetBoolean() == actual.GetBoolean(),
+            JsonValueKind.Null => true,
+            _ => expected.GetRawText() == actual.GetRawText()
+        };
+    }
+}

--- a/src/SemanticStub.Api/Services/MatcherService.cs
+++ b/src/SemanticStub.Api/Services/MatcherService.cs
@@ -5,7 +5,6 @@ using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using SemanticStub.Api.Models;
-using SemanticStub.Api.Utilities;
 
 namespace SemanticStub.Api.Services;
 
@@ -18,18 +17,20 @@ public sealed class MatcherService : IMatcherService
     private static readonly IReadOnlyDictionary<string, string> EmptyHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
     private static readonly QueryMatchSpecificityComparer MatchSpecificityComparer = QueryMatchSpecificityComparer.Instance;
     private readonly ILogger<MatcherService>? logger;
+    private readonly JsonBodyMatcher jsonBodyMatcher;
 
     /// <summary>
     /// Creates a matcher with no logging. Invalid regex patterns will silently produce non-matches.
     /// </summary>
-    public MatcherService() { }
+    public MatcherService()
+    {
+        jsonBodyMatcher = new JsonBodyMatcher();
+    }
 
-    /// <summary>
-    /// Creates a matcher that logs warnings for invalid regex patterns in stub definitions.
-    /// </summary>
-    public MatcherService(ILogger<MatcherService> logger)
+    internal MatcherService(JsonBodyMatcher jsonBodyMatcher, ILogger<MatcherService> logger)
     {
         this.logger = logger;
+        this.jsonBodyMatcher = jsonBodyMatcher;
     }
 
     /// <summary>
@@ -130,7 +131,7 @@ public sealed class MatcherService : IMatcherService
             return null;
         }
 
-        using var bodyDocument = ParseRequestBody(body);
+        using var bodyDocument = jsonBodyMatcher.ParseRequestBody(body);
         var queryParameterTypes = QueryParameterTypeMapBuilder.Build(pathParameters, operation.Parameters);
 
         // Match conditions are conjunctive; after filtering, prefer the candidate with the most explicit constraints.
@@ -153,7 +154,7 @@ public sealed class MatcherService : IMatcherService
         IReadOnlyDictionary<string, string> headers,
         string? body)
     {
-        using var bodyDocument = ParseRequestBody(body);
+        using var bodyDocument = jsonBodyMatcher.ParseRequestBody(body);
         var queryParameterTypes = QueryParameterTypeMapBuilder.Build(pathParameters, operation.Parameters);
         var evaluations = new List<QueryMatchCandidateEvaluation>(operation.Matches.Count);
 
@@ -164,7 +165,7 @@ public sealed class MatcherService : IMatcherService
                 Candidate = candidate,
                 QueryMatched = IsQueryMatch(candidate, query, queryParameterTypes),
                 HeaderMatched = IsExactHeaderMatch(candidate.Headers, headers),
-                BodyMatched = IsBodyMatch(candidate.Body, bodyDocument?.RootElement),
+                BodyMatched = jsonBodyMatcher.IsMatch(candidate.Body, bodyDocument?.RootElement),
             });
         }
 
@@ -216,7 +217,7 @@ public sealed class MatcherService : IMatcherService
     {
         return IsQueryMatch(candidate, query, queryParameterTypes) &&
                IsExactHeaderMatch(candidate.Headers, headers) &&
-               IsBodyMatch(candidate.Body, requestBody);
+               jsonBodyMatcher.IsMatch(candidate.Body, requestBody);
     }
 
     private static bool IsExactQueryMatch(
@@ -564,118 +565,6 @@ public sealed class MatcherService : IMatcherService
         }
 
         return true;
-    }
-
-    private static JsonDocument? ParseRequestBody(string? body)
-    {
-        if (string.IsNullOrWhiteSpace(body))
-        {
-            return null;
-        }
-
-        try
-        {
-            return JsonDocument.Parse(body);
-        }
-        catch (JsonException)
-        {
-            // Invalid JSON should behave like "no structured body match" rather than failing the whole request.
-            return null;
-        }
-    }
-
-    private bool IsBodyMatch(object? expectedBody, JsonElement? actualBody)
-    {
-        if (expectedBody is null)
-        {
-            return true;
-        }
-
-        if (actualBody is null)
-        {
-            return false;
-        }
-
-        try
-        {
-            var expectedJson = StubExampleSerializer.Serialize(expectedBody);
-            using var expectedDocument = JsonDocument.Parse(expectedJson);
-
-            return IsJsonMatch(expectedDocument.RootElement, actualBody.Value);
-        }
-        catch (JsonException ex)
-        {
-            logger?.LogWarning(ex, "Invalid body match definition in stub YAML — treating as non-match.");
-            return false;
-        }
-        catch (NotSupportedException ex)
-        {
-            logger?.LogWarning(ex, "Unsupported body match definition in stub YAML — treating as non-match.");
-            return false;
-        }
-    }
-
-    private static bool IsJsonMatch(JsonElement expected, JsonElement actual)
-    {
-        if (expected.ValueKind == JsonValueKind.Object)
-        {
-            if (actual.ValueKind != JsonValueKind.Object)
-            {
-                return false;
-            }
-
-            // Object matches are partial: every expected property must exist and match, but extra actual properties are allowed.
-            foreach (var property in expected.EnumerateObject())
-            {
-                if (!actual.TryGetProperty(property.Name, out var actualProperty) ||
-                    !IsJsonMatch(property.Value, actualProperty))
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        if (expected.ValueKind == JsonValueKind.Array)
-        {
-            if (actual.ValueKind != JsonValueKind.Array)
-            {
-                return false;
-            }
-
-            var expectedItems = expected.EnumerateArray().ToArray();
-            var actualItems = actual.EnumerateArray().ToArray();
-
-            if (expectedItems.Length != actualItems.Length)
-            {
-                return false;
-            }
-
-            for (var index = 0; index < expectedItems.Length; index++)
-            {
-                if (!IsJsonMatch(expectedItems[index], actualItems[index]))
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        if (expected.ValueKind != actual.ValueKind)
-        {
-            return false;
-        }
-
-        return expected.ValueKind switch
-        {
-            JsonValueKind.String => expected.GetString() == actual.GetString(),
-            JsonValueKind.Number => expected.GetRawText() == actual.GetRawText(),
-            JsonValueKind.True or JsonValueKind.False => expected.GetBoolean() == actual.GetBoolean(),
-            JsonValueKind.Null => true,
-            _ => expected.GetRawText() == actual.GetRawText()
-        };
     }
 
 }

--- a/tests/SemanticStub.Api.Tests/Unit/JsonBodyMatcherTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/JsonBodyMatcherTests.cs
@@ -1,0 +1,65 @@
+using SemanticStub.Api.Services;
+using Xunit;
+
+namespace SemanticStub.Api.Tests.Unit;
+
+public sealed class JsonBodyMatcherTests
+{
+    [Fact]
+    public void ParseRequestBody_ReturnsNullForInvalidJson()
+    {
+        var matcher = new JsonBodyMatcher();
+
+        using var bodyDocument = matcher.ParseRequestBody("{not-json");
+
+        Assert.Null(bodyDocument);
+    }
+
+    [Fact]
+    public void IsMatch_AllowsPartialObjectMatches()
+    {
+        var matcher = new JsonBodyMatcher();
+        using var actualBody = matcher.ParseRequestBody("{\"username\":\"demo\",\"rememberMe\":true}");
+
+        var matched = matcher.IsMatch(
+            new Dictionary<object, object>
+            {
+                ["username"] = "demo"
+            },
+            actualBody?.RootElement);
+
+        Assert.True(matched);
+    }
+
+    [Fact]
+    public void IsMatch_ReturnsFalseForUnsupportedBodyDefinitions()
+    {
+        var matcher = new JsonBodyMatcher();
+        using var actualBody = matcher.ParseRequestBody("{\"value\":42}");
+
+        var matched = matcher.IsMatch(
+            new Dictionary<object, object>
+            {
+                ["value"] = new IntPtr(42)
+            },
+            actualBody?.RootElement);
+
+        Assert.False(matched);
+    }
+
+    [Fact]
+    public void IsMatch_RequiresArrayLengthAndOrderToMatch()
+    {
+        var matcher = new JsonBodyMatcher();
+        using var actualBody = matcher.ParseRequestBody("{\"items\":[1,2]}");
+
+        var matched = matcher.IsMatch(
+            new Dictionary<object, object>
+            {
+                ["items"] = new List<object> { 2, 1 }
+            },
+            actualBody?.RootElement);
+
+        Assert.False(matched);
+    }
+}


### PR DESCRIPTION
## Summary
Extract JSON request body parsing and body comparison from MatcherService into JsonBodyMatcher while keeping existing matching behavior and YAML compatibility.

## Files Changed
- src/SemanticStub.Api/Services/MatcherService.cs
- src/SemanticStub.Api/Services/JsonBodyMatcher.cs
- src/SemanticStub.Api/Extensions/StubServiceCollectionExtensions.cs
- tests/SemanticStub.Api.Tests/Unit/JsonBodyMatcherTests.cs

## Tests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter "FullyQualifiedName~MatcherServiceTests|FullyQualifiedName~JsonBodyMatcherTests|FullyQualifiedName~StubServiceTests|FullyQualifiedName~StubInspectionServiceTests"
- dotnet test SemanticStub.sln

## Notes
Body matching warnings now log under JsonBodyMatcher via DI, while MatcherService keeps the same public behavior and remains focused on orchestration.