### PR TITLE
refactor: extract regex query matcher

### DIFF
--- a/src/SemanticStub.Api/Extensions/StubServiceCollectionExtensions.cs
+++ b/src/SemanticStub.Api/Extensions/StubServiceCollectionExtensions.cs
@@ -28,9 +28,11 @@ public static class StubServiceCollectionExtensions
         services.AddHostedService<StubDefinitionWatcher>();
         services.AddSingleton(serviceProvider => new JsonBodyMatcher(
             serviceProvider.GetRequiredService<ILogger<JsonBodyMatcher>>()));
+        services.AddSingleton(serviceProvider => new RegexQueryMatcher(
+            serviceProvider.GetRequiredService<ILogger<RegexQueryMatcher>>()));
         services.AddSingleton<IMatcherService>(serviceProvider => new MatcherService(
             serviceProvider.GetRequiredService<JsonBodyMatcher>(),
-            serviceProvider.GetRequiredService<ILogger<MatcherService>>()));
+            serviceProvider.GetRequiredService<RegexQueryMatcher>()));
         services.AddSingleton<ScenarioService>();
         services.AddSingleton<IStubService>(serviceProvider => new StubService(
             serviceProvider.GetRequiredService<StubDefinitionState>(),

--- a/src/SemanticStub.Api/Services/MatcherService.cs
+++ b/src/SemanticStub.Api/Services/MatcherService.cs
@@ -1,7 +1,4 @@
-using System.Collections;
-using System.Text.RegularExpressions;
 using System.Text.Json;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using SemanticStub.Api.Models;
 
@@ -12,12 +9,11 @@ namespace SemanticStub.Api.Services;
 /// </summary>
 public sealed class MatcherService : IMatcherService
 {
-    private static readonly TimeSpan RegexMatchTimeout = TimeSpan.FromMilliseconds(100);
     private static readonly IReadOnlyDictionary<string, string> EmptyHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
     private static readonly QueryMatchSpecificityComparer MatchSpecificityComparer = QueryMatchSpecificityComparer.Instance;
-    private readonly ILogger<MatcherService>? logger;
     private readonly JsonBodyMatcher jsonBodyMatcher;
     private readonly QueryValueMatcher queryValueMatcher;
+    private readonly RegexQueryMatcher regexQueryMatcher;
 
     /// <summary>
     /// Creates a matcher with no logging. Invalid regex patterns will silently produce non-matches.
@@ -26,13 +22,14 @@ public sealed class MatcherService : IMatcherService
     {
         jsonBodyMatcher = new JsonBodyMatcher();
         queryValueMatcher = new QueryValueMatcher();
+        regexQueryMatcher = new RegexQueryMatcher();
     }
 
-    internal MatcherService(JsonBodyMatcher jsonBodyMatcher, ILogger<MatcherService> logger)
+    internal MatcherService(JsonBodyMatcher jsonBodyMatcher, RegexQueryMatcher regexQueryMatcher)
     {
-        this.logger = logger;
         this.jsonBodyMatcher = jsonBodyMatcher;
         queryValueMatcher = new QueryValueMatcher();
+        this.regexQueryMatcher = regexQueryMatcher;
     }
 
     /// <summary>
@@ -228,80 +225,8 @@ public sealed class MatcherService : IMatcherService
         IReadOnlyDictionary<string, string> queryParameterTypes)
     {
         return queryValueMatcher.IsExactMatch(match.Query, actual, queryParameterTypes) &&
-               IsRegexQueryMatch(match.RegexQuery, actual) &&
+               regexQueryMatcher.IsMatch(match.RegexQuery, actual) &&
                queryValueMatcher.IsPartialMatch(match.PartialQuery, actual, queryParameterTypes);
-    }
-
-    private bool IsRegexQueryMatch(
-        IReadOnlyDictionary<string, object?> expected,
-        IReadOnlyDictionary<string, StringValues> actual)
-    {
-        foreach (var pair in expected)
-        {
-            if (!actual.TryGetValue(pair.Key, out var value) || !IsRegexQueryValueMatch(pair.Value, value))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private bool IsRegexQueryValueMatch(object? expected, StringValues actual)
-    {
-        if (expected is IEnumerable expectedSequence && expected is not string)
-        {
-            return IsRegexQuerySequenceMatch(expectedSequence, actual);
-        }
-
-        return actual.Count == 1 &&
-               actual[0] is not null &&
-               IsSingleRegexQueryValueMatch(expected, actual[0]!);
-    }
-
-    private bool IsRegexQuerySequenceMatch(IEnumerable expectedSequence, StringValues actual)
-    {
-        var expectedValues = expectedSequence.Cast<object?>().ToArray();
-        var actualValues = actual.ToArray();
-
-        if (expectedValues.Length != actualValues.Length)
-        {
-            return false;
-        }
-
-        for (var index = 0; index < expectedValues.Length; index++)
-        {
-            if (actualValues[index] is null ||
-                !IsSingleRegexQueryValueMatch(expectedValues[index], actualValues[index]!))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private bool IsSingleRegexQueryValueMatch(object? expected, string actual)
-    {
-        if (expected is not string pattern)
-        {
-            return false;
-        }
-
-        try
-        {
-            return Regex.IsMatch(actual, pattern, RegexOptions.CultureInvariant, RegexMatchTimeout);
-        }
-        catch (ArgumentException ex)
-        {
-            logger?.LogWarning(ex, "Invalid x-regex-query pattern '{Pattern}' in stub definition — treating as non-match.", pattern);
-            return false;
-        }
-        catch (RegexMatchTimeoutException)
-        {
-            logger?.LogWarning("x-regex-query pattern '{Pattern}' timed out after {TimeoutMs}ms — treating as non-match.", pattern, RegexMatchTimeout.TotalMilliseconds);
-            return false;
-        }
     }
 
     private static IReadOnlyDictionary<string, StringValues> ConvertQueryValues(IReadOnlyDictionary<string, string> query)

--- a/src/SemanticStub.Api/Services/RegexQueryMatcher.cs
+++ b/src/SemanticStub.Api/Services/RegexQueryMatcher.cs
@@ -1,0 +1,95 @@
+using System.Collections;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+
+namespace SemanticStub.Api.Services;
+
+/// <summary>
+/// Evaluates <c>x-query-regex</c> constraints without changing matcher orchestration or precedence behavior.
+/// </summary>
+internal sealed class RegexQueryMatcher
+{
+    private static readonly TimeSpan RegexMatchTimeout = TimeSpan.FromMilliseconds(100);
+    private readonly ILogger<RegexQueryMatcher>? logger;
+
+    /// <summary>
+    /// Creates a regex query matcher with optional warning logging for invalid or slow regex patterns.
+    /// </summary>
+    internal RegexQueryMatcher(ILogger<RegexQueryMatcher>? logger = null)
+    {
+        this.logger = logger;
+    }
+
+    internal bool IsMatch(
+        IReadOnlyDictionary<string, object?> expected,
+        IReadOnlyDictionary<string, StringValues> actual)
+    {
+        foreach (var pair in expected)
+        {
+            if (!actual.TryGetValue(pair.Key, out var value) || !IsRegexQueryValueMatch(pair.Value, value))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private bool IsRegexQueryValueMatch(object? expected, StringValues actual)
+    {
+        if (expected is IEnumerable expectedSequence && expected is not string)
+        {
+            return IsRegexQuerySequenceMatch(expectedSequence, actual);
+        }
+
+        return actual.Count == 1 &&
+               actual[0] is not null &&
+               IsSingleRegexQueryValueMatch(expected, actual[0]!);
+    }
+
+    private bool IsRegexQuerySequenceMatch(IEnumerable expectedSequence, StringValues actual)
+    {
+        var expectedValues = expectedSequence.Cast<object?>().ToArray();
+        var actualValues = actual.ToArray();
+
+        if (expectedValues.Length != actualValues.Length)
+        {
+            return false;
+        }
+
+        for (var index = 0; index < expectedValues.Length; index++)
+        {
+            if (actualValues[index] is null ||
+                !IsSingleRegexQueryValueMatch(expectedValues[index], actualValues[index]!))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private bool IsSingleRegexQueryValueMatch(object? expected, string actual)
+    {
+        if (expected is not string pattern)
+        {
+            return false;
+        }
+
+        try
+        {
+            return Regex.IsMatch(actual, pattern, RegexOptions.CultureInvariant, RegexMatchTimeout);
+        }
+        catch (ArgumentException ex)
+        {
+            logger?.LogWarning(ex, "Invalid x-regex-query pattern '{Pattern}' in stub definition — treating as non-match.", pattern);
+            return false;
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            logger?.LogWarning("x-regex-query pattern '{Pattern}' timed out after {TimeoutMs}ms — treating as non-match.", pattern, RegexMatchTimeout.TotalMilliseconds);
+            return false;
+        }
+    }
+}

--- a/tests/SemanticStub.Api.Tests/Unit/RegexQueryMatcherTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/RegexQueryMatcherTests.cs
@@ -1,0 +1,125 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+using SemanticStub.Api.Services;
+using Xunit;
+
+namespace SemanticStub.Api.Tests.Unit;
+
+public sealed class RegexQueryMatcherTests
+{
+    [Fact]
+    public void IsMatch_MatchesSingleRegexQueryValue()
+    {
+        var matcher = new RegexQueryMatcher();
+
+        var matched = matcher.IsMatch(
+            new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["role"] = "^admin-[0-9]+$"
+            },
+            new Dictionary<string, StringValues>(StringComparer.Ordinal)
+            {
+                ["role"] = new StringValues("admin-42")
+            });
+
+        Assert.True(matched);
+    }
+
+    [Fact]
+    public void IsMatch_MatchesRepeatedRegexQueryValuesInOrder()
+    {
+        var matcher = new RegexQueryMatcher();
+
+        var matched = matcher.IsMatch(
+            new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["tag"] = new List<object?> { "^alpha$", "^beta$" }
+            },
+            new Dictionary<string, StringValues>(StringComparer.Ordinal)
+            {
+                ["tag"] = new StringValues(["alpha", "beta"])
+            });
+
+        Assert.True(matched);
+    }
+
+    [Fact]
+    public void IsMatch_ReturnsFalseForInvalidRegexAndLogsWarning()
+    {
+        var logger = new ListLogger<RegexQueryMatcher>();
+        var matcher = new RegexQueryMatcher(logger);
+
+        var matched = matcher.IsMatch(
+            new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["role"] = "["
+            },
+            new Dictionary<string, StringValues>(StringComparer.Ordinal)
+            {
+                ["role"] = new StringValues("admin")
+            });
+
+        Assert.False(matched);
+        Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, logger.Entries[0].LogLevel);
+        Assert.Contains("Invalid x-regex-query pattern", logger.Entries[0].Message, StringComparison.Ordinal);
+        Assert.IsAssignableFrom<ArgumentException>(logger.Entries[0].Exception);
+    }
+
+    [Fact]
+    public void IsMatch_ReturnsFalseWhenRegexEvaluationTimesOutAndLogsWarning()
+    {
+        var logger = new ListLogger<RegexQueryMatcher>();
+        var matcher = new RegexQueryMatcher(logger);
+
+        var matched = matcher.IsMatch(
+            new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["role"] = "^(a+)+$"
+            },
+            new Dictionary<string, StringValues>(StringComparer.Ordinal)
+            {
+                ["role"] = new StringValues(new string('a', 4096) + "!")
+            });
+
+        Assert.False(matched);
+        Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, logger.Entries[0].LogLevel);
+        Assert.Contains("timed out after", logger.Entries[0].Message, StringComparison.Ordinal);
+        Assert.Null(logger.Entries[0].Exception);
+    }
+
+    private sealed class ListLogger<T> : ILogger<T>
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public IDisposable BeginScope<TState>(TState state)
+            where TState : notnull
+        {
+            return NullScope.Instance;
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add(new LogEntry(logLevel, formatter(state, exception), exception));
+        }
+    }
+
+    private sealed record LogEntry(LogLevel LogLevel, string Message, Exception? Exception);
+
+    private sealed class NullScope : IDisposable
+    {
+        public static NullScope Instance { get; } = new();
+
+        public void Dispose()
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract regex query evaluation from MatcherService into a focused internal RegexQueryMatcher
- keep timeout handling, invalid regex warning behavior, and matching semantics unchanged
- register the helper through DI and leave MatcherService as the orchestrator

## Files Changed
- src/SemanticStub.Api/Services/MatcherService.cs
- src/SemanticStub.Api/Services/RegexQueryMatcher.cs
- src/SemanticStub.Api/Extensions/StubServiceCollectionExtensions.cs
- tests/SemanticStub.Api.Tests/Unit/RegexQueryMatcherTests.cs

## Tests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter MatcherServiceTests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter RegexQueryMatcherTests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj

## Notes
- logger category for regex warnings now lives on RegexQueryMatcher, aligned with the focused helper pattern used by JsonBodyMatcher
- scope is limited to issue #118 and does not change YAML shape or public matcher APIs