### PR TITLE
refactor: remove redundant matcher overloads

### DIFF
--- a/src/SemanticStub.Api/Services/IMatcherService.cs
+++ b/src/SemanticStub.Api/Services/IMatcherService.cs
@@ -9,58 +9,6 @@ namespace SemanticStub.Api.Services;
 public interface IMatcherService
 {
     /// <summary>
-    /// Evaluates conditional matches using operation-level query definitions and no request headers.
-    /// </summary>
-    /// <param name="operation">The operation whose <c>x-match</c> candidates should be evaluated.</param>
-    /// <param name="query">Single-value query parameters keyed by parameter name.</param>
-    /// <param name="body">The request body used for JSON body matching. <see langword="null"/> means no structured body is available.</param>
-    /// <returns>The best matching candidate, or <see langword="null"/> when no candidate matches.</returns>
-    QueryMatchDefinition? FindBestMatch(
-        OperationDefinition operation,
-        IReadOnlyDictionary<string, string> query,
-        string? body);
-
-    /// <summary>
-    /// Evaluates conditional matches using operation-level query definitions and no request headers.
-    /// </summary>
-    /// <param name="operation">The operation whose <c>x-match</c> candidates should be evaluated.</param>
-    /// <param name="query">Query parameters keyed by parameter name, including repeated values in request order.</param>
-    /// <param name="body">The request body used for JSON body matching. <see langword="null"/> means no structured body is available.</param>
-    /// <returns>The best matching candidate, or <see langword="null"/> when no candidate matches.</returns>
-    QueryMatchDefinition? FindBestMatch(
-        OperationDefinition operation,
-        IReadOnlyDictionary<string, StringValues> query,
-        string? body);
-
-    /// <summary>
-    /// Evaluates conditional matches using the operation's query parameter definitions and the supplied request headers.
-    /// </summary>
-    /// <param name="operation">The operation whose <c>x-match</c> candidates should be evaluated.</param>
-    /// <param name="query">Single-value query parameters keyed by parameter name.</param>
-    /// <param name="headers">Request headers keyed by header name. Supply a case-insensitive dictionary for HTTP semantics.</param>
-    /// <param name="body">The request body used for JSON body matching. Invalid JSON is treated as "no structured body" instead of causing an exception.</param>
-    /// <returns>The best matching conditional definition, or <see langword="null"/> when none satisfy the request.</returns>
-    QueryMatchDefinition? FindBestMatch(
-        OperationDefinition operation,
-        IReadOnlyDictionary<string, string> query,
-        IReadOnlyDictionary<string, string> headers,
-        string? body);
-
-    /// <summary>
-    /// Evaluates conditional matches using the operation's query parameter definitions and the supplied request headers.
-    /// </summary>
-    /// <param name="operation">The operation whose <c>x-match</c> candidates should be evaluated.</param>
-    /// <param name="query">Query parameters keyed by parameter name, including repeated values in request order.</param>
-    /// <param name="headers">Request headers keyed by header name. Supply a case-insensitive dictionary for HTTP semantics.</param>
-    /// <param name="body">The request body used for JSON body matching. Invalid JSON is treated as "no structured body" instead of causing an exception.</param>
-    /// <returns>The best matching conditional definition, or <see langword="null"/> when none satisfy the request.</returns>
-    QueryMatchDefinition? FindBestMatch(
-        OperationDefinition operation,
-        IReadOnlyDictionary<string, StringValues> query,
-        IReadOnlyDictionary<string, string> headers,
-        string? body);
-
-    /// <summary>
     /// Filters candidates by every configured condition and returns the most specific surviving match.
     /// </summary>
     /// <param name="pathParameters">Path-level parameters whose query-schema definitions may contribute typed comparison metadata.</param>

--- a/src/SemanticStub.Api/Services/MatcherService.cs
+++ b/src/SemanticStub.Api/Services/MatcherService.cs
@@ -9,7 +9,6 @@ namespace SemanticStub.Api.Services;
 /// </summary>
 public sealed class MatcherService : IMatcherService
 {
-    private static readonly IReadOnlyDictionary<string, string> EmptyHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
     private static readonly QueryMatchSpecificityComparer MatchSpecificityComparer = QueryMatchSpecificityComparer.Instance;
     private readonly JsonBodyMatcher jsonBodyMatcher;
     private readonly QueryValueMatcher queryValueMatcher;
@@ -30,77 +29,6 @@ public sealed class MatcherService : IMatcherService
         this.jsonBodyMatcher = jsonBodyMatcher;
         queryValueMatcher = new QueryValueMatcher();
         this.regexQueryMatcher = regexQueryMatcher;
-    }
-
-    /// <summary>
-    /// Evaluates conditional matches using operation-level query definitions and no request headers.
-    /// </summary>
-    /// <param name="operation">The operation whose <c>x-match</c> candidates should be evaluated.</param>
-    /// <param name="query">Single-value query parameters keyed by parameter name.</param>
-    /// <param name="body">The request body used for JSON body matching. <see langword="null"/> means no structured body is available.</param>
-    /// <returns>The best matching candidate, or <see langword="null"/> when no candidate matches.</returns>
-    public QueryMatchDefinition? FindBestMatch(
-        OperationDefinition operation,
-        IReadOnlyDictionary<string, string> query,
-        string? body)
-    {
-        return FindBestMatch(
-            operation,
-            ConvertQueryValues(query),
-            body);
-    }
-
-    /// <summary>
-    /// Evaluates conditional matches using operation-level query definitions and no request headers.
-    /// </summary>
-    /// <param name="operation">The operation whose <c>x-match</c> candidates should be evaluated.</param>
-    /// <param name="query">Query parameters keyed by parameter name, including repeated values in request order.</param>
-    /// <param name="body">The request body used for JSON body matching. <see langword="null"/> means no structured body is available.</param>
-    /// <returns>The best matching candidate, or <see langword="null"/> when no candidate matches.</returns>
-    public QueryMatchDefinition? FindBestMatch(
-        OperationDefinition operation,
-        IReadOnlyDictionary<string, StringValues> query,
-        string? body)
-    {
-        return FindBestMatchWithOperationParameters(operation, query, EmptyHeaders, body);
-    }
-
-    /// <summary>
-    /// Evaluates conditional matches using the operation's query parameter definitions and the supplied request headers.
-    /// </summary>
-    /// <param name="operation">The operation whose <c>x-match</c> candidates should be evaluated.</param>
-    /// <param name="query">Single-value query parameters keyed by parameter name.</param>
-    /// <param name="headers">Request headers keyed by header name. Supply a case-insensitive dictionary for HTTP semantics.</param>
-    /// <param name="body">The request body used for JSON body matching. Invalid JSON is treated as "no structured body" instead of causing an exception.</param>
-    /// <returns>The best matching conditional definition, or <see langword="null"/> when none satisfy the request.</returns>
-    public QueryMatchDefinition? FindBestMatch(
-        OperationDefinition operation,
-        IReadOnlyDictionary<string, string> query,
-        IReadOnlyDictionary<string, string> headers,
-        string? body)
-    {
-        return FindBestMatch(
-            operation,
-            ConvertQueryValues(query),
-            headers,
-            body);
-    }
-
-    /// <summary>
-    /// Evaluates conditional matches using the operation's query parameter definitions and the supplied request headers.
-    /// </summary>
-    /// <param name="operation">The operation whose <c>x-match</c> candidates should be evaluated.</param>
-    /// <param name="query">Query parameters keyed by parameter name, including repeated values in request order.</param>
-    /// <param name="headers">Request headers keyed by header name. Supply a case-insensitive dictionary for HTTP semantics.</param>
-    /// <param name="body">The request body used for JSON body matching. Invalid JSON is treated as "no structured body" instead of causing an exception.</param>
-    /// <returns>The best matching conditional definition, or <see langword="null"/> when none satisfy the request.</returns>
-    public QueryMatchDefinition? FindBestMatch(
-        OperationDefinition operation,
-        IReadOnlyDictionary<string, StringValues> query,
-        IReadOnlyDictionary<string, string> headers,
-        string? body)
-    {
-        return FindBestMatchWithOperationParameters(operation, query, headers, body);
     }
 
     /// <summary>
@@ -166,20 +94,6 @@ public sealed class MatcherService : IMatcherService
         return evaluations;
     }
 
-    private QueryMatchDefinition? FindBestMatchWithOperationParameters(
-        OperationDefinition operation,
-        IReadOnlyDictionary<string, StringValues> query,
-        IReadOnlyDictionary<string, string> headers,
-        string? body)
-    {
-        return FindBestMatch(
-            operation.Parameters,
-            operation,
-            query,
-            headers,
-            body);
-    }
-
     private IEnumerable<QueryMatchDefinition> GetCandidatesMatchingRequest(
         IReadOnlyCollection<QueryMatchDefinition> candidates,
         MatchEvaluationContext matchContext,
@@ -227,14 +141,6 @@ public sealed class MatcherService : IMatcherService
         var queryParameterTypes = QueryParameterTypeMapBuilder.Build(pathParameters, operation.Parameters);
         var bodyDocument = jsonBodyMatcher.ParseRequestBody(body);
         return new MatchEvaluationContext(query, headers, queryParameterTypes, bodyDocument);
-    }
-
-    private static IReadOnlyDictionary<string, StringValues> ConvertQueryValues(IReadOnlyDictionary<string, string> query)
-    {
-        return query.ToDictionary(
-            entry => entry.Key,
-            entry => new StringValues(entry.Value),
-            StringComparer.Ordinal);
     }
 
     private static bool IsExactHeaderMatch(IReadOnlyDictionary<string, string> expected, IReadOnlyDictionary<string, string> actual)

--- a/tests/SemanticStub.Api.Tests/Unit/MatcherServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/MatcherServiceTests.cs
@@ -49,7 +49,8 @@ public sealed class MatcherServiceTests
             ["view"] = "summary"
         };
 
-        var match = matcher.FindBestMatch(
+        var match = FindBestMatch(
+            matcher,
             operation,
             query,
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
@@ -80,7 +81,8 @@ public sealed class MatcherServiceTests
 
         var matcher = new MatcherService();
 
-        var match = matcher.FindBestMatch(
+        var match = FindBestMatch(
+            matcher,
             operation,
             new Dictionary<string, string>(StringComparer.Ordinal),
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
@@ -108,7 +110,8 @@ public sealed class MatcherServiceTests
 
         var matcher = new MatcherService();
 
-        var match = matcher.FindBestMatch(
+        var match = FindBestMatch(
+            matcher,
             operation,
             new Dictionary<string, string>(StringComparer.Ordinal),
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
@@ -136,43 +139,14 @@ public sealed class MatcherServiceTests
 
         var matcher = new MatcherService();
 
-        var match = matcher.FindBestMatch(
+        var match = FindBestMatch(
+            matcher,
             operation,
             new Dictionary<string, string>(StringComparer.Ordinal),
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
             "{\"value\":42}");
 
         Assert.Null(match);
-    }
-
-    [Fact]
-    public void FindBestMatch_OldOverloadRemainsCompatible()
-    {
-        var operation = new OperationDefinition
-        {
-            Matches =
-            [
-                new QueryMatchDefinition
-                {
-                    Query = new Dictionary<string, object?>(StringComparer.Ordinal)
-                    {
-                        ["role"] = "admin"
-                    }
-                }
-            ]
-        };
-
-        var matcher = new MatcherService();
-
-        var match = matcher.FindBestMatch(
-            operation,
-            new Dictionary<string, string>(StringComparer.Ordinal)
-            {
-                ["role"] = "admin"
-            },
-            body: null);
-
-        Assert.NotNull(match);
     }
 
     [Fact]
@@ -367,7 +341,8 @@ public sealed class MatcherServiceTests
 
         var matcher = new MatcherService();
 
-        var match = matcher.FindBestMatch(
+        var match = FindBestMatch(
+            matcher,
             operation,
             new Dictionary<string, string>(StringComparer.Ordinal),
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
@@ -410,7 +385,8 @@ public sealed class MatcherServiceTests
 
         var matcher = new MatcherService();
 
-        var match = matcher.FindBestMatch(
+        var match = FindBestMatch(
+            matcher,
             operation,
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
@@ -453,7 +429,8 @@ public sealed class MatcherServiceTests
 
         var matcher = new MatcherService();
 
-        var match = matcher.FindBestMatch(
+        var match = FindBestMatch(
+            matcher,
             operation,
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
@@ -496,7 +473,8 @@ public sealed class MatcherServiceTests
 
         var matcher = new MatcherService();
 
-        var match = matcher.FindBestMatch(
+        var match = FindBestMatch(
+            matcher,
             operation,
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
@@ -539,7 +517,8 @@ public sealed class MatcherServiceTests
 
         var matcher = new MatcherService();
 
-        var match = matcher.FindBestMatch(
+        var match = FindBestMatch(
+            matcher,
             operation,
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
@@ -612,7 +591,8 @@ public sealed class MatcherServiceTests
 
         var matcher = new MatcherService();
 
-        var match = matcher.FindBestMatch(
+        var match = FindBestMatch(
+            matcher,
             operation,
             new Dictionary<string, StringValues>(StringComparer.Ordinal)
             {
@@ -643,7 +623,8 @@ public sealed class MatcherServiceTests
 
         var matcher = new MatcherService();
 
-        var match = matcher.FindBestMatch(
+        var match = FindBestMatch(
+            matcher,
             operation,
             new Dictionary<string, StringValues>(StringComparer.Ordinal)
             {
@@ -674,7 +655,8 @@ public sealed class MatcherServiceTests
 
         var matcher = new MatcherService();
 
-        var match = matcher.FindBestMatch(
+        var match = FindBestMatch(
+            matcher,
             operation,
             new Dictionary<string, StringValues>(StringComparer.Ordinal)
             {
@@ -713,7 +695,8 @@ public sealed class MatcherServiceTests
 
         var matcher = new MatcherService();
 
-        var match = matcher.FindBestMatch(
+        var match = FindBestMatch(
+            matcher,
             operation,
             new Dictionary<string, string>(StringComparer.Ordinal),
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
@@ -746,7 +729,8 @@ public sealed class MatcherServiceTests
 
         var matcher = new MatcherService();
 
-        var match = matcher.FindBestMatch(
+        var match = FindBestMatch(
+            matcher,
             operation,
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
@@ -785,7 +769,8 @@ public sealed class MatcherServiceTests
 
         var matcher = new MatcherService();
 
-        var match = matcher.FindBestMatch(
+        var match = FindBestMatch(
+            matcher,
             operation,
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
@@ -818,7 +803,8 @@ public sealed class MatcherServiceTests
 
         var matcher = new MatcherService();
 
-        var match = matcher.FindBestMatch(
+        var match = FindBestMatch(
+            matcher,
             operation,
             new Dictionary<string, StringValues>(StringComparer.Ordinal)
             {
@@ -849,7 +835,8 @@ public sealed class MatcherServiceTests
 
         var matcher = new MatcherService();
 
-        var match = matcher.FindBestMatch(
+        var match = FindBestMatch(
+            matcher,
             operation,
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
@@ -880,7 +867,8 @@ public sealed class MatcherServiceTests
 
         var matcher = new MatcherService();
 
-        var match = matcher.FindBestMatch(
+        var match = FindBestMatch(
+            matcher,
             operation,
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
@@ -911,7 +899,8 @@ public sealed class MatcherServiceTests
 
         var matcher = new MatcherService();
 
-        var match = matcher.FindBestMatch(
+        var match = FindBestMatch(
+            matcher,
             operation,
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
@@ -943,7 +932,8 @@ public sealed class MatcherServiceTests
 
         var matcher = new MatcherService();
 
-        var match = matcher.FindBestMatch(
+        var match = FindBestMatch(
+            matcher,
             operation,
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
@@ -980,7 +970,8 @@ public sealed class MatcherServiceTests
 
         var stopwatch = Stopwatch.StartNew();
 
-        var match = matcher.FindBestMatch(
+        var match = FindBestMatch(
+            matcher,
             operation,
             query,
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
@@ -1022,7 +1013,8 @@ public sealed class MatcherServiceTests
 
         var matcher = new MatcherService();
 
-        var match = matcher.FindBestMatch(
+        var match = FindBestMatch(
+            matcher,
             operation,
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
@@ -1066,7 +1058,8 @@ public sealed class MatcherServiceTests
 
         var matcher = new MatcherService();
 
-        var match = matcher.FindBestMatch(
+        var match = FindBestMatch(
+            matcher,
             operation,
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
@@ -1078,5 +1071,38 @@ public sealed class MatcherServiceTests
         Assert.NotNull(match);
         Assert.Equal("^admin-[0-9]+$", match.RegexQuery["role"]);
         Assert.Empty(match.PartialQuery);
+    }
+
+    private static QueryMatchDefinition? FindBestMatch(
+        MatcherService matcher,
+        OperationDefinition operation,
+        IReadOnlyDictionary<string, string> query,
+        IReadOnlyDictionary<string, string> headers,
+        string? body)
+    {
+        return matcher.FindBestMatch(
+            operation.Parameters,
+            operation,
+            query.ToDictionary(
+                entry => entry.Key,
+                entry => new StringValues(entry.Value),
+                StringComparer.Ordinal),
+            headers,
+            body);
+    }
+
+    private static QueryMatchDefinition? FindBestMatch(
+        MatcherService matcher,
+        OperationDefinition operation,
+        IReadOnlyDictionary<string, StringValues> query,
+        IReadOnlyDictionary<string, string> headers,
+        string? body)
+    {
+        return matcher.FindBestMatch(
+            operation.Parameters,
+            operation,
+            query,
+            headers,
+            body);
     }
 }


### PR DESCRIPTION
## Summary
- remove the non-essential `FindBestMatch` overloads from `IMatcherService` and `MatcherService`
- keep the full `FindBestMatch` entry point that `StubService` already uses in production
- update matcher tests to target the remaining API directly and drop the overload-compatibility test

## Files Changed
- src/SemanticStub.Api/Services/IMatcherService.cs
- src/SemanticStub.Api/Services/MatcherService.cs
- tests/SemanticStub.Api.Tests/Unit/MatcherServiceTests.cs

## Tests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter MatcherServiceTests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj

## Notes
- limited to matcher API surface cleanup only
- no YAML structure or matching behavior changes are intended
- no unrelated service-layer refactors included