### PR TITLE
refactor: extract scenario state store

### DIFF
--- a/src/SemanticStub.Api/Services/ScenarioService.cs
+++ b/src/SemanticStub.Api/Services/ScenarioService.cs
@@ -1,5 +1,4 @@
 using SemanticStub.Api.Models;
-using System.Collections.Concurrent;
 
 namespace SemanticStub.Api.Services;
 
@@ -8,8 +7,7 @@ namespace SemanticStub.Api.Services;
 /// </summary>
 public sealed class ScenarioService
 {
-    private const string InitialState = "initial";
-    private readonly ConcurrentDictionary<string, ScenarioStateSnapshot> currentStates = new(StringComparer.Ordinal);
+    private readonly ScenarioStateStore stateStore = new();
     private readonly SemaphoreSlim semaphore = new(1, 1);
 
     /// <summary>
@@ -23,11 +21,7 @@ public sealed class ScenarioService
             return true;
         }
 
-        var currentState = currentStates.TryGetValue(scenario.Name, out var snapshot)
-            ? snapshot.State
-            : InitialState;
-
-        return string.Equals(currentState, scenario.State, StringComparison.Ordinal);
+        return stateStore.IsMatch(scenario);
     }
 
     /// <summary>
@@ -36,12 +30,7 @@ public sealed class ScenarioService
     /// <param name="scenario">The scenario definition attached to the selected response.</param>
     public void Advance(ScenarioDefinition? scenario)
     {
-        if (scenario is null || string.IsNullOrWhiteSpace(scenario.Next))
-        {
-            return;
-        }
-
-        currentStates[scenario.Name] = new ScenarioStateSnapshot(scenario.Next, DateTimeOffset.UtcNow);
+        stateStore.Advance(scenario, DateTimeOffset.UtcNow);
     }
 
     /// <summary>
@@ -58,7 +47,7 @@ public sealed class ScenarioService
 
     internal void ResetWithinLock()
     {
-        currentStates.Clear();
+        stateStore.Clear();
     }
 
     /// <summary>
@@ -117,26 +106,17 @@ public sealed class ScenarioService
 
     internal ScenarioStateSnapshot GetSnapshotWithinLock(string scenarioName)
     {
-        return currentStates.TryGetValue(scenarioName, out var snapshot)
-            ? snapshot
-            : new ScenarioStateSnapshot(InitialState, null);
+        return stateStore.GetSnapshot(scenarioName);
     }
 
     internal void ResetScenarioWithinLock(string scenarioName, DateTimeOffset timestamp)
     {
-        currentStates[scenarioName] = new ScenarioStateSnapshot(InitialState, timestamp);
+        stateStore.ResetScenario(scenarioName, timestamp);
     }
 
     internal void ResetScenariosWithinLock(IEnumerable<string> scenarioNames, DateTimeOffset timestamp)
     {
-        var scenarioNameSet = new HashSet<string>(scenarioNames, StringComparer.Ordinal);
-
-        currentStates.Clear();
-
-        foreach (var scenarioName in scenarioNameSet)
-        {
-            currentStates[scenarioName] = new ScenarioStateSnapshot(InitialState, timestamp);
-        }
+        stateStore.ResetScenarios(scenarioNames, timestamp);
     }
 
     /// <summary>

--- a/src/SemanticStub.Api/Services/ScenarioStateStore.cs
+++ b/src/SemanticStub.Api/Services/ScenarioStateStore.cs
@@ -1,0 +1,63 @@
+using SemanticStub.Api.Models;
+using System.Collections.Concurrent;
+
+namespace SemanticStub.Api.Services;
+
+/// <summary>
+/// Stores in-memory scenario state snapshots and applies the runtime transition rules used by <see cref="ScenarioService"/>.
+/// </summary>
+internal sealed class ScenarioStateStore
+{
+    private const string InitialState = "initial";
+    private readonly ConcurrentDictionary<string, ScenarioStateSnapshot> currentStates = new(StringComparer.Ordinal);
+
+    public bool IsMatch(ScenarioDefinition scenario)
+    {
+        var currentState = GetSnapshot(scenario.Name).State;
+        return string.Equals(currentState, scenario.State, StringComparison.Ordinal);
+    }
+
+    public void Advance(ScenarioDefinition? scenario, DateTimeOffset timestamp)
+    {
+        if (scenario is null || string.IsNullOrWhiteSpace(scenario.Next))
+        {
+            return;
+        }
+
+        currentStates[scenario.Name] = CreateSnapshot(scenario.Next, timestamp);
+    }
+
+    public ScenarioStateSnapshot GetSnapshot(string scenarioName)
+    {
+        return currentStates.TryGetValue(scenarioName, out var snapshot)
+            ? snapshot
+            : CreateSnapshot(InitialState, timestamp: null);
+    }
+
+    public void ResetScenario(string scenarioName, DateTimeOffset timestamp)
+    {
+        currentStates[scenarioName] = CreateSnapshot(InitialState, timestamp);
+    }
+
+    public void ResetScenarios(IEnumerable<string> scenarioNames, DateTimeOffset timestamp)
+    {
+        var scenarioNameSet = new HashSet<string>(scenarioNames, StringComparer.Ordinal);
+
+        currentStates.Clear();
+
+        foreach (var scenarioName in scenarioNameSet)
+        {
+            currentStates[scenarioName] = CreateSnapshot(InitialState, timestamp);
+        }
+    }
+
+    public void Clear()
+    {
+        currentStates.Clear();
+    }
+
+    private static ScenarioStateSnapshot CreateSnapshot(string state, DateTimeOffset? timestamp)
+    {
+        return new ScenarioStateSnapshot(state, timestamp);
+    }
+}

--- a/tests/SemanticStub.Api.Tests/Unit/ScenarioStateStoreTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/ScenarioStateStoreTests.cs
@@ -1,0 +1,58 @@
+using SemanticStub.Api.Models;
+using SemanticStub.Api.Services;
+using Xunit;
+
+namespace SemanticStub.Api.Tests.Unit;
+
+public sealed class ScenarioStateStoreTests
+{
+    [Fact]
+    public void GetSnapshot_ReturnsInitialStateWithNullTimestamp_WhenScenarioHasNotAdvanced()
+    {
+        var store = new ScenarioStateStore();
+
+        var snapshot = store.GetSnapshot("checkout-flow");
+
+        Assert.Equal("initial", snapshot.State);
+        Assert.Null(snapshot.LastUpdatedTimestamp);
+    }
+
+    [Fact]
+    public void Advance_StoresNextStateAndTimestamp()
+    {
+        var store = new ScenarioStateStore();
+        var scenario = new ScenarioDefinition
+        {
+            Name = "checkout-flow",
+            State = "initial",
+            Next = "confirmed"
+        };
+        var timestamp = DateTimeOffset.UtcNow;
+
+        store.Advance(scenario, timestamp);
+
+        var snapshot = store.GetSnapshot("checkout-flow");
+        Assert.Equal("confirmed", snapshot.State);
+        Assert.Equal(timestamp, snapshot.LastUpdatedTimestamp);
+    }
+
+    [Fact]
+    public void ResetScenarios_ClearsUnknownStatesAndDeduplicatesNames()
+    {
+        var store = new ScenarioStateStore();
+        var timestamp = DateTimeOffset.UtcNow;
+
+        store.Advance(new ScenarioDefinition { Name = "checkout-flow", State = "initial", Next = "confirmed" }, timestamp);
+        store.Advance(new ScenarioDefinition { Name = "payment-flow", State = "initial", Next = "authorized" }, timestamp);
+
+        store.ResetScenarios(["checkout-flow", "checkout-flow"], timestamp);
+
+        var checkoutSnapshot = store.GetSnapshot("checkout-flow");
+        var paymentSnapshot = store.GetSnapshot("payment-flow");
+
+        Assert.Equal("initial", checkoutSnapshot.State);
+        Assert.Equal(timestamp, checkoutSnapshot.LastUpdatedTimestamp);
+        Assert.Equal("initial", paymentSnapshot.State);
+        Assert.Null(paymentSnapshot.LastUpdatedTimestamp);
+    }
+}


### PR DESCRIPTION
## Summary
- extract in-memory scenario state storage and transition rules from `ScenarioService` into an internal `ScenarioStateStore`
- keep `ScenarioService` public API and lock orchestration unchanged so existing scenario behavior remains intact
- add focused state-store regression tests for initial state, advancing, and multi-reset behavior

## Files Changed
- `src/SemanticStub.Api/Services/ScenarioService.cs`
- `src/SemanticStub.Api/Services/ScenarioStateStore.cs`
- `tests/SemanticStub.Api.Tests/Unit/ScenarioStateStoreTests.cs`

## Tests
- `dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter "ScenarioServiceTests|ScenarioStateStoreTests|StubInspectionServiceTests"`
- `dotnet test SemanticStub.sln`

## Notes
- preserves existing behavior and YAML compatibility for scenario matching, advancement, snapshots, and resets
- keeps follow-up synchronization and facade cleanup out of scope for this PR
- closes #126