### PR TITLE
refactor: slim ScenarioService synchronization facade

### DIFF
--- a/src/SemanticStub.Api/Services/ScenarioService.cs
+++ b/src/SemanticStub.Api/Services/ScenarioService.cs
@@ -38,11 +38,7 @@ public sealed class ScenarioService
     /// </summary>
     public void Reset()
     {
-        ExecuteLocked(() =>
-        {
-            ResetWithinLock();
-            return 0;
-        });
+        ExecuteLocked(ResetWithinLock);
     }
 
     internal void ResetWithinLock()
@@ -84,11 +80,7 @@ public sealed class ScenarioService
     /// <param name="scenarioName">The scenario name defined in YAML.</param>
     public void ResetScenario(string scenarioName)
     {
-        ExecuteLocked(() =>
-        {
-            ResetScenarioWithinLock(scenarioName, DateTimeOffset.UtcNow);
-            return 0;
-        });
+        ExecuteLockedWithTimestamp(timestamp => ResetScenarioWithinLock(scenarioName, timestamp));
     }
 
     /// <summary>
@@ -97,11 +89,7 @@ public sealed class ScenarioService
     /// <param name="scenarioNames">The scenario names defined in YAML.</param>
     public void ResetScenarios(IEnumerable<string> scenarioNames)
     {
-        ExecuteLocked(() =>
-        {
-            ResetScenariosWithinLock(scenarioNames, DateTimeOffset.UtcNow);
-            return 0;
-        });
+        ExecuteLockedWithTimestamp(timestamp => ResetScenariosWithinLock(scenarioNames, timestamp));
     }
 
     internal ScenarioStateSnapshot GetSnapshotWithinLock(string scenarioName)
@@ -117,6 +105,19 @@ public sealed class ScenarioService
     internal void ResetScenariosWithinLock(IEnumerable<string> scenarioNames, DateTimeOffset timestamp)
     {
         stateStore.ResetScenarios(scenarioNames, timestamp);
+    }
+
+    /// <summary>
+    /// Executes scenario-sensitive selection and transition logic under one lock so state checks and advances stay atomic across concurrent requests.
+    /// </summary>
+    /// <param name="action">The scenario-aware operation to run atomically.</param>
+    public void ExecuteLocked(Action action)
+    {
+        ExecuteLocked(() =>
+        {
+            action();
+            return 0;
+        });
     }
 
     /// <summary>
@@ -151,6 +152,11 @@ public sealed class ScenarioService
         {
             semaphore.Release();
         }
+    }
+
+    private void ExecuteLockedWithTimestamp(Action<DateTimeOffset> action)
+    {
+        ExecuteLocked(() => action(DateTimeOffset.UtcNow));
     }
 }
 

--- a/tests/SemanticStub.Api.Tests/Unit/ScenarioServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/ScenarioServiceTests.cs
@@ -63,6 +63,21 @@ public sealed class ScenarioServiceTests
     }
 
     [Fact]
+    public void GetSnapshots_ReturnsCurrentSnapshotForEachRequestedScenario()
+    {
+        var service = new ScenarioService();
+        service.Advance(new ScenarioDefinition { Name = "checkout-flow", State = "initial", Next = "confirmed" });
+
+        var snapshots = service.GetSnapshots(["checkout-flow", "payment-flow"]);
+
+        Assert.Equal(2, snapshots.Count);
+        Assert.Equal("confirmed", snapshots["checkout-flow"].State);
+        Assert.NotNull(snapshots["checkout-flow"].LastUpdatedTimestamp);
+        Assert.Equal("initial", snapshots["payment-flow"].State);
+        Assert.Null(snapshots["payment-flow"].LastUpdatedTimestamp);
+    }
+
+    [Fact]
     public void Advance_StoresCurrentStateTimestamp()
     {
         var service = new ScenarioService();
@@ -139,7 +154,6 @@ public sealed class ScenarioServiceTests
         service.ExecuteLocked(() =>
         {
             service.ResetWithinLock();
-            return 0;
         });
 
         Assert.True(service.IsMatch(scenario));


### PR DESCRIPTION
## Summary
- reduce duplication in `ScenarioService` by centralizing lock-only wrapper paths
- keep the existing public API and `*WithinLock` internal call sites unchanged
- add regression coverage for `GetSnapshots` while preserving current scenario behavior

## Files Changed
- `src/SemanticStub.Api/Services/ScenarioService.cs`
- `tests/SemanticStub.Api.Tests/Unit/ScenarioServiceTests.cs`

## Tests
- `dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter "ScenarioServiceTests|StubInspectionServiceTests|ScenarioStateStoreTests"`

## Notes
- Issue: #125
- no YAML compatibility changes
- no unrelated service or infrastructure changes