### PR TITLE
fix: raise default semantic match threshold

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -180,7 +180,7 @@ paths:
 "SemanticMatching": {
   "Enabled": true,
   "Endpoint": "http://localhost:8081",
-  "Threshold": 0.8,
+  "Threshold": 0.85,
   "TopScoreMargin": 0,
   "TimeoutSeconds": 30
 }
@@ -190,7 +190,7 @@ paths:
 | --- | --- | --- |
 | `Enabled` | セマンティックマッチングフォールバックを有効化します。 | `false` |
 | `Endpoint` | TEI エンドポイントのベース URL。 | `""` |
-| `Threshold` | マッチを受け入れる最小コサイン類似度 (-1.0〜1.0)。 | `0.8` |
+| `Threshold` | マッチを受け入れる最小コサイン類似度 (-1.0〜1.0)。 | `0.85` |
 | `TopScoreMargin` | 上位2候補間の最小スコア差。`0` で曖昧性チェックを無効化します。 | `0` |
 | `TimeoutSeconds` | 埋め込みエンドポイントへの HTTP リクエストタイムアウト（秒）。 | `30` |
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Configure semantic matching in `appsettings.json`:
 "SemanticMatching": {
   "Enabled": true,
   "Endpoint": "http://localhost:8081",
-  "Threshold": 0.8,
+  "Threshold": 0.85,
   "TopScoreMargin": 0,
   "TimeoutSeconds": 30
 }
@@ -219,7 +219,7 @@ Configure semantic matching in `appsettings.json`:
 | --- | --- | --- |
 | `Enabled` | Enables semantic matching fallback. | `false` |
 | `Endpoint` | Base URL of the TEI endpoint. | `""` |
-| `Threshold` | Minimum cosine similarity to accept a match (-1.0–1.0). | `0.8` |
+| `Threshold` | Minimum cosine similarity to accept a match (-1.0–1.0). | `0.85` |
 | `TopScoreMargin` | Minimum score gap between the top two candidates; `0` disables the ambiguity check. | `0` |
 | `TimeoutSeconds` | HTTP request timeout for the embedding endpoint. | `30` |
 

--- a/src/SemanticStub.Api/Infrastructure/Yaml/SemanticMatchingSettings.cs
+++ b/src/SemanticStub.Api/Infrastructure/Yaml/SemanticMatchingSettings.cs
@@ -17,10 +17,10 @@ public sealed class SemanticMatchingSettings
 
     /// <summary>
     /// Gets the minimum cosine similarity required to accept a semantic match.
-    /// Values range from -1.0 (opposite) to 1.0 (identical). The default of 0.8
-    /// targets high-confidence matches while still allowing moderate paraphrasing.
+    /// Values range from -1.0 (opposite) to 1.0 (identical). The default of 0.85
+    /// favors safer matching and reduces broad false positives.
     /// </summary>
-    public double Threshold { get; init; } = 0.8d;
+    public double Threshold { get; init; } = 0.85d;
 
     /// <summary>
     /// Gets the minimum score gap required between the top two candidates to accept

--- a/src/SemanticStub.Api/appsettings.Development.json
+++ b/src/SemanticStub.Api/appsettings.Development.json
@@ -14,9 +14,7 @@
   "StubSettings": {
     "SemanticMatching": {
       "Enabled": true,
-      "Endpoint": "http://localhost:8081",
-      "Threshold": 0.85,
-      "TimeoutSeconds": 30
+      "Endpoint": "http://localhost:8081"
     }
   }
 }

--- a/src/SemanticStub.Api/appsettings.json
+++ b/src/SemanticStub.Api/appsettings.json
@@ -14,7 +14,7 @@
     "SemanticMatching": {
       "Enabled": false,
       "Endpoint": "",
-      "Threshold": 0.8,
+      "Threshold": 0.85,
       "TimeoutSeconds": 30
     }
   }

--- a/tests/SemanticStub.Api.Tests/Unit/SemanticMatcherServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/SemanticMatcherServiceTests.cs
@@ -180,6 +180,35 @@ public sealed class SemanticMatcherServiceTests
     }
 
     [Fact]
+    public async Task FindBestMatchAsync_UsesDefaultThresholdWhenNoneIsConfigured()
+    {
+        var service = CreateService(
+            new StubSettings
+            {
+                SemanticMatching = new SemanticMatchingSettings
+                {
+                    Enabled = true,
+                    Endpoint = "http://tei"
+                }
+            },
+            CreateEmbeddingHandler(new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["method: POST\npath: /search\nbody:\ncoffee shop search"] = "[1.0,0.0]",
+                ["show unpaid billing invoices"] = "[0.84,0.5425863986500215]"
+            }));
+
+        var match = await service.FindBestMatchAsync(
+            "POST",
+            "/search",
+            new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            "coffee shop search",
+            [CreateCandidate("show unpaid billing invoices")]);
+
+        Assert.Null(match);
+    }
+
+    [Fact]
     public async Task FindBestMatchAsync_ReturnsNullWhenTopScoreMarginIsTooSmall()
     {
         var service = CreateService(


### PR DESCRIPTION
## Summary
- raise the default semantic matching threshold from `0.8` to `0.85`
- align the runtime defaults and README examples with the more conservative threshold
- add a regression test for the default-threshold fallback behavior and remove redundant Development overrides

## Files Changed
- `src/SemanticStub.Api/Infrastructure/Yaml/SemanticMatchingSettings.cs`
- `src/SemanticStub.Api/appsettings.json`
- `src/SemanticStub.Api/appsettings.Development.json`
- `tests/SemanticStub.Api.Tests/Unit/SemanticMatcherServiceTests.cs`
- `README.md`
- `README.ja.md`

## Tests
- `dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter SemanticMatcherServiceTests`
- verified the semantic sample requests locally, including the `coffee shops` fallback returning `404`

## Notes
- scoped this PR to Issue #155 only
- left unrelated untracked local files out of the PR