### PR TITLE
fix: show stub reload logs by default

### DIFF
--- a/src/SemanticStub.Api/appsettings.json
+++ b/src/SemanticStub.Api/appsettings.json
@@ -6,7 +6,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Warning",
-      "Microsoft.AspNetCore.HttpLogging": "Information"
+      "Microsoft.AspNetCore.HttpLogging": "Information",
+      "SemanticStub.Api.Infrastructure.Yaml": "Information"
     }
   },
   "StubSettings": {

--- a/tests/SemanticStub.Api.Tests/Integration/HttpLoggingTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/HttpLoggingTests.cs
@@ -71,6 +71,17 @@ public sealed class HttpLoggingTests
     }
 
     [Fact]
+    public void CreateClient_ConfiguresYamlInfrastructureCategoryAtInformation()
+    {
+        using var factory = new HttpLoggingFactory("Production");
+        using var client = factory.CreateClient();
+
+        var configuration = factory.Services.GetRequiredService<IConfiguration>();
+
+        Assert.Equal("Information", configuration["Logging:LogLevel:SemanticStub.Api.Infrastructure.Yaml"]);
+    }
+
+    [Fact]
     public async Task GetPlainText_WritesTextResponseBodyToHttpLogs()
     {
         using var workspace = HttpLoggingWorkspace.Create(


### PR DESCRIPTION
## Summary
- Make stub definition reload-related Information logs visible in the default runtime configuration.
- Keep the global default log level at Warning and scope the override to YAML infrastructure.

## Files Changed
- src/SemanticStub.Api/appsettings.json: add the SemanticStub.Api.Infrastructure.Yaml Information log-level override.
- tests/SemanticStub.Api.Tests/Integration/HttpLoggingTests.cs: cover the new default logging configuration.

## Tests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter HttpLoggingTests

## Notes
- Closes #160
- YAML compatibility, routing, API contracts, and reload behavior are unchanged.