### PR TITLE
feat: add runtime metrics reset endpoint

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -231,6 +231,7 @@ SemanticStub は、runtime inspection endpoint を予約プレフィックス
 - `GET /_semanticstub/runtime/routes/{routeId}` は、1 件の active route の effective runtime detail を返します。
 - `GET /_semanticstub/runtime/scenarios` は、現在の scenario state snapshot を返します。
 - `GET /_semanticstub/runtime/metrics` は、現在のプロセスで処理した実リクエストの集計 metrics を返します。
+- `POST /_semanticstub/runtime/metrics/reset` は、現在のプロセスの集計 metrics と recent request history を reset します。
 - `GET /_semanticstub/runtime/requests?limit=20` は、現在のプロセスで処理した実リクエストの recent request history を返します。
 - `POST /_semanticstub/runtime/test-match` は、実レスポンスを実行せず scenario state も変更せずに virtual request を評価します。
 - `POST /_semanticstub/runtime/explain` は、virtual request の structured match detail を返します。該当する場合は deterministic / semantic evaluation も含みます。
@@ -246,6 +247,7 @@ SemanticStub は、runtime inspection endpoint を予約プレフィックス
 - `/_semanticstub/runtime/routes/{routeId}` は、1 件の route について top-level response と正規化済み conditional match metadata を含む detail view を返します。
 - `/_semanticstub/runtime/scenarios` は、既知の scenario ごとに現在の state と active かどうかを返します。
 - `/_semanticstub/runtime/metrics` は process-local で、total request count、matched / unmatched count、fallback / semantic count、average latency、status code summary、top routes を返します。
+- `/_semanticstub/runtime/metrics/reset` は process-local な aggregate metrics と recent request history を消去します。configuration reload、scenario state の変更、`/_semanticstub/runtime/explain/last` の消去は行いません。
 - `/_semanticstub/runtime/requests` は process-local で、最大 100 件の recent request history を新しい順で返します。各 item には timestamp、method、path、利用可能な場合の route id、status code、elapsed time、match mode、および unmatched request の failure reason が含まれます。`limit` query parameter のデフォルトは `20` です。
 - `/_semanticstub/runtime/test-match` と `/_semanticstub/runtime/explain` は、method、path、省略可能な query / header / body、および省略可能な candidate detail flag を持つ virtual request payload を受け取ります。
 - `/_semanticstub/runtime/explain/last` は process-local で、実リクエストが stub response に match した後だけ更新されます。

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ SemanticStub exposes runtime inspection endpoints under the reserved prefix
 - `GET /_semanticstub/runtime/routes/{routeId}` returns the effective runtime details for one active route.
 - `GET /_semanticstub/runtime/scenarios` returns the current scenario state snapshot.
 - `GET /_semanticstub/runtime/metrics` returns aggregate runtime metrics for real requests handled by the current process.
+- `POST /_semanticstub/runtime/metrics/reset` resets aggregate runtime metrics and recent request history for the current process.
 - `GET /_semanticstub/runtime/requests?limit=20` returns a bounded recent request history for real requests handled by the current process.
 - `POST /_semanticstub/runtime/test-match` evaluates a virtual request without executing a real response or mutating scenario state.
 - `POST /_semanticstub/runtime/explain` returns structured match details for a virtual request, including deterministic and semantic evaluation when applicable.
@@ -280,6 +281,7 @@ Inspection notes:
 - `/_semanticstub/runtime/routes/{routeId}` expands a single route into a stable detail view with top-level responses and normalized conditional match metadata.
 - `/_semanticstub/runtime/scenarios` returns one item per known scenario with its current state and whether it is active.
 - `/_semanticstub/runtime/metrics` is process-local and currently returns total request count, matched and unmatched counts, fallback and semantic counts, average latency, status-code summaries, and top routes.
+- `/_semanticstub/runtime/metrics/reset` clears process-local aggregate metrics and recent request history without reloading configuration, changing scenario state, or clearing `/_semanticstub/runtime/explain/last`.
 - `/_semanticstub/runtime/requests` is process-local and currently returns up to 100 recent real requests in newest-first order. Each item includes timestamp, method, path, resolved route id when available, status code, elapsed time, match mode, and failure reason for unmatched requests. The `limit` query parameter defaults to `20`.
 - `/_semanticstub/runtime/test-match` and `/_semanticstub/runtime/explain` accept a virtual request payload with method, path, optional query/header/body values, and optional candidate-detail flags.
 - `/_semanticstub/runtime/explain/last` is process-local and only updates after a real request produces a matched stub response.

--- a/SemanticStub.http
+++ b/SemanticStub.http
@@ -24,6 +24,10 @@ Accept: application/json
 GET {{host}}/_semanticstub/runtime/metrics
 Accept: application/json
 
+### Runtime inspection reset metrics and recent requests
+POST {{host}}/_semanticstub/runtime/metrics/reset
+Accept: application/json
+
 ### Runtime inspection recent requests
 GET {{host}}/_semanticstub/runtime/requests
 Accept: application/json
@@ -82,6 +86,10 @@ Accept: application/json
 
 ### Runtime observability walkthrough: inspect recent requests
 GET {{host}}/_semanticstub/runtime/requests?limit=3
+Accept: application/json
+
+### Runtime observability walkthrough: reset metrics and recent requests
+POST {{host}}/_semanticstub/runtime/metrics/reset
 Accept: application/json
 
 ### Hello world stub

--- a/src/SemanticStub.Api/Controllers/StubInspectionController.cs
+++ b/src/SemanticStub.Api/Controllers/StubInspectionController.cs
@@ -47,6 +47,14 @@ public sealed class StubInspectionController : ControllerBase
     [HttpGet("metrics")]
     public IActionResult GetMetrics() => Ok(inspectionService.GetRuntimeMetrics());
 
+    /// <summary>Resets aggregate runtime metrics and recent request history for the current process.</summary>
+    [HttpPost("metrics/reset")]
+    public IActionResult ResetMetrics()
+    {
+        inspectionService.ResetRuntimeMetrics();
+        return NoContent();
+    }
+
     /// <summary>Returns the bounded recent request history for real requests handled by the current process.</summary>
     [HttpGet("requests")]
     public IActionResult GetRecentRequests([FromQuery] int limit = 20) => Ok(inspectionService.GetRecentRequests(limit));

--- a/src/SemanticStub.Api/Services/Inspection/IStubInspectionService.cs
+++ b/src/SemanticStub.Api/Services/Inspection/IStubInspectionService.cs
@@ -82,6 +82,11 @@ public interface IStubInspectionService
     void RecordRecentRequest(DateTimeOffset timestamp, string method, string path, MatchExplanationInfo explanation, int statusCode, TimeSpan elapsed);
 
     /// <summary>
+    /// Resets aggregate runtime metrics and recent request history for the current process.
+    /// </summary>
+    void ResetRuntimeMetrics();
+
+    /// <summary>
     /// Resets all configured scenarios back to their initial state.
     /// </summary>
     void ResetScenarioStates();

--- a/src/SemanticStub.Api/Services/Inspection/StubInspectionRuntimeStore.cs
+++ b/src/SemanticStub.Api/Services/Inspection/StubInspectionRuntimeStore.cs
@@ -109,6 +109,22 @@ internal sealed class StubInspectionRuntimeStore
         }
     }
 
+    public void ResetMetrics()
+    {
+        lock (metricsSyncRoot)
+        {
+            statusCodeCounts.Clear();
+            routeRequestCounts.Clear();
+            recentRequests.Clear();
+            totalRequestCount = 0;
+            matchedRequestCount = 0;
+            unmatchedRequestCount = 0;
+            fallbackResponseCount = 0;
+            semanticMatchCount = 0;
+            totalLatencyMilliseconds = 0;
+        }
+    }
+
     public IReadOnlyList<RecentRequestInfo> GetRecentRequests(int limit)
     {
         lock (metricsSyncRoot)

--- a/src/SemanticStub.Api/Services/Inspection/StubInspectionService.cs
+++ b/src/SemanticStub.Api/Services/Inspection/StubInspectionService.cs
@@ -116,6 +116,12 @@ internal sealed class StubInspectionService : IStubInspectionService
     }
 
     /// <inheritdoc/>
+    public void ResetRuntimeMetrics()
+    {
+        runtimeStore.ResetMetrics();
+    }
+
+    /// <inheritdoc/>
     public void ResetScenarioStates()
     {
         scenarioCoordinator.ResetScenarioStates();

--- a/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
@@ -209,6 +209,43 @@ public sealed class StubInspectionEndpointTests : IClassFixture<WebApplicationFa
     }
 
     [Fact]
+    public async Task ResetMetrics_ReturnsNoContent()
+    {
+        var response = await client.PostAsync("/_semanticstub/runtime/metrics/reset", content: null);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ResetMetrics_ClearsMetricsAndRecentRequests()
+    {
+        var routedResponse = await client.GetAsync("/users?role=admin");
+        routedResponse.EnsureSuccessStatusCode();
+
+        var resetResponse = await client.PostAsync("/_semanticstub/runtime/metrics/reset", content: null);
+        Assert.Equal(HttpStatusCode.NoContent, resetResponse.StatusCode);
+
+        var metricsResponse = await client.GetAsync("/_semanticstub/runtime/metrics");
+        metricsResponse.EnsureSuccessStatusCode();
+        var metrics = await metricsResponse.Content.ReadFromJsonAsync<RuntimeMetricsSummaryInfo>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        var requestsResponse = await client.GetAsync("/_semanticstub/runtime/requests");
+        requestsResponse.EnsureSuccessStatusCode();
+        var requests = await requestsResponse.Content.ReadFromJsonAsync<RecentRequestInfo[]>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.NotNull(metrics);
+        Assert.Equal(0, metrics!.TotalRequestCount);
+        Assert.Equal(0, metrics.MatchedRequestCount);
+        Assert.Equal(0, metrics.UnmatchedRequestCount);
+        Assert.Empty(metrics.StatusCodes);
+        Assert.Empty(metrics.TopRoutes);
+        Assert.NotNull(requests);
+        Assert.Empty(requests!);
+    }
+
+    [Fact]
     public async Task GetRecentRequests_ReturnsOk()
     {
         var response = await client.GetAsync("/_semanticstub/runtime/requests");

--- a/tests/SemanticStub.Api.Tests/Unit/StubControllerTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubControllerTests.cs
@@ -424,6 +424,8 @@ public sealed class StubControllerTests
             RecordRecentRequestCallCount++;
         }
 
+        public void ResetRuntimeMetrics() => throw new NotSupportedException();
+
         public void ResetScenarioStates() => throw new NotSupportedException();
 
         public bool ResetScenarioState(string scenarioName) => throw new NotSupportedException();

--- a/tests/SemanticStub.Api.Tests/Unit/StubInspectionServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubInspectionServiceTests.cs
@@ -381,6 +381,37 @@ public sealed class StubInspectionServiceTests
         Assert.Collection(metrics.TopRoutes, route => Assert.Equal("listUsers", route.RouteId));
     }
 
+    [Fact]
+    public void ResetRuntimeMetrics_ClearsMetricsAndRecentRequests_ButKeepsLastMatchExplanation()
+    {
+        var service = CreateService(EmptyDocument());
+        var explanation = CreateRecordedExplanation(matched: true, matchResult: "Matched", routeId: "listUsers", matchMode: "fallback");
+
+        service.RecordRequestMetrics(explanation, StatusCodes.Status200OK, TimeSpan.FromMilliseconds(25));
+        service.RecordRecentRequest(
+            DateTimeOffset.Parse("2026-04-07T00:00:00Z"),
+            HttpMethods.Get,
+            "/users",
+            explanation,
+            StatusCodes.Status200OK,
+            TimeSpan.FromMilliseconds(25));
+        service.RecordLastMatchExplanation(explanation);
+
+        service.ResetRuntimeMetrics();
+
+        var metrics = service.GetRuntimeMetrics();
+        Assert.Equal(0, metrics.TotalRequestCount);
+        Assert.Equal(0, metrics.MatchedRequestCount);
+        Assert.Equal(0, metrics.UnmatchedRequestCount);
+        Assert.Equal(0, metrics.FallbackResponseCount);
+        Assert.Equal(0, metrics.SemanticMatchCount);
+        Assert.Equal(0, metrics.AverageLatencyMilliseconds);
+        Assert.Empty(metrics.StatusCodes);
+        Assert.Empty(metrics.TopRoutes);
+        Assert.Empty(service.GetRecentRequests(20));
+        Assert.Same(explanation, service.GetLastMatchExplanation());
+    }
+
     // ---------------------------------------------------------------------------
     // GetRecentRequests
     // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `POST /_semanticstub/runtime/metrics/reset` to clear process-local runtime metrics and recent request history.
- Keep active configuration, YAML, scenario state, and `explain/last` unchanged.
- Document the new endpoint in English/Japanese READMEs and `SemanticStub.http`.

## Files Changed
- Runtime inspection controller/service/store reset path
- Unit and integration tests for reset behavior
- README.md, README.ja.md, and SemanticStub.http endpoint docs

## Tests
- `dotnet test SemanticStub.sln`

## Notes
- Addresses #161.
- This PR intentionally does not change YAML compatibility or scenario reset behavior.
