### PR TITLE
fix: validate semantic match conditions

### DIFF
--- a/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionValidator.cs
+++ b/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionValidator.cs
@@ -119,6 +119,7 @@ internal sealed class StubDefinitionValidator
         for (var index = 0; index < operation.Matches.Count; index++)
         {
             var match = operation.Matches[index];
+            var semanticMatchErrorCount = errors.Count;
 
             ValidateSemanticMatchDefinition(
                 path,
@@ -127,47 +128,50 @@ internal sealed class StubDefinitionValidator
                 match,
                 errors);
 
-            foreach (var queryKey in match.Query.Keys)
+            if (errors.Count == semanticMatchErrorCount)
             {
-                if (queryParameters.Count > 0 && !queryParameters.Contains(queryKey))
+                foreach (var queryKey in match.Query.Keys)
                 {
-                    errors.Add(
-                        $"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].query['{queryKey}'] must reference a declared query parameter.");
-                }
-            }
-
-            foreach (var queryKey in match.PartialQuery.Keys)
-            {
-                if (queryParameters.Count > 0 && !queryParameters.Contains(queryKey))
-                {
-                    errors.Add(
-                        $"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].x-query-partial['{queryKey}'] must reference a declared query parameter.");
-                }
-            }
-
-            foreach (var queryKey in match.RegexQuery.Keys)
-            {
-                if (queryParameters.Count > 0 && !queryParameters.Contains(queryKey))
-                {
-                    errors.Add(
-                        $"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].x-query-regex['{queryKey}'] must reference a declared query parameter.");
+                    if (queryParameters.Count > 0 && !queryParameters.Contains(queryKey))
+                    {
+                        errors.Add(
+                            $"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].query['{queryKey}'] must reference a declared query parameter.");
+                    }
                 }
 
-                ValidateRegexQueryDefinition(
-                    path,
-                    method,
-                    index,
-                    queryKey,
-                    match.RegexQuery[queryKey],
-                    errors);
-            }
-
-            foreach (var headerKey in match.Headers.Keys)
-            {
-                if (headerParameters.Count > 0 && !headerParameters.Contains(headerKey))
+                foreach (var queryKey in match.PartialQuery.Keys)
                 {
-                    errors.Add(
-                        $"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].headers['{headerKey}'] must reference a declared header parameter.");
+                    if (queryParameters.Count > 0 && !queryParameters.Contains(queryKey))
+                    {
+                        errors.Add(
+                            $"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].x-query-partial['{queryKey}'] must reference a declared query parameter.");
+                    }
+                }
+
+                foreach (var queryKey in match.RegexQuery.Keys)
+                {
+                    if (queryParameters.Count > 0 && !queryParameters.Contains(queryKey))
+                    {
+                        errors.Add(
+                            $"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].x-query-regex['{queryKey}'] must reference a declared query parameter.");
+                    }
+
+                    ValidateRegexQueryDefinition(
+                        path,
+                        method,
+                        index,
+                        queryKey,
+                        match.RegexQuery[queryKey],
+                        errors);
+                }
+
+                foreach (var headerKey in match.Headers.Keys)
+                {
+                    if (headerParameters.Count > 0 && !headerParameters.Contains(headerKey))
+                    {
+                        errors.Add(
+                            $"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].headers['{headerKey}'] must reference a declared header parameter.");
+                    }
                 }
             }
 
@@ -222,16 +226,39 @@ internal sealed class StubDefinitionValidator
         if (string.IsNullOrWhiteSpace(match.SemanticMatch))
         {
             errors.Add($"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].x-semantic-match must not be empty.");
+            return;
         }
 
-        if (match.Query.Count > 0 ||
-            match.PartialQuery.Count > 0 ||
-            match.RegexQuery.Count > 0 ||
-            match.Headers.Count > 0 ||
-            match.Body is not null)
+        var conflicts = new List<string>();
+        if (match.Query.Count > 0)
+        {
+            conflicts.Add("query");
+        }
+
+        if (match.PartialQuery.Count > 0)
+        {
+            conflicts.Add("x-query-partial");
+        }
+
+        if (match.RegexQuery.Count > 0)
+        {
+            conflicts.Add("x-query-regex");
+        }
+
+        if (match.Headers.Count > 0)
+        {
+            conflicts.Add("headers");
+        }
+
+        if (match.Body is not null)
+        {
+            conflicts.Add("body");
+        }
+
+        if (conflicts.Count > 0)
         {
             errors.Add(
-                $"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].x-semantic-match cannot be combined with query, x-query-partial, x-query-regex, headers, or body.");
+                $"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].x-semantic-match cannot be combined with {string.Join(", ", conflicts)}.");
         }
     }
 

--- a/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionValidator.cs
+++ b/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionValidator.cs
@@ -124,7 +124,7 @@ internal sealed class StubDefinitionValidator
                 path,
                 method,
                 index,
-                match.SemanticMatch,
+                match,
                 errors);
 
             foreach (var queryKey in match.Query.Keys)
@@ -211,17 +211,27 @@ internal sealed class StubDefinitionValidator
         string path,
         string method,
         int index,
-        string? semanticMatch,
+        QueryMatchDefinition match,
         ICollection<string> errors)
     {
-        if (semanticMatch is null)
+        if (match.SemanticMatch is null)
         {
             return;
         }
 
-        if (string.IsNullOrWhiteSpace(semanticMatch))
+        if (string.IsNullOrWhiteSpace(match.SemanticMatch))
         {
             errors.Add($"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].x-semantic-match must not be empty.");
+        }
+
+        if (match.Query.Count > 0 ||
+            match.PartialQuery.Count > 0 ||
+            match.RegexQuery.Count > 0 ||
+            match.Headers.Count > 0 ||
+            match.Body is not null)
+        {
+            errors.Add(
+                $"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].x-semantic-match cannot be combined with query, x-query-partial, x-query-regex, headers, or body.");
         }
     }
 

--- a/tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs
@@ -233,6 +233,43 @@ public sealed class StubDefinitionLoaderTests
         Assert.Contains("x-match[0].x-semantic-match must not be empty", exception.Message);
     }
 
+    [Theory]
+    [InlineData("query", "query:\n                        role: admin")]
+    [InlineData("x-query-partial", "x-query-partial:\n                        role: admin")]
+    [InlineData("x-query-regex", "x-query-regex:\n                        role: ^admin-[0-9]+$")]
+    [InlineData("headers", "headers:\n                        X-Env: staging")]
+    [InlineData("body", "body:\n                        role: admin")]
+    public void LoadDefaultDefinition_ThrowsWhenSemanticMatchIsCombinedWithDeterministicCondition(
+        string deterministicField,
+        string deterministicCondition)
+    {
+        using var workspace = TestWorkspace.Create(
+            $$"""
+            openapi: 3.1.0
+            paths:
+              /search:
+                post:
+                  x-match:
+                    - x-semantic-match: find admin users
+                      {{deterministicCondition}}
+                      response:
+                        statusCode: 200
+                        content:
+                          application/json:
+                            example:
+                              message: admin
+            """);
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
+
+        Assert.Contains(
+            "x-match[0].x-semantic-match cannot be combined with query, x-query-partial, x-query-regex, headers, or body",
+            exception.Message);
+        Assert.Contains(deterministicField, exception.Message);
+    }
+
     [Fact]
     public void LoadDefaultDefinition_ThrowsForInvalidMatchedResponse()
     {

--- a/tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs
@@ -233,6 +233,35 @@ public sealed class StubDefinitionLoaderTests
         Assert.Contains("x-match[0].x-semantic-match must not be empty", exception.Message);
     }
 
+    [Fact]
+    public void LoadDefaultDefinition_DoesNotReportCombinationErrorWhenSemanticMatchIsEmpty()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+              /search:
+                post:
+                  x-match:
+                    - x-semantic-match: "   "
+                      query:
+                        role: admin
+                      response:
+                        statusCode: 200
+                        content:
+                          application/json:
+                            example:
+                              message: admin
+            """);
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
+
+        Assert.Contains("x-match[0].x-semantic-match must not be empty", exception.Message);
+        Assert.DoesNotContain("x-match[0].x-semantic-match cannot be combined", exception.Message);
+    }
+
     [Theory]
     [InlineData("query", "query:\n                        role: admin")]
     [InlineData("x-query-partial", "x-query-partial:\n                        role: admin")]
@@ -265,9 +294,42 @@ public sealed class StubDefinitionLoaderTests
         var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
 
         Assert.Contains(
-            "x-match[0].x-semantic-match cannot be combined with query, x-query-partial, x-query-regex, headers, or body",
+            $"x-match[0].x-semantic-match cannot be combined with {deterministicField}.",
             exception.Message);
-        Assert.Contains(deterministicField, exception.Message);
+    }
+
+    [Fact]
+    public void LoadDefaultDefinition_DoesNotReportParameterDeclarationErrorsWhenSemanticMatchIsCombinedWithQuery()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+              /search:
+                post:
+                  parameters:
+                    - name: status
+                      in: query
+                      schema:
+                        type: string
+                  x-match:
+                    - x-semantic-match: find admin users
+                      query:
+                        role: admin
+                      response:
+                        statusCode: 200
+                        content:
+                          application/json:
+                            example:
+                              message: admin
+            """);
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
+
+        Assert.Contains("x-match[0].x-semantic-match cannot be combined with query.", exception.Message);
+        Assert.DoesNotContain("x-match[0].query['role'] must reference a declared query parameter", exception.Message);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Validate that `x-semantic-match` entries are not combined with deterministic match conditions.
- Reject mixed entries with `query`, `x-query-partial`, `x-query-regex`, `headers`, or `body`.
- Report only the deterministic fields that are actually present in each conflict.

## Files Changed
- `src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionValidator.cs`
- `tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs`

## Tests
- `dotnet test SemanticStub.sln` (340 passed)

## Notes
- Keeps runtime matching behavior and YAML structure unchanged.
- Addresses #158.