### PR TITLE
Remove redundant ConfigureAwait(false) calls throughout ASP.NET Core services

### DIFF
--- a/src/SemanticStub.Api/Controllers/StubController.cs
+++ b/src/SemanticStub.Api/Controllers/StubController.cs
@@ -71,12 +71,12 @@ public sealed class StubController : ControllerBase
     {
         var stopwatch = Stopwatch.StartNew();
         var requestPath = NormalizeRequestPath(path);
-        var dispatch = await DispatchRequestAsync(method, requestPath).ConfigureAwait(false);
+        var dispatch = await DispatchRequestAsync(method, requestPath);
         int? statusCode = null;
 
         try
         {
-            return await CreateActionResultAsync(dispatch, requestPath, code => statusCode = code).ConfigureAwait(false);
+            return await CreateActionResultAsync(dispatch, requestPath, code => statusCode = code);
         }
         finally
         {
@@ -99,8 +99,8 @@ public sealed class StubController : ControllerBase
         var query = Request.Query.ToDictionary(entry => entry.Key, entry => entry.Value, StringComparer.Ordinal);
         var headers = Request.Headers.ToDictionary(entry => entry.Key, entry => entry.Value.ToString(), StringComparer.OrdinalIgnoreCase);
         Request.EnableBuffering();
-        var requestBody = await ReadRequestBodyAsync().ConfigureAwait(false);
-        return await stubService.DispatchAsync(method, requestPath, query, headers, requestBody).ConfigureAwait(false);
+        var requestBody = await ReadRequestBodyAsync();
+        return await stubService.DispatchAsync(method, requestPath, query, headers, requestBody);
     }
 
     private async Task<IActionResult> CreateActionResultAsync(StubDispatchResult dispatch, string requestPath, Action<int> setStatusCode)
@@ -134,7 +134,7 @@ public sealed class StubController : ControllerBase
 
         if (response.DelayMilliseconds is > 0)
         {
-            await Task.Delay(response.DelayMilliseconds.Value, HttpContext.RequestAborted).ConfigureAwait(false);
+            await Task.Delay(response.DelayMilliseconds.Value, HttpContext.RequestAborted);
         }
 
         CopyResponseHeaders(response);

--- a/src/SemanticStub.Api/Controllers/StubInspectionController.cs
+++ b/src/SemanticStub.Api/Controllers/StubInspectionController.cs
@@ -63,14 +63,14 @@ public sealed class StubInspectionController : ControllerBase
     [HttpPost("test-match")]
     public async Task<IActionResult> TestMatch([FromBody] MatchRequestInfo request)
     {
-        return Ok(await inspectionService.TestMatchAsync(request).ConfigureAwait(false));
+        return Ok(await inspectionService.TestMatchAsync(request));
     }
 
     /// <summary>Explains how the runtime evaluated a virtual request without executing a response.</summary>
     [HttpPost("explain")]
     public async Task<IActionResult> ExplainMatch([FromBody] MatchRequestInfo request)
     {
-        return Ok(await inspectionService.ExplainMatchAsync(request).ConfigureAwait(false));
+        return Ok(await inspectionService.ExplainMatchAsync(request));
     }
 
     /// <summary>Returns the explanation captured for the most recent real request.</summary>

--- a/src/SemanticStub.Api/Services/Inspection/StubInspectionService.cs
+++ b/src/SemanticStub.Api/Services/Inspection/StubInspectionService.cs
@@ -81,7 +81,7 @@ internal sealed class StubInspectionService : IStubInspectionService
     /// <inheritdoc/>
     public async Task<MatchSimulationInfo> TestMatchAsync(MatchRequestInfo request)
     {
-        var explanation = await stubService.ExplainMatchAsync(request).ConfigureAwait(false);
+        var explanation = await stubService.ExplainMatchAsync(request);
         return explanation.Result;
     }
 

--- a/src/SemanticStub.Api/Services/Resolution/IStubService.cs
+++ b/src/SemanticStub.Api/Services/Resolution/IStubService.cs
@@ -148,7 +148,7 @@ public interface IStubService
         IReadOnlyDictionary<string, string> headers,
         string? body)
     {
-        var dispatch = await DispatchAsync(method, path, query, headers, body).ConfigureAwait(false);
+        var dispatch = await DispatchAsync(method, path, query, headers, body);
         return (dispatch.Result, dispatch.Response);
     }
 

--- a/src/SemanticStub.Api/Services/Resolution/StubDispatchSelector.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubDispatchSelector.cs
@@ -100,7 +100,7 @@ internal sealed class StubDispatchSelector
                 body,
                 operation.Matches,
                 candidate => scenarioService.IsMatch(candidate.Response.Scenario),
-                includeCandidateScores: includeSemanticCandidates).ConfigureAwait(false);
+                includeCandidateScores: includeSemanticCandidates);
 
         if (semanticExplanation.SelectedCandidate is not null)
         {

--- a/src/SemanticStub.Api/Services/Resolution/StubService.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubService.cs
@@ -207,7 +207,7 @@ public sealed class StubService : IStubService
             body,
             mutateScenarioState: true,
             includeCandidates: true,
-            includeSemanticCandidates: false).ConfigureAwait(false);
+            includeSemanticCandidates: false);
     }
 
     /// <inheritdoc/>
@@ -221,7 +221,7 @@ public sealed class StubService : IStubService
             NormalizeBody(request.Body),
             mutateScenarioState: false,
             includeCandidates: request.IncludeCandidates,
-            includeSemanticCandidates: request.IncludeSemanticCandidates).ConfigureAwait(false);
+            includeSemanticCandidates: request.IncludeSemanticCandidates);
 
         return dispatch.Explanation;
     }
@@ -252,10 +252,10 @@ public sealed class StubService : IStubService
         if (OperationUsesScenario(operation))
         {
             return await scenarioService.ExecuteLockedAsync(
-                () => DispatchCoreAsync(method, path, pathPattern, pathItem, operation, query, headers, body, mutateScenarioState, includeCandidates, includeSemanticCandidates)).ConfigureAwait(false);
+                () => DispatchCoreAsync(method, path, pathPattern, pathItem, operation, query, headers, body, mutateScenarioState, includeCandidates, includeSemanticCandidates));
         }
 
-        return await DispatchCoreAsync(method, path, pathPattern, pathItem, operation, query, headers, body, mutateScenarioState, includeCandidates, includeSemanticCandidates).ConfigureAwait(false);
+        return await DispatchCoreAsync(method, path, pathPattern, pathItem, operation, query, headers, body, mutateScenarioState, includeCandidates, includeSemanticCandidates);
     }
 
     /// <inheritdoc/>
@@ -266,7 +266,7 @@ public sealed class StubService : IStubService
         IReadOnlyDictionary<string, string> headers,
         string? body)
     {
-        var dispatch = await DispatchAsync(method, path, query, headers, body).ConfigureAwait(false);
+        var dispatch = await DispatchAsync(method, path, query, headers, body);
         return (dispatch.Result, dispatch.Response);
     }
 
@@ -304,7 +304,7 @@ public sealed class StubService : IStubService
             headers,
             body,
             mutateScenarioState,
-            includeSemanticCandidates).ConfigureAwait(false);
+            includeSemanticCandidates);
 
         SemanticMatchInfo? semanticEvaluationInfo = null;
         if (selection.SemanticExplanation.Attempted)

--- a/src/SemanticStub.Api/Services/Scenario/ScenarioService.cs
+++ b/src/SemanticStub.Api/Services/Scenario/ScenarioService.cs
@@ -143,10 +143,10 @@ public sealed class ScenarioService
     /// <param name="action">The scenario-aware async operation to run atomically.</param>
     public async Task<T> ExecuteLockedAsync<T>(Func<Task<T>> action)
     {
-        await semaphore.WaitAsync().ConfigureAwait(false);
+        await semaphore.WaitAsync();
         try
         {
-            return await action().ConfigureAwait(false);
+            return await action();
         }
         finally
         {

--- a/src/SemanticStub.Api/Services/Semantic/SemanticEmbeddingClient.cs
+++ b/src/SemanticStub.Api/Services/Semantic/SemanticEmbeddingClient.cs
@@ -37,11 +37,11 @@ internal sealed class SemanticEmbeddingClient
     {
         var httpClient = httpClientFactory.CreateClient(HttpClientName);
         var endpoint = NormalizeEndpoint(settings.Endpoint!);
-        var response = await httpClient.PostAsJsonAsync(endpoint, new EmbedRequest(inputs)).ConfigureAwait(false);
+        var response = await httpClient.PostAsJsonAsync(endpoint, new EmbedRequest(inputs));
         response.EnsureSuccessStatusCode();
 
-        using var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-        using var document = await JsonDocument.ParseAsync(responseStream).ConfigureAwait(false);
+        using var responseStream = await response.Content.ReadAsStreamAsync();
+        using var document = await JsonDocument.ParseAsync(responseStream);
 
         if (TryReadEmbeddings(document.RootElement, inputs.Count, out var embeddings))
         {

--- a/src/SemanticStub.Api/Services/Semantic/SemanticMatcherService.cs
+++ b/src/SemanticStub.Api/Services/Semantic/SemanticMatcherService.cs
@@ -45,7 +45,7 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
             body,
             candidates,
             candidateFilter,
-            includeCandidateScores: false).ConfigureAwait(false);
+            includeCandidateScores: false);
 
         return explanation.SelectedCandidate;
     }
@@ -104,7 +104,7 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
                 query,
                 headers,
                 body,
-                semanticCandidates).ConfigureAwait(false);
+                semanticCandidates);
 
             return ScoreAndLogExplanation(
                 path,
@@ -188,7 +188,7 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
         };
 
         allTexts.AddRange(semanticCandidates.Select(candidate => candidate.SemanticMatch!));
-        return await embeddingClient.GetEmbeddingsAsync(allTexts).ConfigureAwait(false);
+        return await embeddingClient.GetEmbeddingsAsync(allTexts);
     }
 
     private SemanticMatchExplanation ScoreAndLogExplanation(


### PR DESCRIPTION
ASP.NET Core does not have a SynchronizationContext, so ConfigureAwait(false)
has no effect on thread continuation behaviour or performance. Removing it
eliminates noise across controllers and service classes without any functional
change.

https://claude.ai/code/session_016mGttbc2FrZYwXZcEifWn6