### PR TITLE
feat: unify match operators

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -101,6 +101,11 @@ paths:
       x-match:
         - query:
             role: admin
+            region:
+              regex: ^ap-.*
+          headers:
+            X-Env:
+              equals: staging
           response:
             statusCode: 200
             content:
@@ -121,10 +126,8 @@ paths:
 
 各 `x-match` エントリには次を含められます。
 
-- `query`: 完全一致の query string 条件
-- `x-query-regex`: regex による query string 条件
-- `x-query-partial`: 部分一致の query string 条件
-- `headers`: 完全一致の header 条件
+- `query`: scalar の `equals` 省略形、または明示的な `equals` / `regex` operator による query string 条件
+- `headers`: scalar の `equals` 省略形、または明示的な `equals` / `regex` operator による header 条件
 - `body`: リクエストボディ条件
 - `x-semantic-match`: セマンティックフォールバックマッチングに使う自然言語の説明
 - `response`: 条件に一致したときに返すレスポンス
@@ -135,12 +138,12 @@ paths:
 - `x-match` のレスポンスは、通常レスポンスと同じく `content`、`headers`、`x-delay`、`x-response-file` をサポートします。
 - query、header、body 条件は、1 つの `x-match` 内では AND 条件として組み合わされます。
 - `x-match` で使う query と header のキーは、path または operation にパラメータ宣言がある場合、その OpenAPI 宣言を参照している必要があります。
-- `query` は単一値の完全一致、順序付きの繰り返し値、および `integer`、`number`、`boolean` など宣言済み OpenAPI query parameter type に対する型付き比較をサポートします。
-- `x-query-regex` は query 値に対して regex マッチを行います。
-- `x-query-partial` は部分文字列一致を行います。複数候補が成功した場合は、完全一致の `query` が regex や partial より優先されます。
+- scalar の `query` / `headers` 値は `equals` の省略形として扱われます。
+- `query.equals` は単一値の完全一致、順序付きの繰り返し値、および `integer`、`number`、`boolean` など宣言済み OpenAPI query parameter type に対する型付き比較をサポートします。
+- `query.regex` と `headers.regex` は regex マッチを行います。contains / starts-with / ends-with は `.*value.*`、`^value`、`value$` のような regex pattern で表現できます。
 - `body` マッチは現在 JSON リクエストボディに対して適用されます。object に対する body マッチは部分一致なので、追加プロパティを含んでいても一致できます。
 - 不正な JSON リクエストボディは `body` 条件に一致しません。
-- `x-semantic-match` エントリは、すべての決定的な条件が失敗したときのみ評価されます。アプリケーション設定でセマンティックマッチングを有効化する必要があります。`x-semantic-match` を含むエントリに `query`、`x-query-regex`、`x-query-partial`、`headers`、`body` を同時に指定することはできません。
+- `x-semantic-match` エントリは、すべての決定的な条件が失敗したときのみ評価されます。アプリケーション設定でセマンティックマッチングを有効化する必要があります。`x-semantic-match` を含むエントリに `query`、`headers`、`body` を同時に指定することはできません。
 - どの `x-match` も成功しない場合、SemanticStub は標準の `responses` セクションへフォールバックします。
 - 複数の `x-match` が成功した場合、SemanticStub はより具体的な候補を選び、狭い条件が広い条件より優先されます。
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ paths:
       x-match:
         - query:
             role: admin
+            region:
+              regex: ^ap-.*
+          headers:
+            X-Env:
+              equals: staging
           response:
             statusCode: 200
             content:
@@ -132,10 +137,10 @@ paths:
 
 Each `x-match` entry may contain:
 
-- `query`: exact query-string matches.
-- `x-query-regex`: regex query-string matches.
-- `x-query-partial`: partial query-string matches.
-- `headers`: exact header matches.
+- `query`: query-string matches using scalar `equals` shorthand or explicit
+  `equals` / `regex` operators.
+- `headers`: header matches using scalar `equals` shorthand or explicit
+  `equals` / `regex` operators.
 - `body`: exact body match data.
 - `x-semantic-match`: natural-language description used for semantic fallback matching.
 - `response`: the response returned when the match succeeds.
@@ -149,12 +154,13 @@ Notes:
   single `x-match` entry.
 - Query and header keys used by `x-match` must reference parameters declared in
   OpenAPI when those parameters are present on the path or operation.
-- `query` supports exact single-value matches, ordered repeated values, and
-  typed comparison for declared OpenAPI query parameter types such as
+- Scalar `query` and `headers` values are shorthand for `equals`.
+- `query.equals` supports exact single-value matches, ordered repeated values,
+  and typed comparison for declared OpenAPI query parameter types such as
   `integer`, `number`, and `boolean`.
-- `x-query-regex` performs regex matching against query values.
-- `x-query-partial` performs substring matching. Exact `query` matches are
-  preferred over regex and partial matches when multiple candidates succeed.
+- `query.regex` and `headers.regex` perform regex matching. Use regex patterns
+  such as `.*value.*`, `^value`, or `value$` for contains, starts-with, or
+  ends-with matches.
 - `body` matching currently applies to JSON request bodies. Body matching is
   partial for objects, so a request may contain additional properties and still
   match.
@@ -162,7 +168,7 @@ Notes:
 - `x-semantic-match` entries are evaluated only after all deterministic
   conditions fail. They require semantic matching to be enabled in application
   configuration. An entry with `x-semantic-match` must not be combined with
-  `query`, `x-query-regex`, `x-query-partial`, `headers`, or `body`.
+  `query`, `headers`, or `body`.
 - When no `x-match` entry succeeds, SemanticStub falls back to the standard
   `responses` section.
 - When multiple `x-match` entries succeed, SemanticStub chooses the most

--- a/SemanticStub.http
+++ b/SemanticStub.http
@@ -117,7 +117,7 @@ Accept: application/json
 GET {{host}}/users?role=guest
 Accept: application/json
 
-### Users stub filtered by partial query match
+### Users stub filtered by regex query match
 GET {{host}}/users?role=super-admin
 Accept: application/json
 
@@ -129,7 +129,7 @@ Accept: application/json
 GET {{host}}/search?tag=beta&tag=alpha
 Accept: application/json
 
-### Regex users stub filtered by x-query-regex
+### Regex users stub filtered by query regex operator
 GET {{host}}/regex-users?role=admin-123
 Accept: application/json
 

--- a/samples/basic-routing.yaml
+++ b/samples/basic-routing.yaml
@@ -85,8 +85,9 @@ paths:
                       name: Bob
                       role: guest
 
-        - x-query-partial:
-            role: admin
+        - query:
+            role:
+              regex: .*admin.*
           response:
             statusCode: 200
             content:
@@ -94,8 +95,8 @@ paths:
                 example:
                   users:
                     - id: 5
-                      name: Partial Alice
-                      role: partial-admin
+                      name: Regex Alice
+                      role: regex-admin
 
       responses:
         '200':
@@ -161,8 +162,9 @@ paths:
           schema:
             type: string
       x-match:
-        - x-query-regex:
-            role: ^admin-[0-9]+$
+        - query:
+            role:
+              regex: ^admin-[0-9]+$
           response:
             statusCode: 200
             content:

--- a/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionNormalizer.cs
+++ b/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionNormalizer.cs
@@ -69,16 +69,11 @@ internal sealed class StubDefinitionNormalizer
                         entry => entry.Key,
                         entry => StubExampleSerializer.NormalizeValue(entry.Value),
                         StringComparer.Ordinal),
-                    PartialQuery = match.PartialQuery.ToDictionary(
-                        entry => entry.Key,
-                        entry => StubExampleSerializer.NormalizeValue(entry.Value),
-                        StringComparer.Ordinal),
-                    RegexQuery = match.RegexQuery.ToDictionary(
-                        entry => entry.Key,
-                        entry => StubExampleSerializer.NormalizeValue(entry.Value),
-                        StringComparer.Ordinal),
                     SemanticMatch = match.SemanticMatch,
-                    Headers = new Dictionary<string, string>(match.Headers, StringComparer.OrdinalIgnoreCase),
+                    Headers = match.Headers.ToDictionary(
+                        entry => entry.Key,
+                        entry => StubExampleSerializer.NormalizeValue(entry.Value),
+                        StringComparer.OrdinalIgnoreCase),
                     Body = StubExampleSerializer.NormalizeValue(match.Body),
                     Response = new QueryMatchResponseDefinition
                     {

--- a/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionValidator.cs
+++ b/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionValidator.cs
@@ -130,6 +130,8 @@ internal sealed class StubDefinitionValidator
 
             if (errors.Count == semanticMatchErrorCount)
             {
+                ValidateLegacyQueryMatchFields(path, method, index, match, errors);
+
                 foreach (var queryKey in match.Query.Keys)
                 {
                     if (queryParameters.Count > 0 && !queryParameters.Contains(queryKey))
@@ -137,31 +139,14 @@ internal sealed class StubDefinitionValidator
                         errors.Add(
                             $"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].query['{queryKey}'] must reference a declared query parameter.");
                     }
-                }
 
-                foreach (var queryKey in match.PartialQuery.Keys)
-                {
-                    if (queryParameters.Count > 0 && !queryParameters.Contains(queryKey))
-                    {
-                        errors.Add(
-                            $"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].x-query-partial['{queryKey}'] must reference a declared query parameter.");
-                    }
-                }
-
-                foreach (var queryKey in match.RegexQuery.Keys)
-                {
-                    if (queryParameters.Count > 0 && !queryParameters.Contains(queryKey))
-                    {
-                        errors.Add(
-                            $"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].x-query-regex['{queryKey}'] must reference a declared query parameter.");
-                    }
-
-                    ValidateRegexQueryDefinition(
+                    ValidateMatchOperatorDefinition(
                         path,
                         method,
                         index,
+                        "query",
                         queryKey,
-                        match.RegexQuery[queryKey],
+                        match.Query[queryKey],
                         errors);
                 }
 
@@ -172,6 +157,15 @@ internal sealed class StubDefinitionValidator
                         errors.Add(
                             $"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].headers['{headerKey}'] must reference a declared header parameter.");
                     }
+
+                    ValidateMatchOperatorDefinition(
+                        path,
+                        method,
+                        index,
+                        "headers",
+                        headerKey,
+                        match.Headers[headerKey],
+                        errors);
                 }
             }
 
@@ -401,11 +395,74 @@ internal sealed class StubDefinitionValidator
         }
     }
 
-    private static void ValidateRegexQueryDefinition(
+    private static void ValidateLegacyQueryMatchFields(
         string path,
         string method,
         int index,
-        string queryKey,
+        QueryMatchDefinition match,
+        ICollection<string> errors)
+    {
+        if (match.PartialQuery.Count > 0)
+        {
+            errors.Add($"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].x-query-partial is no longer supported; use query.<name>.regex instead.");
+        }
+
+        if (match.RegexQuery.Count > 0)
+        {
+            errors.Add($"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].x-query-regex is no longer supported; use query.<name>.regex instead.");
+        }
+    }
+
+    private static void ValidateMatchOperatorDefinition(
+        string path,
+        string method,
+        int index,
+        string fieldName,
+        string key,
+        object? value,
+        ICollection<string> errors)
+    {
+        var operatorKeys = MatchOperatorDefinition.GetKeys(value);
+
+        if (operatorKeys.Count == 0)
+        {
+            if (value is IDictionary)
+            {
+                errors.Add(
+                    $"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].{fieldName}['{key}'] must define at least one supported operator: equals, regex.");
+            }
+
+            return;
+        }
+
+        foreach (var operatorKey in operatorKeys)
+        {
+            if (operatorKey is not MatchOperatorDefinition.EqualsOperator and not MatchOperatorDefinition.RegexOperator)
+            {
+                errors.Add(
+                    $"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].{fieldName}['{key}'] uses unsupported operator '{operatorKey}'.");
+            }
+        }
+
+        if (operatorKeys.Contains(MatchOperatorDefinition.EqualsOperator) &&
+            operatorKeys.Contains(MatchOperatorDefinition.RegexOperator))
+        {
+            errors.Add(
+                $"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].{fieldName}['{key}'] must not combine equals and regex operators.");
+        }
+
+        if (MatchOperatorDefinition.TryGetRegex(value, out var regex))
+        {
+            ValidateRegexDefinition(path, method, index, fieldName, key, regex, errors);
+        }
+    }
+
+    private static void ValidateRegexDefinition(
+        string path,
+        string method,
+        int index,
+        string fieldName,
+        string key,
         object? value,
         ICollection<string> errors)
     {
@@ -415,14 +472,14 @@ internal sealed class StubDefinitionValidator
             if (!enumerator.MoveNext())
             {
                 errors.Add(
-                    $"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].x-query-regex['{queryKey}'] must be a string pattern.");
+                    $"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].{fieldName}['{key}'].regex must be a string pattern.");
                 return;
             }
 
             var patternIndex = 0;
             do
             {
-                ValidateRegexPattern(path, method, index, queryKey, enumerator.Current, $"[{patternIndex}]", errors);
+                ValidateRegexPattern(path, method, index, fieldName, key, enumerator.Current, $"[{patternIndex}]", errors);
                 patternIndex++;
             }
             while (enumerator.MoveNext());
@@ -430,14 +487,15 @@ internal sealed class StubDefinitionValidator
             return;
         }
 
-        ValidateRegexPattern(path, method, index, queryKey, value, string.Empty, errors);
+        ValidateRegexPattern(path, method, index, fieldName, key, value, string.Empty, errors);
     }
 
     private static void ValidateRegexPattern(
         string path,
         string method,
         int index,
-        string queryKey,
+        string fieldName,
+        string key,
         object? value,
         string suffix,
         ICollection<string> errors)
@@ -445,7 +503,7 @@ internal sealed class StubDefinitionValidator
         if (value is not string pattern)
         {
             errors.Add(
-                $"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].x-query-regex['{queryKey}']{suffix} must be a string pattern.");
+                $"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].{fieldName}['{key}'].regex{suffix} must be a string pattern.");
             return;
         }
 
@@ -456,7 +514,7 @@ internal sealed class StubDefinitionValidator
         catch (ArgumentException)
         {
             errors.Add(
-                $"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].x-query-regex['{queryKey}']{suffix} must be a valid regex pattern.");
+                $"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].{fieldName}['{key}'].regex{suffix} must be a valid regex pattern.");
         }
     }
 }

--- a/src/SemanticStub.Api/Inspection/StubRouteConditionInfo.cs
+++ b/src/SemanticStub.Api/Inspection/StubRouteConditionInfo.cs
@@ -14,12 +14,6 @@ public sealed class StubRouteConditionInfo
     /// <summary>Gets the exact query parameter names constrained by the candidate.</summary>
     public IReadOnlyList<string> ExactQueryKeys { get; init; } = [];
 
-    /// <summary>Gets whether the candidate defines partial query constraints.</summary>
-    public bool HasPartialQuery { get; init; }
-
-    /// <summary>Gets the partial query parameter names constrained by the candidate.</summary>
-    public IReadOnlyList<string> PartialQueryKeys { get; init; } = [];
-
     /// <summary>Gets whether the candidate defines regex query constraints.</summary>
     public bool HasRegexQuery { get; init; }
 

--- a/src/SemanticStub.Api/Models/MatchOperatorDefinition.cs
+++ b/src/SemanticStub.Api/Models/MatchOperatorDefinition.cs
@@ -1,0 +1,72 @@
+using System.Collections;
+
+namespace SemanticStub.Api.Models;
+
+internal static class MatchOperatorDefinition
+{
+    public const string EqualsOperator = "equals";
+    public const string RegexOperator = "regex";
+
+    public static bool IsOperatorMap(object? value)
+        => TryGetMap(value, out var map) &&
+           (map.ContainsKey(EqualsOperator) || map.ContainsKey(RegexOperator));
+
+    public static bool TryGetEquals(object? value, out object? equals)
+    {
+        if (TryGetMap(value, out var map) && map.TryGetValue(EqualsOperator, out equals))
+        {
+            return true;
+        }
+
+        if (IsOperatorMap(value))
+        {
+            equals = null;
+            return false;
+        }
+
+        equals = value;
+        return true;
+    }
+
+    public static bool TryGetRegex(object? value, out object? regex)
+    {
+        if (TryGetMap(value, out var map) && map.TryGetValue(RegexOperator, out regex))
+        {
+            return true;
+        }
+
+        regex = null;
+        return false;
+    }
+
+    public static IReadOnlyCollection<string> GetKeys(object? value)
+    {
+        if (!TryGetMap(value, out var map))
+        {
+            return [];
+        }
+
+        return map.Keys;
+    }
+
+    private static bool TryGetMap(object? value, out Dictionary<string, object?> map)
+    {
+        switch (value)
+        {
+            case IDictionary<string, object?> typed:
+                map = new Dictionary<string, object?>(typed, StringComparer.Ordinal);
+                return true;
+            case IDictionary dictionary:
+                map = new Dictionary<string, object?>(StringComparer.Ordinal);
+                foreach (DictionaryEntry entry in dictionary)
+                {
+                    map[entry.Key.ToString() ?? string.Empty] = entry.Value;
+                }
+
+                return true;
+            default:
+                map = [];
+                return false;
+        }
+    }
+}

--- a/src/SemanticStub.Api/Models/QueryMatchDefinition.cs
+++ b/src/SemanticStub.Api/Models/QueryMatchDefinition.cs
@@ -15,7 +15,7 @@ public sealed class QueryMatchDefinition
     [YamlMember(Alias = "x-semantic-match", ApplyNamingConventions = false)]
     public string? SemanticMatch { get; init; }
 
-    public Dictionary<string, string> Headers { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+    public Dictionary<string, object?> Headers { get; init; } = new(StringComparer.OrdinalIgnoreCase);
 
     public object? Body { get; init; }
 

--- a/src/SemanticStub.Api/Services/Inspection/StubInspectionDocumentProjector.cs
+++ b/src/SemanticStub.Api/Services/Inspection/StubInspectionDocumentProjector.cs
@@ -127,12 +127,10 @@ internal static class StubInspectionDocumentProjector
             .Select((match, index) => new StubRouteConditionInfo
             {
                 CandidateIndex = index,
-                HasExactQuery = match.Query.Count > 0,
-                ExactQueryKeys = OrderKeys(match.Query.Keys),
-                HasPartialQuery = match.PartialQuery.Count > 0,
-                PartialQueryKeys = OrderKeys(match.PartialQuery.Keys),
-                HasRegexQuery = match.RegexQuery.Count > 0,
-                RegexQueryKeys = OrderKeys(match.RegexQuery.Keys),
+                HasExactQuery = GetEqualsKeys(match.Query).Count > 0,
+                ExactQueryKeys = GetEqualsKeys(match.Query),
+                HasRegexQuery = GetRegexKeys(match.Query).Count > 0,
+                RegexQueryKeys = GetRegexKeys(match.Query),
                 HeaderKeys = OrderKeys(match.Headers.Keys),
                 HasBody = match.Body is not null,
                 UsesSemanticMatching = match.SemanticMatch is not null,
@@ -157,6 +155,20 @@ internal static class StubInspectionDocumentProjector
 
     private static IReadOnlyList<string> OrderKeys(IEnumerable<string> keys)
         => keys.OrderBy(key => key, StringComparer.Ordinal).ToList();
+
+    private static IReadOnlyList<string> GetEqualsKeys(IReadOnlyDictionary<string, object?> fields)
+        => fields
+            .Where(field => MatchOperatorDefinition.TryGetEquals(field.Value, out _))
+            .Select(field => field.Key)
+            .OrderBy(key => key, StringComparer.Ordinal)
+            .ToList();
+
+    private static IReadOnlyList<string> GetRegexKeys(IReadOnlyDictionary<string, object?> fields)
+        => fields
+            .Where(field => MatchOperatorDefinition.TryGetRegex(field.Value, out _))
+            .Select(field => field.Key)
+            .OrderBy(key => key, StringComparer.Ordinal)
+            .ToList();
 
     private static string GetRouteId(string method, string path, OperationDefinition operation)
         => string.IsNullOrEmpty(operation.OperationId)

--- a/src/SemanticStub.Api/Services/Matching/MatcherService.cs
+++ b/src/SemanticStub.Api/Services/Matching/MatcherService.cs
@@ -87,7 +87,7 @@ public sealed class MatcherService
             {
                 Candidate = candidate,
                 QueryMatched = IsQueryMatch(candidate, matchContext),
-                HeaderMatched = IsExactHeaderMatch(candidate.Headers, matchContext.Headers),
+                HeaderMatched = IsHeaderMatch(candidate.Headers, matchContext.Headers),
                 BodyMatched = jsonBodyMatcher.IsMatch(candidate.Body, matchContext.RequestBody),
             });
         }
@@ -119,7 +119,7 @@ public sealed class MatcherService
         MatchEvaluationContext matchContext)
     {
         return IsQueryMatch(candidate, matchContext) &&
-               IsExactHeaderMatch(candidate.Headers, matchContext.Headers) &&
+               IsHeaderMatch(candidate.Headers, matchContext.Headers) &&
                jsonBodyMatcher.IsMatch(candidate.Body, matchContext.RequestBody);
     }
 
@@ -128,8 +128,7 @@ public sealed class MatcherService
         MatchEvaluationContext matchContext)
     {
         return queryValueMatcher.IsExactMatch(match.Query, matchContext.Query, matchContext.QueryParameterTypes) &&
-               regexQueryMatcher.IsMatch(match.RegexQuery, matchContext.Query) &&
-               queryValueMatcher.IsPartialMatch(match.PartialQuery, matchContext.Query, matchContext.QueryParameterTypes);
+               regexQueryMatcher.IsMatch(match.Query, matchContext.Query);
     }
 
     private MatchEvaluationContext CreateMatchContext(
@@ -144,17 +143,15 @@ public sealed class MatcherService
         return new MatchEvaluationContext(query, headers, queryParameterTypes, bodyDocument);
     }
 
-    private static bool IsExactHeaderMatch(IReadOnlyDictionary<string, string> expected, IReadOnlyDictionary<string, string> actual)
+    private bool IsHeaderMatch(IReadOnlyDictionary<string, object?> expected, IReadOnlyDictionary<string, string> actual)
     {
-        foreach (var pair in expected)
-        {
-            if (!actual.TryGetValue(pair.Key, out var value) || value != pair.Value)
-            {
-                return false;
-            }
-        }
+        var actualValues = actual.ToDictionary(
+            entry => entry.Key,
+            entry => new StringValues(entry.Value),
+            StringComparer.OrdinalIgnoreCase);
 
-        return true;
+        return queryValueMatcher.IsExactMatch(expected, actualValues, new Dictionary<string, string>(StringComparer.Ordinal)) &&
+               regexQueryMatcher.IsMatch(expected, actualValues);
     }
 
     private readonly struct MatchEvaluationContext : IDisposable

--- a/src/SemanticStub.Api/Services/Matching/QueryMatchSpecificityComparer.cs
+++ b/src/SemanticStub.Api/Services/Matching/QueryMatchSpecificityComparer.cs
@@ -28,7 +28,7 @@ internal sealed class QueryMatchSpecificityComparer : IComparer<QueryMatchDefini
             return -1;
         }
 
-        var exactQueryComparison = y.Query.Count.CompareTo(x.Query.Count);
+        var exactQueryComparison = GetEqualsSpecificity(y.Query).CompareTo(GetEqualsSpecificity(x.Query));
 
         if (exactQueryComparison != 0)
         {
@@ -42,12 +42,27 @@ internal sealed class QueryMatchSpecificityComparer : IComparer<QueryMatchDefini
             return overallComparison;
         }
 
-        return y.RegexQuery.Count.CompareTo(x.RegexQuery.Count);
+        return GetRegexSpecificity(y.Query).CompareTo(GetRegexSpecificity(x.Query));
     }
 
     private static int GetOverallSpecificity(QueryMatchDefinition match)
     {
-        return match.Query.Count + match.RegexQuery.Count + match.PartialQuery.Count + match.Headers.Count + GetBodySpecificity(match.Body);
+        return GetFieldSpecificity(match.Query) + GetFieldSpecificity(match.Headers) + GetBodySpecificity(match.Body);
+    }
+
+    private static int GetFieldSpecificity(IReadOnlyDictionary<string, object?> fields)
+    {
+        return GetEqualsSpecificity(fields) + GetRegexSpecificity(fields);
+    }
+
+    private static int GetEqualsSpecificity(IReadOnlyDictionary<string, object?> fields)
+    {
+        return fields.Count(field => MatchOperatorDefinition.TryGetEquals(field.Value, out _));
+    }
+
+    private static int GetRegexSpecificity(IReadOnlyDictionary<string, object?> fields)
+    {
+        return fields.Count(field => MatchOperatorDefinition.TryGetRegex(field.Value, out _));
     }
 
     private static int GetBodySpecificity(object? body)

--- a/src/SemanticStub.Api/Services/Matching/QueryValueMatcher.cs
+++ b/src/SemanticStub.Api/Services/Matching/QueryValueMatcher.cs
@@ -1,11 +1,12 @@
 using System.Collections;
 using System.Globalization;
 using Microsoft.Extensions.Primitives;
+using SemanticStub.Api.Models;
 
 namespace SemanticStub.Api.Services;
 
 /// <summary>
-/// Evaluates exact and partial query value matches, including typed comparisons for declared query parameter schemas.
+/// Evaluates exact query value matches, including typed comparisons for declared query parameter schemas.
 /// </summary>
 internal sealed class QueryValueMatcher
 {
@@ -23,32 +24,13 @@ internal sealed class QueryValueMatcher
     {
         foreach (var pair in expected)
         {
-            if (!actual.TryGetValue(pair.Key, out var value) ||
-                !IsTypedQueryValueMatch(pair.Value, value, queryParameterTypes.GetValueOrDefault(pair.Key)))
+            if (!MatchOperatorDefinition.TryGetEquals(pair.Value, out var expectedValue))
             {
-                return false;
+                continue;
             }
-        }
 
-        return true;
-    }
-
-    /// <summary>
-    /// Determines whether every expected query value partially matches against the actual request query values.
-    /// </summary>
-    /// <param name="expected">Expected partial query values keyed by parameter name.</param>
-    /// <param name="actual">Actual request query values keyed by parameter name.</param>
-    /// <param name="queryParameterTypes">Declared OpenAPI query parameter types keyed by parameter name.</param>
-    /// <returns><see langword="true"/> when every expected query value partially matches; otherwise, <see langword="false"/>.</returns>
-    public bool IsPartialMatch(
-        IReadOnlyDictionary<string, object?> expected,
-        IReadOnlyDictionary<string, StringValues> actual,
-        IReadOnlyDictionary<string, string> queryParameterTypes)
-    {
-        foreach (var pair in expected)
-        {
             if (!actual.TryGetValue(pair.Key, out var value) ||
-                !IsTypedPartialQueryValueMatch(pair.Value, value, queryParameterTypes.GetValueOrDefault(pair.Key)))
+                !IsTypedQueryValueMatch(expectedValue, value, queryParameterTypes.GetValueOrDefault(pair.Key)))
             {
                 return false;
             }
@@ -69,18 +51,6 @@ internal sealed class QueryValueMatcher
                IsTypedSingleQueryValueMatch(expected, actual[0]!, parameterType);
     }
 
-    private static bool IsTypedPartialQueryValueMatch(object? expected, StringValues actual, string? parameterType)
-    {
-        if (expected is IEnumerable expectedSequence && expected is not string)
-        {
-            return IsTypedPartialQuerySequenceMatch(expectedSequence, actual, parameterType);
-        }
-
-        return actual.Any(actualValue =>
-            actualValue is not null &&
-            IsTypedSinglePartialQueryValueMatch(expected, actualValue!, parameterType));
-    }
-
     private static bool IsTypedQuerySequenceMatch(IEnumerable expectedSequence, StringValues actual, string? parameterType)
     {
         var expectedValues = expectedSequence.Cast<object?>().ToArray();
@@ -95,43 +65,6 @@ internal sealed class QueryValueMatcher
         {
             if (actualValues[index] is null ||
                 !IsTypedSingleQueryValueMatch(expectedValues[index], actualValues[index]!, parameterType))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private static bool IsTypedPartialQuerySequenceMatch(IEnumerable expectedSequence, StringValues actual, string? parameterType)
-    {
-        var expectedValues = expectedSequence.Cast<object?>().ToArray();
-        var actualValues = actual.ToArray();
-
-        if (expectedValues.Length == 0)
-        {
-            return true;
-        }
-
-        var actualIndex = 0;
-
-        foreach (var expectedValue in expectedValues)
-        {
-            var matched = false;
-
-            while (actualIndex < actualValues.Length)
-            {
-                var actualValue = actualValues[actualIndex++];
-
-                if (actualValue is not null &&
-                    IsTypedSinglePartialQueryValueMatch(expectedValue, actualValue!, parameterType))
-                {
-                    matched = true;
-                    break;
-                }
-            }
-
-            if (!matched)
             {
                 return false;
             }
@@ -164,25 +97,6 @@ internal sealed class QueryValueMatcher
         }
 
         return string.Equals(ConvertQueryValueToString(expected), actual, StringComparison.Ordinal);
-    }
-
-    private static bool IsTypedSinglePartialQueryValueMatch(object? expected, string actual, string? parameterType)
-    {
-        if (string.Equals(parameterType, "integer", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(parameterType, "number", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(parameterType, "boolean", StringComparison.OrdinalIgnoreCase))
-        {
-            return IsTypedSingleQueryValueMatch(expected, actual, parameterType);
-        }
-
-        var expectedText = ConvertQueryValueToString(expected);
-
-        if (expectedText.Length == 0)
-        {
-            return string.Equals(expectedText, actual, StringComparison.Ordinal);
-        }
-
-        return actual.Contains(expectedText, StringComparison.Ordinal);
     }
 
     private static bool TryConvertInteger(object? value, out decimal integer)

--- a/src/SemanticStub.Api/Services/Matching/RegexQueryMatcher.cs
+++ b/src/SemanticStub.Api/Services/Matching/RegexQueryMatcher.cs
@@ -2,11 +2,12 @@ using System.Collections;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
+using SemanticStub.Api.Models;
 
 namespace SemanticStub.Api.Services;
 
 /// <summary>
-/// Evaluates <c>x-query-regex</c> constraints without changing matcher orchestration or precedence behavior.
+/// Evaluates regex match constraints without changing matcher orchestration behavior.
 /// </summary>
 internal sealed class RegexQueryMatcher
 {
@@ -27,6 +28,11 @@ internal sealed class RegexQueryMatcher
     {
         foreach (var pair in expected)
         {
+            if (!MatchOperatorDefinition.TryGetRegex(pair.Value, out _))
+            {
+                continue;
+            }
+
             if (!actual.TryGetValue(pair.Key, out var value) || !IsRegexQueryValueMatch(pair.Value, value))
             {
                 return false;
@@ -38,6 +44,13 @@ internal sealed class RegexQueryMatcher
 
     private bool IsRegexQueryValueMatch(object? expected, StringValues actual)
     {
+        if (!MatchOperatorDefinition.TryGetRegex(expected, out var regex))
+        {
+            return true;
+        }
+
+        expected = regex;
+
         if (expected is IEnumerable expectedSequence && expected is not string)
         {
             return IsRegexQuerySequenceMatch(expectedSequence, actual);
@@ -83,12 +96,12 @@ internal sealed class RegexQueryMatcher
         }
         catch (ArgumentException ex)
         {
-            logger?.LogWarning(ex, "Invalid x-regex-query pattern '{Pattern}' in stub definition — treating as non-match.", pattern);
+            logger?.LogWarning(ex, "Invalid regex match pattern '{Pattern}' in stub definition — treating as non-match.", pattern);
             return false;
         }
         catch (RegexMatchTimeoutException)
         {
-            logger?.LogWarning("x-regex-query pattern '{Pattern}' timed out after {TimeoutMs}ms — treating as non-match.", pattern, RegexMatchTimeout.TotalMilliseconds);
+            logger?.LogWarning("Regex match pattern '{Pattern}' timed out after {TimeoutMs}ms — treating as non-match.", pattern, RegexMatchTimeout.TotalMilliseconds);
             return false;
         }
     }

--- a/src/SemanticStub.Api/Services/Resolution/StubDispatchSelector.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubDispatchSelector.cs
@@ -69,7 +69,7 @@ internal sealed class StubDispatchSelector
                 "Deterministic conditional match selected for '{Path}' {Method}. QueryKeys={QueryKeys}, HeaderKeys={HeaderKeys}, HasBody={HasBody}.",
                 path,
                 method.ToUpperInvariant(),
-                selectedDeterministicCandidate.Query.Count + selectedDeterministicCandidate.PartialQuery.Count + selectedDeterministicCandidate.RegexQuery.Count,
+                selectedDeterministicCandidate.Query.Count,
                 selectedDeterministicCandidate.Headers.Count,
                 selectedDeterministicCandidate.Body is not null);
 
@@ -171,8 +171,6 @@ internal sealed class StubDispatchSelector
     private static bool IsDeterministicCandidate(QueryMatchDefinition candidate)
     {
         return candidate.Query.Count > 0 ||
-               candidate.PartialQuery.Count > 0 ||
-               candidate.RegexQuery.Count > 0 ||
                candidate.Headers.Count > 0 ||
                candidate.Body is not null;
     }

--- a/tests/SemanticStub.Api.Tests/Integration/BasicRoutingStubTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/BasicRoutingStubTests.cs
@@ -167,7 +167,7 @@ public sealed class BasicRoutingStubTests : IClassFixture<WebApplicationFactory<
     }
 
     [Fact]
-    public async Task GetUsersWithPartialRoleQuery_ReturnsPartialMatchResponse()
+    public async Task GetUsersWithRegexRoleQuery_ReturnsRegexMatchResponse()
     {
         var response = await client.GetAsync("/users?role=super-admin");
 
@@ -175,8 +175,8 @@ public sealed class BasicRoutingStubTests : IClassFixture<WebApplicationFactory<
         var payload = await response.Content.ReadFromJsonAsync<UsersResponse>();
         Assert.NotNull(payload);
         Assert.Single(payload.Users);
-        Assert.Equal("Partial Alice", payload.Users[0].Name);
-        Assert.Equal("partial-admin", payload.Users[0].Role);
+        Assert.Equal("Regex Alice", payload.Users[0].Name);
+        Assert.Equal("regex-admin", payload.Users[0].Role);
     }
 
     [Fact]

--- a/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
@@ -108,7 +108,7 @@ public sealed class StubInspectionEndpointTests : IClassFixture<WebApplicationFa
         Assert.True(route.ResponseCount >= 1);
         Assert.Contains(route.Responses, response => response.ResponseId == "200");
         Assert.Contains(route.ConditionalMatches, candidate => candidate.HasExactQuery);
-        Assert.Contains(route.ConditionalMatches, candidate => candidate.HasPartialQuery);
+        Assert.Contains(route.ConditionalMatches, candidate => candidate.HasRegexQuery);
     }
 
     [Fact]

--- a/tests/SemanticStub.Api.Tests/Unit/MatcherServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/MatcherServiceTests.cs
@@ -192,7 +192,7 @@ public sealed class MatcherServiceTests
                     {
                         ["page"] = 2
                     },
-                    Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    Headers = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
                     {
                         ["X-Env"] = "staging"
                     },
@@ -239,7 +239,7 @@ public sealed class MatcherServiceTests
                     {
                         ["role"] = "admin"
                     },
-                    Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    Headers = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
                     {
                         ["X-Env"] = "staging"
                     }
@@ -336,7 +336,7 @@ public sealed class MatcherServiceTests
             [
                 new QueryMatchDefinition
                 {
-                    Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    Headers = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
                     {
                         ["X-Env"] = "staging"
                     }
@@ -682,14 +682,14 @@ public sealed class MatcherServiceTests
             [
                 new QueryMatchDefinition
                 {
-                    Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    Headers = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
                     {
                         ["X-Env"] = "staging"
                     }
                 },
                 new QueryMatchDefinition
                 {
-                    Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    Headers = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
                     {
                         ["X-Env"] = "staging",
                         ["X-Tenant"] = "alpha"
@@ -716,7 +716,7 @@ public sealed class MatcherServiceTests
     }
 
     [Fact]
-    public void FindBestMatch_MatchesPartialSingleQueryValue()
+    public void FindBestMatch_MatchesRegexQueryValueAsContainsReplacement()
     {
         var operation = new OperationDefinition
         {
@@ -724,9 +724,12 @@ public sealed class MatcherServiceTests
             [
                 new QueryMatchDefinition
                 {
-                    PartialQuery = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    Query = new Dictionary<string, object?>(StringComparer.Ordinal)
                     {
-                        ["role"] = "admin"
+                        ["role"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                        {
+                            ["regex"] = ".*admin.*"
+                        }
                     }
                 }
             ]
@@ -745,11 +748,10 @@ public sealed class MatcherServiceTests
             body: null);
 
         Assert.NotNull(match);
-        Assert.Equal("admin", match.PartialQuery["role"]);
     }
 
     [Fact]
-    public void FindBestMatch_PrefersExactQueryOverPartialQuery()
+    public void FindBestMatch_PrefersEqualsQueryOverRegexQuery()
     {
         var operation = new OperationDefinition
         {
@@ -757,9 +759,12 @@ public sealed class MatcherServiceTests
             [
                 new QueryMatchDefinition
                 {
-                    PartialQuery = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    Query = new Dictionary<string, object?>(StringComparer.Ordinal)
                     {
-                        ["role"] = "admin"
+                        ["role"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                        {
+                            ["regex"] = ".*admin.*"
+                        }
                     }
                 },
                 new QueryMatchDefinition
@@ -786,11 +791,10 @@ public sealed class MatcherServiceTests
 
         Assert.NotNull(match);
         Assert.Equal("admin", match.Query["role"]);
-        Assert.Empty(match.PartialQuery);
     }
 
     [Fact]
-    public void FindBestMatch_MatchesPartialRepeatedQueryValuesInOrder()
+    public void FindBestMatch_MatchesRepeatedRegexQueryValuesInOrder()
     {
         var operation = new OperationDefinition
         {
@@ -798,9 +802,12 @@ public sealed class MatcherServiceTests
             [
                 new QueryMatchDefinition
                 {
-                    PartialQuery = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    Query = new Dictionary<string, object?>(StringComparer.Ordinal)
                     {
-                        ["tag"] = new List<object?> { "alpha", "beta" }
+                        ["tag"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                        {
+                            ["regex"] = new List<object?> { ".*alpha.*", ".*beta.*" }
+                        }
                     }
                 }
             ]
@@ -813,7 +820,7 @@ public sealed class MatcherServiceTests
             operation,
             new Dictionary<string, StringValues>(StringComparer.Ordinal)
             {
-                ["tag"] = new StringValues(["pre-alpha", "middle", "beta-post"])
+                ["tag"] = new StringValues(["pre-alpha", "beta-post"])
             },
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
             body: null);
@@ -822,7 +829,7 @@ public sealed class MatcherServiceTests
     }
 
     [Fact]
-    public void FindBestMatch_DoesNotTreatNullPartialQueryValueAsWildcard()
+    public void FindBestMatch_MatchesEqualsOperatorQueryValue()
     {
         var operation = new OperationDefinition
         {
@@ -830,9 +837,12 @@ public sealed class MatcherServiceTests
             [
                 new QueryMatchDefinition
                 {
-                    PartialQuery = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    Query = new Dictionary<string, object?>(StringComparer.Ordinal)
                     {
-                        ["role"] = null
+                        ["role"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                        {
+                            ["equals"] = "admin"
+                        }
                     }
                 }
             ]
@@ -850,11 +860,11 @@ public sealed class MatcherServiceTests
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
             body: null);
 
-        Assert.Null(match);
+        Assert.NotNull(match);
     }
 
     [Fact]
-    public void FindBestMatch_MatchesNullPartialQueryValueOnlyAgainstEmptyString()
+    public void FindBestMatch_ReturnsNullWhenEqualsOperatorQueryDoesNotMatch()
     {
         var operation = new OperationDefinition
         {
@@ -862,9 +872,12 @@ public sealed class MatcherServiceTests
             [
                 new QueryMatchDefinition
                 {
-                    PartialQuery = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    Query = new Dictionary<string, object?>(StringComparer.Ordinal)
                     {
-                        ["role"] = null
+                        ["role"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                        {
+                            ["equals"] = "admin"
+                        }
                     }
                 }
             ]
@@ -877,12 +890,12 @@ public sealed class MatcherServiceTests
             operation,
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
-                ["role"] = string.Empty
+                ["role"] = "guest"
             },
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
             body: null);
 
-        Assert.NotNull(match);
+        Assert.Null(match);
     }
 
     [Fact]
@@ -894,9 +907,12 @@ public sealed class MatcherServiceTests
             [
                 new QueryMatchDefinition
                 {
-                    RegexQuery = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    Query = new Dictionary<string, object?>(StringComparer.Ordinal)
                     {
-                        ["role"] = "^admin-[0-9]+$"
+                        ["role"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                        {
+                            ["regex"] = "^admin-[0-9]+$"
+                        }
                     }
                 }
             ]
@@ -915,7 +931,6 @@ public sealed class MatcherServiceTests
             body: null);
 
         Assert.NotNull(match);
-        Assert.Equal("^admin-[0-9]+$", match.RegexQuery["role"]);
     }
 
     [Fact]
@@ -927,9 +942,12 @@ public sealed class MatcherServiceTests
             [
                 new QueryMatchDefinition
                 {
-                    RegexQuery = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    Query = new Dictionary<string, object?>(StringComparer.Ordinal)
                     {
-                        ["role"] = "^admin-[0-9]+$"
+                        ["role"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                        {
+                            ["regex"] = "^admin-[0-9]+$"
+                        }
                     }
                 }
             ]
@@ -959,9 +977,12 @@ public sealed class MatcherServiceTests
             [
                 new QueryMatchDefinition
                 {
-                    RegexQuery = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    Query = new Dictionary<string, object?>(StringComparer.Ordinal)
                     {
-                        ["role"] = "^(a+)+$"
+                        ["role"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                        {
+                            ["regex"] = "^(a+)+$"
+                        }
                     }
                 }
             ]
@@ -993,11 +1014,14 @@ public sealed class MatcherServiceTests
     {
         var specificHeaderMatch = new QueryMatchDefinition
         {
-            PartialQuery = new Dictionary<string, object?>(StringComparer.Ordinal)
+            Query = new Dictionary<string, object?>(StringComparer.Ordinal)
             {
-                ["role"] = "admin"
+                ["role"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["regex"] = ".*admin.*"
+                }
             },
-            Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            Headers = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
             {
                 ["x-tenant"] = "alpha"
             }
@@ -1005,9 +1029,12 @@ public sealed class MatcherServiceTests
 
         var broaderRegexMatch = new QueryMatchDefinition
         {
-            RegexQuery = new Dictionary<string, object?>(StringComparer.Ordinal)
+            Query = new Dictionary<string, object?>(StringComparer.Ordinal)
             {
-                ["role"] = "^admin-[0-9]+$"
+                ["role"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["regex"] = "^admin-[0-9]+$"
+                }
             }
         };
 
@@ -1032,13 +1059,11 @@ public sealed class MatcherServiceTests
             body: null);
 
         Assert.NotNull(match);
-        Assert.Equal("admin", match.PartialQuery["role"]);
         Assert.Equal("alpha", match.Headers["x-tenant"]);
-        Assert.Empty(match.RegexQuery);
     }
 
     [Fact]
-    public void FindBestMatch_PrefersRegexQueryOverPartialQuery()
+    public void FindBestMatch_MatchesRegexHeaders()
     {
         var operation = new OperationDefinition
         {
@@ -1046,16 +1071,12 @@ public sealed class MatcherServiceTests
             [
                 new QueryMatchDefinition
                 {
-                    PartialQuery = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    Headers = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
                     {
-                        ["role"] = "admin"
-                    }
-                },
-                new QueryMatchDefinition
-                {
-                    RegexQuery = new Dictionary<string, object?>(StringComparer.Ordinal)
-                    {
-                        ["role"] = "^admin-[0-9]+$"
+                        ["X-Env"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                        {
+                            ["regex"] = "^stag.*$"
+                        }
                     }
                 }
             ]
@@ -1066,16 +1087,14 @@ public sealed class MatcherServiceTests
         var match = FindBestMatch(
             matcher,
             operation,
-            new Dictionary<string, string>(StringComparer.Ordinal)
+            new Dictionary<string, string>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
-                ["role"] = "admin-42"
+                ["x-env"] = "staging"
             },
-            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
             body: null);
 
         Assert.NotNull(match);
-        Assert.Equal("^admin-[0-9]+$", match.RegexQuery["role"]);
-        Assert.Empty(match.PartialQuery);
     }
 
     private static QueryMatchDefinition? FindBestMatch(

--- a/tests/SemanticStub.Api.Tests/Unit/QueryMatchSpecificityComparerTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/QueryMatchSpecificityComparerTests.cs
@@ -11,11 +11,14 @@ public sealed class QueryMatchSpecificityComparerTests
     {
         var broaderOverallMatch = new QueryMatchDefinition
         {
-            PartialQuery = new Dictionary<string, object?>(StringComparer.Ordinal)
+            Query = new Dictionary<string, object?>(StringComparer.Ordinal)
             {
-                ["role"] = "admin"
+                ["role"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["regex"] = ".*admin.*"
+                }
             },
-            Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            Headers = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
             {
                 ["x-tenant"] = "alpha"
             }
@@ -41,11 +44,14 @@ public sealed class QueryMatchSpecificityComparerTests
     {
         var specificHeaderMatch = new QueryMatchDefinition
         {
-            PartialQuery = new Dictionary<string, object?>(StringComparer.Ordinal)
+            Query = new Dictionary<string, object?>(StringComparer.Ordinal)
             {
-                ["role"] = "admin"
+                ["role"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["regex"] = ".*admin.*"
+                }
             },
-            Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            Headers = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
             {
                 ["x-tenant"] = "alpha"
             }
@@ -53,9 +59,12 @@ public sealed class QueryMatchSpecificityComparerTests
 
         var broaderRegexMatch = new QueryMatchDefinition
         {
-            RegexQuery = new Dictionary<string, object?>(StringComparer.Ordinal)
+            Query = new Dictionary<string, object?>(StringComparer.Ordinal)
             {
-                ["role"] = "^admin-[0-9]+$"
+                ["role"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["regex"] = "^admin-[0-9]+$"
+                }
             }
         };
 

--- a/tests/SemanticStub.Api.Tests/Unit/QueryValueMatcherTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/QueryValueMatcherTests.cs
@@ -73,18 +73,21 @@ public sealed class QueryValueMatcherTests
     }
 
     [Fact]
-    public void IsPartialMatch_UsesTypedEqualityForBooleanValues()
+    public void IsExactMatch_MatchesEqualsOperatorUsingDeclaredType()
     {
         var matcher = new QueryValueMatcher();
 
-        var matched = matcher.IsPartialMatch(
+        var matched = matcher.IsExactMatch(
             new Dictionary<string, object?>(StringComparer.Ordinal)
             {
-                ["enabled"] = true
+                ["enabled"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["equals"] = true
+                }
             },
             new Dictionary<string, StringValues>(StringComparer.Ordinal)
             {
-                ["enabled"] = new StringValues(["prefix-true", "true", "suffix"])
+                ["enabled"] = new StringValues("true")
             },
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
@@ -94,60 +97,4 @@ public sealed class QueryValueMatcherTests
         Assert.True(matched);
     }
 
-    [Fact]
-    public void IsPartialMatch_MatchesPlainStringAsSubstring()
-    {
-        var matcher = new QueryValueMatcher();
-
-        var matched = matcher.IsPartialMatch(
-            new Dictionary<string, object?>(StringComparer.Ordinal)
-            {
-                ["role"] = "admin"
-            },
-            new Dictionary<string, StringValues>(StringComparer.Ordinal)
-            {
-                ["role"] = new StringValues("super-admin")
-            },
-            queryParameterTypes: new Dictionary<string, string>(StringComparer.Ordinal));
-
-        Assert.True(matched);
-    }
-
-    [Fact]
-    public void IsPartialMatch_ReturnsTrueWhenExpectedRepeatedValueSequenceIsEmpty()
-    {
-        var matcher = new QueryValueMatcher();
-
-        var matched = matcher.IsPartialMatch(
-            new Dictionary<string, object?>(StringComparer.Ordinal)
-            {
-                ["tag"] = new List<object?>()
-            },
-            new Dictionary<string, StringValues>(StringComparer.Ordinal)
-            {
-                ["tag"] = new StringValues(["alpha", "beta"])
-            },
-            queryParameterTypes: new Dictionary<string, string>(StringComparer.Ordinal));
-
-        Assert.True(matched);
-    }
-
-    [Fact]
-    public void IsPartialMatch_ReturnsFalseWhenRepeatedValuesAppearOutOfOrder()
-    {
-        var matcher = new QueryValueMatcher();
-
-        var matched = matcher.IsPartialMatch(
-            new Dictionary<string, object?>(StringComparer.Ordinal)
-            {
-                ["tag"] = new List<object?> { "alpha", "beta" }
-            },
-            new Dictionary<string, StringValues>(StringComparer.Ordinal)
-            {
-                ["tag"] = new StringValues(["beta-post", "alpha-pre"])
-            },
-            queryParameterTypes: new Dictionary<string, string>(StringComparer.Ordinal));
-
-        Assert.False(matched);
-    }
 }

--- a/tests/SemanticStub.Api.Tests/Unit/RegexQueryMatcherTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/RegexQueryMatcherTests.cs
@@ -15,7 +15,10 @@ public sealed class RegexQueryMatcherTests
         var matched = matcher.IsMatch(
             new Dictionary<string, object?>(StringComparer.Ordinal)
             {
-                ["role"] = "^admin-[0-9]+$"
+                ["role"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["regex"] = "^admin-[0-9]+$"
+                }
             },
             new Dictionary<string, StringValues>(StringComparer.Ordinal)
             {
@@ -33,7 +36,10 @@ public sealed class RegexQueryMatcherTests
         var matched = matcher.IsMatch(
             new Dictionary<string, object?>(StringComparer.Ordinal)
             {
-                ["tag"] = new List<object?> { "^alpha$", "^beta$" }
+                ["tag"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["regex"] = new List<object?> { "^alpha$", "^beta$" }
+                }
             },
             new Dictionary<string, StringValues>(StringComparer.Ordinal)
             {
@@ -52,7 +58,10 @@ public sealed class RegexQueryMatcherTests
         var matched = matcher.IsMatch(
             new Dictionary<string, object?>(StringComparer.Ordinal)
             {
-                ["role"] = "["
+                ["role"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["regex"] = "["
+                }
             },
             new Dictionary<string, StringValues>(StringComparer.Ordinal)
             {
@@ -62,7 +71,7 @@ public sealed class RegexQueryMatcherTests
         Assert.False(matched);
         Assert.Single(logger.Entries);
         Assert.Equal(LogLevel.Warning, logger.Entries[0].LogLevel);
-        Assert.Contains("Invalid x-regex-query pattern", logger.Entries[0].Message, StringComparison.Ordinal);
+        Assert.Contains("Invalid regex match pattern", logger.Entries[0].Message, StringComparison.Ordinal);
         Assert.IsAssignableFrom<ArgumentException>(logger.Entries[0].Exception);
     }
 
@@ -75,7 +84,10 @@ public sealed class RegexQueryMatcherTests
         var matched = matcher.IsMatch(
             new Dictionary<string, object?>(StringComparer.Ordinal)
             {
-                ["role"] = "^(a+)+$"
+                ["role"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["regex"] = "^(a+)+$"
+                }
             },
             new Dictionary<string, StringValues>(StringComparer.Ordinal)
             {

--- a/tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs
@@ -264,8 +264,6 @@ public sealed class StubDefinitionLoaderTests
 
     [Theory]
     [InlineData("query", "query:\n                        role: admin")]
-    [InlineData("x-query-partial", "x-query-partial:\n                        role: admin")]
-    [InlineData("x-query-regex", "x-query-regex:\n                        role: ^admin-[0-9]+$")]
     [InlineData("headers", "headers:\n                        X-Env: staging")]
     [InlineData("body", "body:\n                        role: admin")]
     public void LoadDefaultDefinition_ThrowsWhenSemanticMatchIsCombinedWithDeterministicCondition(
@@ -759,7 +757,7 @@ public sealed class StubDefinitionLoaderTests
     }
 
     [Fact]
-    public void LoadDefaultDefinition_PreservesPartialQueryMatch()
+    public void LoadDefaultDefinition_PreservesQueryEqualsOperatorMatch()
     {
         using var workspace = TestWorkspace.Create(
             """
@@ -773,8 +771,9 @@ public sealed class StubDefinitionLoaderTests
                       schema:
                         type: string
                   x-match:
-                    - x-query-partial:
-                        role: admin
+                    - query:
+                        role:
+                          equals: admin
                       response:
                         statusCode: 200
                         content:
@@ -795,12 +794,13 @@ public sealed class StubDefinitionLoaderTests
         var document = loader.LoadDefaultDefinition();
         var operation = Assert.IsType<OperationDefinition>(document.Paths["/users"].Get);
         var match = Assert.Single(operation.Matches);
+        var role = Assert.IsType<Dictionary<string, object?>>(match.Query["role"]);
 
-        Assert.Equal("admin", Assert.IsType<string>(match.PartialQuery["role"]));
+        Assert.Equal("admin", Assert.IsType<string>(role["equals"]));
     }
 
     [Fact]
-    public void LoadDefaultDefinition_PreservesRegexQueryMatch()
+    public void LoadDefaultDefinition_PreservesQueryRegexOperatorMatch()
     {
         using var workspace = TestWorkspace.Create(
             """
@@ -814,8 +814,9 @@ public sealed class StubDefinitionLoaderTests
                       schema:
                         type: string
                   x-match:
-                    - x-query-regex:
-                        role: ^admin-[0-9]+$
+                    - query:
+                        role:
+                          regex: ^admin-[0-9]+$
                       response:
                         statusCode: 200
                         content:
@@ -836,8 +837,9 @@ public sealed class StubDefinitionLoaderTests
         var document = loader.LoadDefaultDefinition();
         var operation = Assert.IsType<OperationDefinition>(document.Paths["/users"].Get);
         var match = Assert.Single(operation.Matches);
+        var role = Assert.IsType<Dictionary<string, object?>>(match.Query["role"]);
 
-        Assert.Equal("^admin-[0-9]+$", Assert.IsType<string>(match.RegexQuery["role"]));
+        Assert.Equal("^admin-[0-9]+$", Assert.IsType<string>(role["regex"]));
     }
 
     [Fact]
@@ -919,7 +921,7 @@ public sealed class StubDefinitionLoaderTests
     }
 
     [Fact]
-    public void LoadDefaultDefinition_ThrowsWhenPartialMatchedQueryIsNotDeclared()
+    public void LoadDefaultDefinition_ThrowsWhenLegacyPartialQueryIsUsed()
     {
         using var workspace = TestWorkspace.Create(
             """
@@ -928,7 +930,7 @@ public sealed class StubDefinitionLoaderTests
               /users:
                 get:
                   parameters:
-                    - name: status
+                    - name: role
                       in: query
                       schema:
                         type: string
@@ -954,11 +956,11 @@ public sealed class StubDefinitionLoaderTests
 
         var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
 
-        Assert.Contains("x-match[0].x-query-partial['role'] must reference a declared query parameter", exception.Message);
+        Assert.Contains("x-match[0].x-query-partial is no longer supported", exception.Message);
     }
 
     [Fact]
-    public void LoadDefaultDefinition_ThrowsWhenRegexMatchedQueryIsNotDeclared()
+    public void LoadDefaultDefinition_ThrowsWhenLegacyRegexQueryIsUsed()
     {
         using var workspace = TestWorkspace.Create(
             """
@@ -967,7 +969,7 @@ public sealed class StubDefinitionLoaderTests
               /users:
                 get:
                   parameters:
-                    - name: status
+                    - name: role
                       in: query
                       schema:
                         type: string
@@ -993,11 +995,11 @@ public sealed class StubDefinitionLoaderTests
 
         var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
 
-        Assert.Contains("x-match[0].x-query-regex['role'] must reference a declared query parameter", exception.Message);
+        Assert.Contains("x-match[0].x-query-regex is no longer supported", exception.Message);
     }
 
     [Fact]
-    public void LoadDefaultDefinition_ThrowsWhenRegexPatternIsInvalid()
+    public void LoadDefaultDefinition_ThrowsWhenRegexOperatorPatternIsInvalid()
     {
         using var workspace = TestWorkspace.Create(
             """
@@ -1011,8 +1013,9 @@ public sealed class StubDefinitionLoaderTests
                       schema:
                         type: string
                   x-match:
-                    - x-query-regex:
-                        role: "^(admin$"
+                    - query:
+                        role:
+                          regex: "^(admin$"
                       response:
                         statusCode: 200
                         content:
@@ -1032,11 +1035,11 @@ public sealed class StubDefinitionLoaderTests
 
         var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
 
-        Assert.Contains("x-match[0].x-query-regex['role'] must be a valid regex pattern", exception.Message);
+        Assert.Contains("x-match[0].query['role'].regex must be a valid regex pattern", exception.Message);
     }
 
     [Fact]
-    public void LoadDefaultDefinition_ThrowsWhenRegexPatternValueIsAnEmptyMap()
+    public void LoadDefaultDefinition_ThrowsWhenOperatorValueIsAnEmptyMap()
     {
         using var workspace = TestWorkspace.Create(
             """
@@ -1050,7 +1053,7 @@ public sealed class StubDefinitionLoaderTests
                       schema:
                         type: string
                   x-match:
-                    - x-query-regex:
+                    - query:
                         role: {}
                       response:
                         statusCode: 200
@@ -1071,7 +1074,88 @@ public sealed class StubDefinitionLoaderTests
 
         var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
 
-        Assert.Contains("x-match[0].x-query-regex['role'] must be a string pattern", exception.Message);
+        Assert.Contains("x-match[0].query['role'] must define at least one supported operator", exception.Message);
+    }
+
+    [Fact]
+    public void LoadDefaultDefinition_ThrowsWhenMatchOperatorIsUnsupported()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+              /users:
+                get:
+                  parameters:
+                    - name: role
+                      in: query
+                      schema:
+                        type: string
+                  x-match:
+                    - query:
+                        role:
+                          contains: admin
+                      response:
+                        statusCode: 200
+                        content:
+                          application/json:
+                            example:
+                              users: []
+                  responses:
+                    "200":
+                      description: ok
+                      content:
+                        application/json:
+                          example:
+                            users: []
+            """);
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
+
+        Assert.Contains("x-match[0].query['role'] uses unsupported operator 'contains'", exception.Message);
+    }
+
+    [Fact]
+    public void LoadDefaultDefinition_ThrowsWhenMatchOperatorsAreMixed()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+              /users:
+                get:
+                  parameters:
+                    - name: role
+                      in: query
+                      schema:
+                        type: string
+                  x-match:
+                    - query:
+                        role:
+                          equals: admin
+                          regex: ^admin$
+                      response:
+                        statusCode: 200
+                        content:
+                          application/json:
+                            example:
+                              users: []
+                  responses:
+                    "200":
+                      description: ok
+                      content:
+                        application/json:
+                          example:
+                            users: []
+            """);
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
+
+        Assert.Contains("x-match[0].query['role'] must not combine equals and regex operators", exception.Message);
     }
 
     [Fact]

--- a/tests/SemanticStub.Api.Tests/Unit/StubInspectionServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubInspectionServiceTests.cs
@@ -1023,16 +1023,12 @@ public sealed class StubInspectionServiceTests
                                 Query = new Dictionary<string, object?>(StringComparer.Ordinal)
                                 {
                                     ["role"] = "admin",
+                                    ["region"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                                    {
+                                        ["regex"] = "^ap-.*$",
+                                    },
                                 },
-                                PartialQuery = new Dictionary<string, object?>(StringComparer.Ordinal)
-                                {
-                                    ["view"] = "summary",
-                                },
-                                RegexQuery = new Dictionary<string, object?>(StringComparer.Ordinal)
-                                {
-                                    ["region"] = "^ap-.*$",
-                                },
-                                Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                                Headers = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
                                 {
                                     ["X-Env"] = "staging",
                                 },
@@ -1115,8 +1111,6 @@ public sealed class StubInspectionServiceTests
                 Assert.Equal(0, candidate.CandidateIndex);
                 Assert.True(candidate.HasExactQuery);
                 Assert.Equal(["role"], candidate.ExactQueryKeys);
-                Assert.True(candidate.HasPartialQuery);
-                Assert.Equal(["view"], candidate.PartialQueryKeys);
                 Assert.True(candidate.HasRegexQuery);
                 Assert.Equal(["region"], candidate.RegexQueryKeys);
                 Assert.Equal(["X-Env"], candidate.HeaderKeys);
@@ -1134,8 +1128,6 @@ public sealed class StubInspectionServiceTests
                 Assert.Equal(1, candidate.CandidateIndex);
                 Assert.False(candidate.HasExactQuery);
                 Assert.Empty(candidate.ExactQueryKeys);
-                Assert.False(candidate.HasPartialQuery);
-                Assert.Empty(candidate.PartialQueryKeys);
                 Assert.False(candidate.HasRegexQuery);
                 Assert.Empty(candidate.RegexQueryKeys);
                 Assert.Empty(candidate.HeaderKeys);

--- a/tests/SemanticStub.Api.Tests/Unit/StubServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubServiceTests.cs
@@ -1579,7 +1579,7 @@ public sealed class StubServiceTests
                         [
                             new QueryMatchDefinition
                             {
-                                Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                                Headers = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
                                 {
                                     ["X-Env"] = "staging"
                                 },


### PR DESCRIPTION
## Summary
- Add operator-based `equals` / `regex` matching for `query` and `headers`
- Remove runtime support for `x-query-regex` and `x-query-partial` with validation errors for legacy YAML
- Update samples, docs, and tests for the unified matcher syntax

## Files Changed
- Matcher model, validation, normalization, selection, inspection, and specificity logic
- Query/header matcher unit tests plus integration coverage for updated samples
- README, Japanese README, HTTP samples, and basic routing sample YAML

## Tests
- `dotnet test SemanticStub.sln`

## Notes
- `body.form` is intentionally out of scope for this PR and will be handled separately.
- This is a breaking YAML change for `x-query-regex` and `x-query-partial`.

Closes #171