### PR TITLE
feat: support form-urlencoded body matching

### DIFF
--- a/src/SemanticStub.Api/Extensions/StubServiceCollectionExtensions.cs
+++ b/src/SemanticStub.Api/Extensions/StubServiceCollectionExtensions.cs
@@ -41,11 +41,13 @@ public static class StubServiceCollectionExtensions
         services.AddHostedService<StubDefinitionWatcher>();
         services.AddSingleton(serviceProvider => new JsonBodyMatcher(
             serviceProvider.GetRequiredService<ILogger<JsonBodyMatcher>>()));
+        services.AddSingleton<FormBodyMatcher>();
         services.AddSingleton<QueryValueMatcher>();
         services.AddSingleton(serviceProvider => new RegexQueryMatcher(
             serviceProvider.GetRequiredService<ILogger<RegexQueryMatcher>>()));
         services.AddSingleton<MatcherService>(serviceProvider => new MatcherService(
             serviceProvider.GetRequiredService<JsonBodyMatcher>(),
+            serviceProvider.GetRequiredService<FormBodyMatcher>(),
             serviceProvider.GetRequiredService<QueryValueMatcher>(),
             serviceProvider.GetRequiredService<RegexQueryMatcher>()));
         services.AddSingleton<ScenarioService>();

--- a/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionValidator.cs
+++ b/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionValidator.cs
@@ -443,6 +443,21 @@ internal sealed class StubDefinitionValidator
             errors.Add(
                 $"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].body.form cannot be combined with {string.Join(", ", conflicts)}.");
         }
+
+        if (TryGetBodyMap(bodyMap["form"], out var formMap))
+        {
+            foreach (var formKey in formMap.Keys)
+            {
+                ValidateMatchOperatorDefinition(
+                    path,
+                    method,
+                    index,
+                    "body.form",
+                    formKey,
+                    formMap[formKey],
+                    errors);
+            }
+        }
     }
 
     private static bool TryGetBodyMap(object? value, out Dictionary<string, object?> map)

--- a/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionValidator.cs
+++ b/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionValidator.cs
@@ -131,6 +131,7 @@ internal sealed class StubDefinitionValidator
             if (errors.Count == semanticMatchErrorCount)
             {
                 ValidateLegacyQueryMatchFields(path, method, index, match, errors);
+                ValidateBodyMatchDefinition(path, method, index, match.Body, errors);
 
                 foreach (var queryKey in match.Query.Keys)
                 {
@@ -410,6 +411,58 @@ internal sealed class StubDefinitionValidator
         if (match.RegexQuery.Count > 0)
         {
             errors.Add($"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].x-query-regex is no longer supported; use query.<name>.regex instead.");
+        }
+    }
+
+    private static void ValidateBodyMatchDefinition(
+        string path,
+        string method,
+        int index,
+        object? body,
+        ICollection<string> errors)
+    {
+        if (!TryGetBodyMap(body, out var bodyMap) ||
+            !bodyMap.ContainsKey("form"))
+        {
+            return;
+        }
+
+        var conflicts = new List<string>();
+        if (bodyMap.ContainsKey("json"))
+        {
+            conflicts.Add("body.json");
+        }
+
+        if (bodyMap.ContainsKey("text"))
+        {
+            conflicts.Add("body.text");
+        }
+
+        if (conflicts.Count > 0)
+        {
+            errors.Add(
+                $"Path '{path}' {method.ToUpperInvariant()} x-match[{index}].body.form cannot be combined with {string.Join(", ", conflicts)}.");
+        }
+    }
+
+    private static bool TryGetBodyMap(object? value, out Dictionary<string, object?> map)
+    {
+        switch (value)
+        {
+            case IDictionary<string, object?> typed:
+                map = new Dictionary<string, object?>(typed, StringComparer.Ordinal);
+                return true;
+            case IDictionary dictionary:
+                map = new Dictionary<string, object?>(StringComparer.Ordinal);
+                foreach (DictionaryEntry entry in dictionary)
+                {
+                    map[entry.Key.ToString() ?? string.Empty] = entry.Value;
+                }
+
+                return true;
+            default:
+                map = [];
+                return false;
         }
     }
 

--- a/src/SemanticStub.Api/Services/Matching/FormBodyMatcher.cs
+++ b/src/SemanticStub.Api/Services/Matching/FormBodyMatcher.cs
@@ -1,0 +1,172 @@
+using System.Collections;
+using System.Globalization;
+using Microsoft.Extensions.Primitives;
+using SemanticStub.Api.Models;
+
+namespace SemanticStub.Api.Services;
+
+internal sealed class FormBodyMatcher
+{
+    private const string FormUrlEncodedMediaType = "application/x-www-form-urlencoded";
+
+    internal IReadOnlyDictionary<string, StringValues>? ParseRequestBody(string? body, string? contentType)
+    {
+        if (string.IsNullOrEmpty(body) || !IsFormUrlEncoded(contentType))
+        {
+            return null;
+        }
+
+        var values = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+
+        foreach (var pair in body.Split('&'))
+        {
+            if (pair.Length == 0)
+            {
+                continue;
+            }
+
+            var separatorIndex = pair.IndexOf('=');
+            var key = separatorIndex < 0 ? pair : pair[..separatorIndex];
+            var value = separatorIndex < 0 ? string.Empty : pair[(separatorIndex + 1)..];
+
+            if (!TryDecode(key, out var decodedKey) ||
+                !TryDecode(value, out var decodedValue))
+            {
+                return null;
+            }
+
+            if (!values.TryGetValue(decodedKey, out var currentValues))
+            {
+                currentValues = [];
+                values[decodedKey] = currentValues;
+            }
+
+            currentValues.Add(decodedValue);
+        }
+
+        return values.ToDictionary(
+            entry => entry.Key,
+            entry => new StringValues(entry.Value.ToArray()),
+            StringComparer.Ordinal);
+    }
+
+    internal bool IsMatch(object? expectedBody, IReadOnlyDictionary<string, StringValues>? actualForm)
+    {
+        if (!TryGetExpectedForm(expectedBody, out var expectedForm))
+        {
+            return false;
+        }
+
+        if (actualForm is null)
+        {
+            return false;
+        }
+
+        foreach (var expectedValue in expectedForm)
+        {
+            if (!MatchOperatorDefinition.TryGetEquals(expectedValue.Value, out var equals) ||
+                !actualForm.TryGetValue(expectedValue.Key, out var actualValue) ||
+                !IsExactStringMatch(equals, actualValue))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    internal bool HasFormCondition(object? expectedBody)
+    {
+        return TryGetExpectedForm(expectedBody, out _);
+    }
+
+    private static bool TryGetExpectedForm(object? expectedBody, out IReadOnlyDictionary<string, object?> expectedForm)
+    {
+        if (TryGetMap(expectedBody, out var bodyMap) &&
+            bodyMap.TryGetValue("form", out var formValue) &&
+            TryGetMap(formValue, out var formMap))
+        {
+            expectedForm = formMap;
+            return true;
+        }
+
+        expectedForm = new Dictionary<string, object?>(StringComparer.Ordinal);
+        return false;
+    }
+
+    private static bool IsExactStringMatch(object? expected, StringValues actual)
+    {
+        if (expected is IEnumerable expectedSequence and not string)
+        {
+            var expectedValues = expectedSequence.Cast<object?>().Select(ConvertFormValueToString).ToArray();
+            var actualValues = actual.ToArray();
+
+            return expectedValues.Length == actualValues.Length &&
+                   expectedValues.SequenceEqual(actualValues, StringComparer.Ordinal);
+        }
+
+        return actual.Count == 1 &&
+               actual[0] is not null &&
+               string.Equals(ConvertFormValueToString(expected), actual[0], StringComparison.Ordinal);
+    }
+
+    private static string ConvertFormValueToString(object? value)
+    {
+        return value switch
+        {
+            null => string.Empty,
+            string text => text,
+            bool boolean => boolean ? "true" : "false",
+            byte or sbyte or short or ushort or int or uint or long or ulong or float or double or decimal
+                => Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty,
+            IFormattable formattable => formattable.ToString(format: null, CultureInfo.InvariantCulture),
+            _ => value.ToString() ?? string.Empty
+        };
+    }
+
+    private static bool TryGetMap(object? value, out Dictionary<string, object?> map)
+    {
+        switch (value)
+        {
+            case IDictionary<string, object?> typed:
+                map = new Dictionary<string, object?>(typed, StringComparer.Ordinal);
+                return true;
+            case IDictionary dictionary:
+                map = new Dictionary<string, object?>(StringComparer.Ordinal);
+                foreach (DictionaryEntry entry in dictionary)
+                {
+                    map[entry.Key.ToString() ?? string.Empty] = entry.Value;
+                }
+
+                return true;
+            default:
+                map = [];
+                return false;
+        }
+    }
+
+    private static bool IsFormUrlEncoded(string? contentType)
+    {
+        if (string.IsNullOrWhiteSpace(contentType))
+        {
+            return false;
+        }
+
+        var mediaType = contentType.Split(';', count: 2)[0].Trim();
+        return string.Equals(mediaType, FormUrlEncodedMediaType, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool TryDecode(string value, out string decoded)
+    {
+        try
+        {
+            decoded = Uri.UnescapeDataString(value.Replace("+", " ", StringComparison.Ordinal));
+            return true;
+        }
+        catch (UriFormatException)
+        {
+            decoded = string.Empty;
+            return false;
+        }
+    }
+}

--- a/src/SemanticStub.Api/Services/Matching/MatcherService.cs
+++ b/src/SemanticStub.Api/Services/Matching/MatcherService.cs
@@ -10,6 +10,7 @@ namespace SemanticStub.Api.Services;
 public sealed class MatcherService
 {
     private static readonly QueryMatchSpecificityComparer MatchSpecificityComparer = QueryMatchSpecificityComparer.Instance;
+    private readonly FormBodyMatcher formBodyMatcher;
     private readonly JsonBodyMatcher jsonBodyMatcher;
     private readonly QueryValueMatcher queryValueMatcher;
     private readonly RegexQueryMatcher regexQueryMatcher;
@@ -18,8 +19,18 @@ public sealed class MatcherService
         JsonBodyMatcher jsonBodyMatcher,
         QueryValueMatcher queryValueMatcher,
         RegexQueryMatcher regexQueryMatcher)
+        : this(jsonBodyMatcher, new FormBodyMatcher(), queryValueMatcher, regexQueryMatcher)
+    {
+    }
+
+    internal MatcherService(
+        JsonBodyMatcher jsonBodyMatcher,
+        FormBodyMatcher formBodyMatcher,
+        QueryValueMatcher queryValueMatcher,
+        RegexQueryMatcher regexQueryMatcher)
     {
         this.jsonBodyMatcher = jsonBodyMatcher;
+        this.formBodyMatcher = formBodyMatcher;
         this.queryValueMatcher = queryValueMatcher;
         this.regexQueryMatcher = regexQueryMatcher;
     }
@@ -88,7 +99,7 @@ public sealed class MatcherService
                 Candidate = candidate,
                 QueryMatched = IsQueryMatch(candidate, matchContext),
                 HeaderMatched = IsHeaderMatch(candidate.Headers, matchContext.Headers),
-                BodyMatched = jsonBodyMatcher.IsMatch(candidate.Body, matchContext.RequestBody),
+                BodyMatched = IsBodyMatch(candidate.Body, matchContext),
             });
         }
 
@@ -120,7 +131,14 @@ public sealed class MatcherService
     {
         return IsQueryMatch(candidate, matchContext) &&
                IsHeaderMatch(candidate.Headers, matchContext.Headers) &&
-               jsonBodyMatcher.IsMatch(candidate.Body, matchContext.RequestBody);
+               IsBodyMatch(candidate.Body, matchContext);
+    }
+
+    private bool IsBodyMatch(object? expectedBody, MatchEvaluationContext matchContext)
+    {
+        return matchContext.RequestForm is not null && formBodyMatcher.HasFormCondition(expectedBody)
+            ? formBodyMatcher.IsMatch(expectedBody, matchContext.RequestForm)
+            : jsonBodyMatcher.IsMatch(expectedBody, matchContext.RequestBody);
     }
 
     private bool IsQueryMatch(
@@ -140,7 +158,21 @@ public sealed class MatcherService
     {
         var queryParameterTypes = QueryParameterTypeMapBuilder.Build(pathParameters, operation.Parameters);
         var bodyDocument = jsonBodyMatcher.ParseRequestBody(body);
-        return new MatchEvaluationContext(query, headers, queryParameterTypes, bodyDocument);
+        var requestForm = formBodyMatcher.ParseRequestBody(body, GetContentType(headers));
+        return new MatchEvaluationContext(query, headers, queryParameterTypes, bodyDocument, requestForm);
+    }
+
+    private static string? GetContentType(IReadOnlyDictionary<string, string> headers)
+    {
+        foreach (var header in headers)
+        {
+            if (string.Equals(header.Key, "Content-Type", StringComparison.OrdinalIgnoreCase))
+            {
+                return header.Value;
+            }
+        }
+
+        return null;
     }
 
     private bool IsHeaderMatch(IReadOnlyDictionary<string, object?> expected, IReadOnlyDictionary<string, string> actual)
@@ -160,13 +192,15 @@ public sealed class MatcherService
             IReadOnlyDictionary<string, StringValues> query,
             IReadOnlyDictionary<string, string> headers,
             IReadOnlyDictionary<string, string> queryParameterTypes,
-            JsonDocument? bodyDocument)
+            JsonDocument? bodyDocument,
+            IReadOnlyDictionary<string, StringValues>? requestForm)
         {
             Query = query;
             Headers = headers;
             QueryParameterTypes = queryParameterTypes;
             this.bodyDocument = bodyDocument;
             RequestBody = bodyDocument?.RootElement;
+            RequestForm = requestForm;
         }
 
         public IReadOnlyDictionary<string, StringValues> Query { get; }
@@ -176,6 +210,8 @@ public sealed class MatcherService
         public IReadOnlyDictionary<string, string> QueryParameterTypes { get; }
 
         public JsonElement? RequestBody { get; }
+
+        public IReadOnlyDictionary<string, StringValues>? RequestForm { get; }
 
         private readonly JsonDocument? bodyDocument;
 

--- a/src/SemanticStub.Api/Services/Matching/MatcherService.cs
+++ b/src/SemanticStub.Api/Services/Matching/MatcherService.cs
@@ -17,14 +17,6 @@ public sealed class MatcherService
 
     internal MatcherService(
         JsonBodyMatcher jsonBodyMatcher,
-        QueryValueMatcher queryValueMatcher,
-        RegexQueryMatcher regexQueryMatcher)
-        : this(jsonBodyMatcher, new FormBodyMatcher(), queryValueMatcher, regexQueryMatcher)
-    {
-    }
-
-    internal MatcherService(
-        JsonBodyMatcher jsonBodyMatcher,
         FormBodyMatcher formBodyMatcher,
         QueryValueMatcher queryValueMatcher,
         RegexQueryMatcher regexQueryMatcher)

--- a/tests/SemanticStub.Api.Tests/Unit/FormBodyMatcherTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/FormBodyMatcherTests.cs
@@ -1,0 +1,83 @@
+using Microsoft.Extensions.Primitives;
+using SemanticStub.Api.Services;
+using Xunit;
+
+namespace SemanticStub.Api.Tests.Unit;
+
+public sealed class FormBodyMatcherTests
+{
+    [Fact]
+    public void ParseRequestBody_DecodesFormValues()
+    {
+        var matcher = new FormBodyMatcher();
+
+        var form = matcher.ParseRequestBody(
+            "userId=test001&display+name=Ada+Lovelace&city=New%20York",
+            "application/x-www-form-urlencoded; charset=utf-8");
+
+        Assert.NotNull(form);
+        Assert.Equal("test001", form["userId"].ToString());
+        Assert.Equal("Ada Lovelace", form["display name"].ToString());
+        Assert.Equal("New York", form["city"].ToString());
+    }
+
+    [Fact]
+    public void ParseRequestBody_PreservesEmptyKeyOnlyAndRepeatedValues()
+    {
+        var matcher = new FormBodyMatcher();
+
+        var form = matcher.ParseRequestBody("empty=&keyOnly&tag=a&tag=b", "application/x-www-form-urlencoded");
+
+        Assert.NotNull(form);
+        Assert.Equal(string.Empty, form["empty"].ToString());
+        Assert.Equal(string.Empty, form["keyOnly"].ToString());
+        Assert.Equal(new[] { "a", "b" }, form["tag"].ToArray());
+    }
+
+    [Fact]
+    public void IsMatch_AllowsAdditionalRequestKeys()
+    {
+        var matcher = new FormBodyMatcher();
+        var form = new Dictionary<string, StringValues>(StringComparer.Ordinal)
+        {
+            ["userId"] = "test001",
+            ["password"] = "secret",
+            ["extra"] = "allowed"
+        };
+
+        var matched = matcher.IsMatch(
+            new Dictionary<object, object>
+            {
+                ["form"] = new Dictionary<object, object>
+                {
+                    ["userId"] = "test001",
+                    ["password"] = "secret"
+                }
+            },
+            form);
+
+        Assert.True(matched);
+    }
+
+    [Fact]
+    public void IsMatch_RequiresRepeatedValuesToMatchInOrder()
+    {
+        var matcher = new FormBodyMatcher();
+        var form = new Dictionary<string, StringValues>(StringComparer.Ordinal)
+        {
+            ["tag"] = new StringValues(["a", "b"])
+        };
+
+        var matched = matcher.IsMatch(
+            new Dictionary<object, object>
+            {
+                ["form"] = new Dictionary<object, object>
+                {
+                    ["tag"] = new[] { "a", "b" }
+                }
+            },
+            form);
+
+        Assert.True(matched);
+    }
+}

--- a/tests/SemanticStub.Api.Tests/Unit/MatcherServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/MatcherServiceTests.cs
@@ -126,6 +126,141 @@ public sealed class MatcherServiceTests
     }
 
     [Fact]
+    public void FindBestMatch_MatchesFormUrlEncodedBodyCondition()
+    {
+        var operation = new OperationDefinition
+        {
+            Matches =
+            [
+                new QueryMatchDefinition
+                {
+                    Body = new Dictionary<object, object>
+                    {
+                        ["form"] = new Dictionary<object, object>
+                        {
+                            ["userId"] = "test001",
+                            ["password"] = "secret"
+                        }
+                    }
+                }
+            ]
+        };
+
+        var matcher = CreateMatcherService();
+
+        var match = FindBestMatch(
+            matcher,
+            operation,
+            new Dictionary<string, string>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Content-Type"] = "application/x-www-form-urlencoded"
+            },
+            "userId=test001&password=secret&extra=allowed");
+
+        Assert.NotNull(match);
+    }
+
+    [Fact]
+    public void FindBestMatch_ReturnsNullWhenFormContentTypeIsMissing()
+    {
+        var operation = new OperationDefinition
+        {
+            Matches =
+            [
+                new QueryMatchDefinition
+                {
+                    Body = new Dictionary<object, object>
+                    {
+                        ["form"] = new Dictionary<object, object>
+                        {
+                            ["userId"] = "test001"
+                        }
+                    }
+                }
+            ]
+        };
+
+        var matcher = CreateMatcherService();
+
+        var match = FindBestMatch(
+            matcher,
+            operation,
+            new Dictionary<string, string>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            "userId=test001");
+
+        Assert.Null(match);
+    }
+
+    [Fact]
+    public void FindBestMatch_ReturnsNullWhenFormValueDiffers()
+    {
+        var operation = new OperationDefinition
+        {
+            Matches =
+            [
+                new QueryMatchDefinition
+                {
+                    Body = new Dictionary<object, object>
+                    {
+                        ["form"] = new Dictionary<object, object>
+                        {
+                            ["userId"] = "test001"
+                        }
+                    }
+                }
+            ]
+        };
+
+        var matcher = CreateMatcherService();
+
+        var match = FindBestMatch(
+            matcher,
+            operation,
+            new Dictionary<string, string>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Content-Type"] = "application/x-www-form-urlencoded"
+            },
+            "userId=other");
+
+        Assert.Null(match);
+    }
+
+    [Fact]
+    public void FindBestMatch_KeepsBodyFormAsJsonWhenContentTypeIsJson()
+    {
+        var operation = new OperationDefinition
+        {
+            Matches =
+            [
+                new QueryMatchDefinition
+                {
+                    Body = new Dictionary<object, object>
+                    {
+                        ["form"] = "legacy-json-property"
+                    }
+                }
+            ]
+        };
+
+        var matcher = CreateMatcherService();
+
+        var match = FindBestMatch(
+            matcher,
+            operation,
+            new Dictionary<string, string>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Content-Type"] = "application/json"
+            },
+            "{\"form\":\"legacy-json-property\"}");
+
+        Assert.NotNull(match);
+    }
+
+    [Fact]
     public void FindBestMatch_ReturnsNullWhenBodyDefinitionContainsUnsupportedValue()
     {
         var operation = new OperationDefinition

--- a/tests/SemanticStub.Api.Tests/Unit/MatcherServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/MatcherServiceTests.cs
@@ -10,7 +10,7 @@ public sealed class MatcherServiceTests
 {
     private static MatcherService CreateMatcherService()
     {
-        return new MatcherService(new JsonBodyMatcher(), new QueryValueMatcher(), new RegexQueryMatcher());
+        return new MatcherService(new JsonBodyMatcher(), new FormBodyMatcher(), new QueryValueMatcher(), new RegexQueryMatcher());
     }
 
     [Fact]

--- a/tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs
@@ -601,6 +601,36 @@ public sealed class StubDefinitionLoaderTests
     }
 
     [Fact]
+    public void LoadDefaultDefinition_ThrowsWhenFormBodyMatchOperatorsAreMixed()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+              /login:
+                post:
+                  x-match:
+                    - body:
+                        form:
+                          username:
+                            equals: demo
+                            regex: "^demo$"
+                      response:
+                        statusCode: 200
+                        content:
+                          application/json:
+                            example:
+                              message: ok
+            """);
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
+
+        Assert.Contains("x-match[0].body.form['username'] must not combine equals and regex operators.", exception.Message);
+    }
+
+    [Fact]
     public void LoadDefaultDefinition_LoadsScenarioDefinitionFromResponseExtension()
     {
         using var workspace = TestWorkspace.Create(

--- a/tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs
@@ -571,6 +571,36 @@ public sealed class StubDefinitionLoaderTests
     }
 
     [Fact]
+    public void LoadDefaultDefinition_ThrowsWhenFormBodyIsCombinedWithOtherBodyMatchTypes()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+              /login:
+                post:
+                  x-match:
+                    - body:
+                        form:
+                          username: demo
+                        json:
+                          username: demo
+                      response:
+                        statusCode: 200
+                        content:
+                          application/json:
+                            example:
+                              message: ok
+            """);
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
+
+        Assert.Contains("x-match[0].body.form cannot be combined with body.json", exception.Message);
+    }
+
+    [Fact]
     public void LoadDefaultDefinition_LoadsScenarioDefinitionFromResponseExtension()
     {
         using var workspace = TestWorkspace.Create(

--- a/tests/SemanticStub.Api.Tests/Unit/StubDispatchSelectorTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubDispatchSelectorTests.cs
@@ -10,7 +10,7 @@ public sealed class StubDispatchSelectorTests
 {
     private static MatcherService CreateMatcherService()
     {
-        return new MatcherService(new JsonBodyMatcher(), new QueryValueMatcher(), new RegexQueryMatcher());
+        return new MatcherService(new JsonBodyMatcher(), new FormBodyMatcher(), new QueryValueMatcher(), new RegexQueryMatcher());
     }
 
     [Fact]

--- a/tests/SemanticStub.Api.Tests/Unit/StubInspectionServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubInspectionServiceTests.cs
@@ -14,7 +14,7 @@ public sealed class StubInspectionServiceTests
 {
     private static MatcherService CreateMatcherService()
     {
-        return new MatcherService(new JsonBodyMatcher(), new QueryValueMatcher(), new RegexQueryMatcher());
+        return new MatcherService(new JsonBodyMatcher(), new FormBodyMatcher(), new QueryValueMatcher(), new RegexQueryMatcher());
     }
 
     // ---------------------------------------------------------------------------

--- a/tests/SemanticStub.Api.Tests/Unit/StubServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubServiceTests.cs
@@ -14,7 +14,7 @@ public sealed class StubServiceTests
 
     private static MatcherService CreateMatcherService()
     {
-        return new MatcherService(new JsonBodyMatcher(), new QueryValueMatcher(), new RegexQueryMatcher());
+        return new MatcherService(new JsonBodyMatcher(), new FormBodyMatcher(), new QueryValueMatcher(), new RegexQueryMatcher());
     }
 
     private static StubResponse AssertMatchedResponse(StubMatchResult matched, StubResponse? response)


### PR DESCRIPTION
## Summary
- Add `body.form` matching for `application/x-www-form-urlencoded` request bodies.
- Parse URL-encoded form bodies with decoding, empty values, key-only entries, and repeated keys.
- Keep existing JSON body matching behavior when the request is not form-encoded.

## Files Changed
- `src/SemanticStub.Api/Services/Matching/FormBodyMatcher.cs`
- `src/SemanticStub.Api/Services/Matching/MatcherService.cs`
- `src/SemanticStub.Api/Extensions/StubServiceCollectionExtensions.cs`
- `src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionValidator.cs`
- `tests/SemanticStub.Api.Tests/Unit/FormBodyMatcherTests.cs`
- `tests/SemanticStub.Api.Tests/Unit/MatcherServiceTests.cs`
- `tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs`

## Tests
- `dotnet test SemanticStub.sln --no-restore`

## Notes
- Addressed review feedback for `body.form` operator validation and explicit matcher dependency wiring.
- Closes #169