### PR TITLE
feat: support form body match operators

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -122,13 +122,31 @@ paths:
             application/json:
               example:
                 users: []
+  /oauth/token:
+    post:
+      x-match:
+        - body:
+            form:
+              grant_type:
+                equals: authorization_code
+              code:
+                regex: "^[A-Za-z0-9_-]+$"
+          response:
+            statusCode: 200
+            content:
+              application/json:
+                example:
+                  access_token: token-123
+      responses:
+        '400':
+          description: Invalid token request
 ```
 
 各 `x-match` エントリには次を含められます。
 
 - `query`: scalar の `equals` 省略形、または明示的な `equals` / `regex` operator による query string 条件
 - `headers`: scalar の `equals` 省略形、または明示的な `equals` / `regex` operator による header 条件
-- `body`: リクエストボディ条件
+- `body`: JSON body 条件、または `body.form` による form-urlencoded body 条件
 - `x-semantic-match`: セマンティックフォールバックマッチングに使う自然言語の説明
 - `response`: 条件に一致したときに返すレスポンス
 
@@ -141,7 +159,9 @@ paths:
 - scalar の `query` / `headers` 値は `equals` の省略形として扱われます。
 - `query.equals` は単一値の完全一致、順序付きの繰り返し値、および `integer`、`number`、`boolean` など宣言済み OpenAPI query parameter type に対する型付き比較をサポートします。
 - `query.regex` と `headers.regex` は regex マッチを行います。contains / starts-with / ends-with は `.*value.*`、`^value`、`value$` のような regex pattern で表現できます。
-- `body` マッチは現在 JSON リクエストボディに対して適用されます。object に対する body マッチは部分一致なので、追加プロパティを含んでいても一致できます。
+- JSON `body` マッチは object に対して部分一致なので、追加プロパティを含んでいても一致できます。
+- `application/x-www-form-urlencoded` リクエストボディには `body.form` を使います。scalar の form 値は `equals` の省略形として扱われ、form field には明示的な `equals` / `regex` operator も使えます。設定した form key は存在する必要があり、追加の request form key は許可されます。
+- `body.form` は同じ match entry 内で `body.json` や `body.text` と併用できません。
 - 不正な JSON リクエストボディは `body` 条件に一致しません。
 - `x-semantic-match` エントリは、すべての決定的な条件が失敗したときのみ評価されます。アプリケーション設定でセマンティックマッチングを有効化する必要があります。`x-semantic-match` を含むエントリに `query`、`headers`、`body` を同時に指定することはできません。
 - どの `x-match` も成功しない場合、SemanticStub は標準の `responses` セクションへフォールバックします。

--- a/README.md
+++ b/README.md
@@ -133,6 +133,24 @@ paths:
             application/json:
               example:
                 users: []
+  /oauth/token:
+    post:
+      x-match:
+        - body:
+            form:
+              grant_type:
+                equals: authorization_code
+              code:
+                regex: "^[A-Za-z0-9_-]+$"
+          response:
+            statusCode: 200
+            content:
+              application/json:
+                example:
+                  access_token: token-123
+      responses:
+        '400':
+          description: Invalid token request
 ```
 
 Each `x-match` entry may contain:
@@ -141,7 +159,7 @@ Each `x-match` entry may contain:
   `equals` / `regex` operators.
 - `headers`: header matches using scalar `equals` shorthand or explicit
   `equals` / `regex` operators.
-- `body`: exact body match data.
+- `body`: JSON body match data or `body.form` form-urlencoded match data.
 - `x-semantic-match`: natural-language description used for semantic fallback matching.
 - `response`: the response returned when the match succeeds.
 
@@ -161,9 +179,14 @@ Notes:
 - `query.regex` and `headers.regex` perform regex matching. Use regex patterns
   such as `.*value.*`, `^value`, or `value$` for contains, starts-with, or
   ends-with matches.
-- `body` matching currently applies to JSON request bodies. Body matching is
-  partial for objects, so a request may contain additional properties and still
-  match.
+- JSON `body` matching is partial for objects, so a request may contain
+  additional properties and still match.
+- Use `body.form` for `application/x-www-form-urlencoded` request bodies. Scalar
+  form values are shorthand for `equals`, and form fields may also use explicit
+  `equals` / `regex` operators. Configured form keys must exist, and additional
+  request form keys are allowed.
+- `body.form` cannot be combined with `body.json` or `body.text` in the same
+  match entry.
 - Invalid JSON request bodies do not satisfy `body` match conditions.
 - `x-semantic-match` entries are evaluated only after all deterministic
   conditions fail. They require semantic matching to be enabled in application

--- a/SemanticStub.http
+++ b/SemanticStub.http
@@ -158,6 +158,20 @@ Accept: application/json
   "password": "wrong"
 }
 
+### OAuth token stub with matching form body operators
+POST {{host}}/oauth/token
+Content-Type: application/x-www-form-urlencoded
+Accept: application/json
+
+grant_type=authorization_code&code=abc_123
+
+### OAuth token stub falls back when form body regex does not match
+POST {{host}}/oauth/token
+Content-Type: application/x-www-form-urlencoded
+Accept: application/json
+
+grant_type=authorization_code&code=invalid!
+
 ### Replace profile
 PUT {{host}}/profile
 Content-Type: application/json

--- a/samples/basic-routing.yaml
+++ b/samples/basic-routing.yaml
@@ -286,6 +286,57 @@ paths:
               example:
                 result: invalid
 
+  /oauth/token:
+    post:
+      operationId: issueToken
+      x-match:
+        - body:
+            form:
+              grant_type:
+                equals: authorization_code
+              code:
+                regex: "^[A-Za-z0-9_-]+$"
+          response:
+            statusCode: 200
+            content:
+              application/json:
+                example:
+                  access_token: token-123
+                  token_type: bearer
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                grant_type:
+                  type: string
+                code:
+                  type: string
+              required:
+                - grant_type
+                - code
+            example:
+              grant_type: authorization_code
+              code: abc_123
+      responses:
+        '400':
+          description: Invalid token request
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                properties:
+                  error:
+                    type: string
+                required:
+                  - error
+              example:
+                error: invalid_grant
+
   /profile:
     put:
       operationId: replaceProfile

--- a/src/SemanticStub.Api/Controllers/StubController.cs
+++ b/src/SemanticStub.Api/Controllers/StubController.cs
@@ -13,6 +13,7 @@ namespace SemanticStub.Api.Controllers;
 [Route("{*path}")]
 public sealed class StubController : ControllerBase
 {
+    private const string FormUrlEncodedMediaType = "application/x-www-form-urlencoded";
     private readonly IStubService stubService;
     private readonly IStubInspectionService inspectionService;
 
@@ -192,7 +193,18 @@ public sealed class StubController : ControllerBase
     {
         try
         {
+            if (IsFormUrlEncoded(Request.ContentType))
+            {
+                var form = await Request.ReadFormAsync();
+                return SerializeFormBody(form);
+            }
+
             using var reader = new StreamReader(Request.Body, leaveOpen: true);
+            if (Request.Body.CanSeek)
+            {
+                Request.Body.Position = 0;
+            }
+
             var body = await reader.ReadToEndAsync();
 
             if (Request.Body.CanSeek)
@@ -210,5 +222,35 @@ public sealed class StubController : ControllerBase
         {
             return null;
         }
+    }
+
+    private static bool IsFormUrlEncoded(string? contentType)
+    {
+        if (string.IsNullOrWhiteSpace(contentType))
+        {
+            return false;
+        }
+
+        var mediaType = contentType.Split(';', count: 2)[0].Trim();
+        return string.Equals(mediaType, FormUrlEncodedMediaType, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string? SerializeFormBody(IFormCollection form)
+    {
+        if (form.Count == 0)
+        {
+            return null;
+        }
+
+        var pairs = new List<string>();
+        foreach (var field in form)
+        {
+            foreach (var value in field.Value)
+            {
+                pairs.Add($"{Uri.EscapeDataString(field.Key)}={Uri.EscapeDataString(value ?? string.Empty)}");
+            }
+        }
+
+        return string.Join("&", pairs);
     }
 }

--- a/src/SemanticStub.Api/Extensions/StubServiceCollectionExtensions.cs
+++ b/src/SemanticStub.Api/Extensions/StubServiceCollectionExtensions.cs
@@ -41,7 +41,8 @@ public static class StubServiceCollectionExtensions
         services.AddHostedService<StubDefinitionWatcher>();
         services.AddSingleton(serviceProvider => new JsonBodyMatcher(
             serviceProvider.GetRequiredService<ILogger<JsonBodyMatcher>>()));
-        services.AddSingleton<FormBodyMatcher>();
+        services.AddSingleton(serviceProvider => new FormBodyMatcher(
+            serviceProvider.GetRequiredService<ILogger<FormBodyMatcher>>()));
         services.AddSingleton<QueryValueMatcher>();
         services.AddSingleton(serviceProvider => new RegexQueryMatcher(
             serviceProvider.GetRequiredService<ILogger<RegexQueryMatcher>>()));

--- a/src/SemanticStub.Api/Services/Matching/FormBodyMatcher.cs
+++ b/src/SemanticStub.Api/Services/Matching/FormBodyMatcher.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Globalization;
 using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using SemanticStub.Api.Models;
 
@@ -10,6 +11,12 @@ internal sealed class FormBodyMatcher
 {
     private const string FormUrlEncodedMediaType = "application/x-www-form-urlencoded";
     private static readonly TimeSpan RegexMatchTimeout = TimeSpan.FromMilliseconds(100);
+    private readonly ILogger<FormBodyMatcher>? logger;
+
+    internal FormBodyMatcher(ILogger<FormBodyMatcher>? logger = null)
+    {
+        this.logger = logger;
+    }
 
     internal IReadOnlyDictionary<string, StringValues>? ParseRequestBody(string? body, string? contentType)
     {
@@ -76,7 +83,7 @@ internal sealed class FormBodyMatcher
         return true;
     }
 
-    private static bool IsFormFieldMatch(object? expected, StringValues actual)
+    private bool IsFormFieldMatch(object? expected, StringValues actual)
     {
         if (MatchOperatorDefinition.TryGetEquals(expected, out var equals))
         {
@@ -122,7 +129,7 @@ internal sealed class FormBodyMatcher
                string.Equals(ConvertFormValueToString(expected), actual[0], StringComparison.Ordinal);
     }
 
-    private static bool IsRegexStringMatch(object? expected, StringValues actual)
+    private bool IsRegexStringMatch(object? expected, StringValues actual)
     {
         if (expected is IEnumerable expectedSequence and not string)
         {
@@ -151,7 +158,7 @@ internal sealed class FormBodyMatcher
                IsSingleRegexStringMatch(expected, actual[0]!);
     }
 
-    private static bool IsSingleRegexStringMatch(object? expected, string actual)
+    private bool IsSingleRegexStringMatch(object? expected, string actual)
     {
         if (expected is not string pattern)
         {
@@ -162,12 +169,14 @@ internal sealed class FormBodyMatcher
         {
             return Regex.IsMatch(actual, pattern, RegexOptions.CultureInvariant, RegexMatchTimeout);
         }
-        catch (ArgumentException)
+        catch (ArgumentException ex)
         {
+            logger?.LogWarning(ex, "Invalid regex match pattern '{Pattern}' in stub definition — treating as non-match.", pattern);
             return false;
         }
         catch (RegexMatchTimeoutException)
         {
+            logger?.LogWarning("Regex match pattern '{Pattern}' timed out after {TimeoutMs}ms — treating as non-match.", pattern, RegexMatchTimeout.TotalMilliseconds);
             return false;
         }
     }

--- a/src/SemanticStub.Api/Services/Matching/FormBodyMatcher.cs
+++ b/src/SemanticStub.Api/Services/Matching/FormBodyMatcher.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Globalization;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Primitives;
 using SemanticStub.Api.Models;
 
@@ -8,6 +9,7 @@ namespace SemanticStub.Api.Services;
 internal sealed class FormBodyMatcher
 {
     private const string FormUrlEncodedMediaType = "application/x-www-form-urlencoded";
+    private static readonly TimeSpan RegexMatchTimeout = TimeSpan.FromMilliseconds(100);
 
     internal IReadOnlyDictionary<string, StringValues>? ParseRequestBody(string? body, string? contentType)
     {
@@ -64,15 +66,25 @@ internal sealed class FormBodyMatcher
 
         foreach (var expectedValue in expectedForm)
         {
-            if (!MatchOperatorDefinition.TryGetEquals(expectedValue.Value, out var equals) ||
-                !actualForm.TryGetValue(expectedValue.Key, out var actualValue) ||
-                !IsExactStringMatch(equals, actualValue))
+            if (!actualForm.TryGetValue(expectedValue.Key, out var actualValue) ||
+                !IsFormFieldMatch(expectedValue.Value, actualValue))
             {
                 return false;
             }
         }
 
         return true;
+    }
+
+    private static bool IsFormFieldMatch(object? expected, StringValues actual)
+    {
+        if (MatchOperatorDefinition.TryGetEquals(expected, out var equals))
+        {
+            return IsExactStringMatch(equals, actual);
+        }
+
+        return MatchOperatorDefinition.TryGetRegex(expected, out var regex) &&
+               IsRegexStringMatch(regex, actual);
     }
 
     internal bool HasFormCondition(object? expectedBody)
@@ -108,6 +120,56 @@ internal sealed class FormBodyMatcher
         return actual.Count == 1 &&
                actual[0] is not null &&
                string.Equals(ConvertFormValueToString(expected), actual[0], StringComparison.Ordinal);
+    }
+
+    private static bool IsRegexStringMatch(object? expected, StringValues actual)
+    {
+        if (expected is IEnumerable expectedSequence and not string)
+        {
+            var expectedValues = expectedSequence.Cast<object?>().ToArray();
+            var actualValues = actual.ToArray();
+
+            if (expectedValues.Length != actualValues.Length)
+            {
+                return false;
+            }
+
+            for (var index = 0; index < expectedValues.Length; index++)
+            {
+                if (actualValues[index] is null ||
+                    !IsSingleRegexStringMatch(expectedValues[index], actualValues[index]!))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return actual.Count == 1 &&
+               actual[0] is not null &&
+               IsSingleRegexStringMatch(expected, actual[0]!);
+    }
+
+    private static bool IsSingleRegexStringMatch(object? expected, string actual)
+    {
+        if (expected is not string pattern)
+        {
+            return false;
+        }
+
+        try
+        {
+            return Regex.IsMatch(actual, pattern, RegexOptions.CultureInvariant, RegexMatchTimeout);
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return false;
+        }
     }
 
     private static string ConvertFormValueToString(object? value)

--- a/tests/SemanticStub.Api.Tests/Integration/BasicRoutingStubTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/BasicRoutingStubTests.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Diagnostics;
 using System.Text;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 
@@ -277,6 +278,26 @@ public sealed class BasicRoutingStubTests : IClassFixture<WebApplicationFactory<
     }
 
     [Fact]
+    public async Task PostOAuthToken_WithMatchingFormBodyOperators_ReturnsToken()
+    {
+        using var content = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["grant_type"] = "authorization_code",
+            ["code"] = "abc_123"
+        });
+
+        var response = await client.PostAsync("/oauth/token", content);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        var payload = await response.Content.ReadFromJsonAsync<TokenResponse>();
+        Assert.NotNull(payload);
+        Assert.Equal("token-123", payload.AccessToken);
+        Assert.Equal("bearer", payload.TokenType);
+    }
+
+    [Fact]
     public async Task PostCheckout_AdvancesScenarioStateAcrossRequests()
     {
         var firstResponse = await client.PostAsync("/checkout", content: null);
@@ -465,6 +486,15 @@ public sealed class BasicRoutingStubTests : IClassFixture<WebApplicationFactory<
         public string Result { get; init; } = string.Empty;
 
         public string? Token { get; init; }
+    }
+
+    public sealed class TokenResponse
+    {
+        [JsonPropertyName("access_token")]
+        public string AccessToken { get; init; } = string.Empty;
+
+        [JsonPropertyName("token_type")]
+        public string TokenType { get; init; } = string.Empty;
     }
 
     public sealed class ProfileRequest

--- a/tests/SemanticStub.Api.Tests/Unit/FormBodyMatcherTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/FormBodyMatcherTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using SemanticStub.Api.Services;
 using Xunit;
@@ -135,6 +136,66 @@ public sealed class FormBodyMatcherTests
     }
 
     [Fact]
+    public void IsMatch_ReturnsFalseForInvalidRegexAndLogsWarning()
+    {
+        var logger = new ListLogger<FormBodyMatcher>();
+        var matcher = new FormBodyMatcher(logger);
+        var form = new Dictionary<string, StringValues>(StringComparer.Ordinal)
+        {
+            ["code"] = "abc_123"
+        };
+
+        var matched = matcher.IsMatch(
+            new Dictionary<object, object>
+            {
+                ["form"] = new Dictionary<object, object>
+                {
+                    ["code"] = new Dictionary<object, object>
+                    {
+                        ["regex"] = "["
+                    }
+                }
+            },
+            form);
+
+        Assert.False(matched);
+        Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, logger.Entries[0].LogLevel);
+        Assert.Contains("Invalid regex match pattern", logger.Entries[0].Message, StringComparison.Ordinal);
+        Assert.IsAssignableFrom<ArgumentException>(logger.Entries[0].Exception);
+    }
+
+    [Fact]
+    public void IsMatch_ReturnsFalseWhenRegexEvaluationTimesOutAndLogsWarning()
+    {
+        var logger = new ListLogger<FormBodyMatcher>();
+        var matcher = new FormBodyMatcher(logger);
+        var form = new Dictionary<string, StringValues>(StringComparer.Ordinal)
+        {
+            ["code"] = new string('a', 4096) + "!"
+        };
+
+        var matched = matcher.IsMatch(
+            new Dictionary<object, object>
+            {
+                ["form"] = new Dictionary<object, object>
+                {
+                    ["code"] = new Dictionary<object, object>
+                    {
+                        ["regex"] = "^(a+)+$"
+                    }
+                }
+            },
+            form);
+
+        Assert.False(matched);
+        Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, logger.Entries[0].LogLevel);
+        Assert.Contains("timed out after", logger.Entries[0].Message, StringComparison.Ordinal);
+        Assert.Null(logger.Entries[0].Exception);
+    }
+
+    [Fact]
     public void IsMatch_RequiresRepeatedValuesToMatchInOrder()
     {
         var matcher = new FormBodyMatcher();
@@ -154,5 +215,39 @@ public sealed class FormBodyMatcherTests
             form);
 
         Assert.True(matched);
+    }
+
+    private sealed class ListLogger<T> : ILogger<T>
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public IDisposable BeginScope<TState>(TState state)
+            where TState : notnull
+        {
+            return NullScope.Instance;
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add(new LogEntry(logLevel, formatter(state, exception), exception));
+        }
+    }
+
+    private sealed record LogEntry(LogLevel LogLevel, string Message, Exception? Exception);
+
+    private sealed class NullScope : IDisposable
+    {
+        public static NullScope Instance { get; } = new();
+
+        public void Dispose()
+        {
+        }
     }
 }

--- a/tests/SemanticStub.Api.Tests/Unit/FormBodyMatcherTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/FormBodyMatcherTests.cs
@@ -60,6 +60,81 @@ public sealed class FormBodyMatcherTests
     }
 
     [Fact]
+    public void IsMatch_MatchesEqualsOperatorFormValue()
+    {
+        var matcher = new FormBodyMatcher();
+        var form = new Dictionary<string, StringValues>(StringComparer.Ordinal)
+        {
+            ["userId"] = "test001"
+        };
+
+        var matched = matcher.IsMatch(
+            new Dictionary<object, object>
+            {
+                ["form"] = new Dictionary<object, object>
+                {
+                    ["userId"] = new Dictionary<object, object>
+                    {
+                        ["equals"] = "test001"
+                    }
+                }
+            },
+            form);
+
+        Assert.True(matched);
+    }
+
+    [Fact]
+    public void IsMatch_MatchesRegexOperatorFormValue()
+    {
+        var matcher = new FormBodyMatcher();
+        var form = new Dictionary<string, StringValues>(StringComparer.Ordinal)
+        {
+            ["code"] = "abc_123"
+        };
+
+        var matched = matcher.IsMatch(
+            new Dictionary<object, object>
+            {
+                ["form"] = new Dictionary<object, object>
+                {
+                    ["code"] = new Dictionary<object, object>
+                    {
+                        ["regex"] = "^[A-Za-z0-9_]+$"
+                    }
+                }
+            },
+            form);
+
+        Assert.True(matched);
+    }
+
+    [Fact]
+    public void IsMatch_ReturnsFalseWhenRegexOperatorFormValueDiffers()
+    {
+        var matcher = new FormBodyMatcher();
+        var form = new Dictionary<string, StringValues>(StringComparer.Ordinal)
+        {
+            ["userId"] = "abc123"
+        };
+
+        var matched = matcher.IsMatch(
+            new Dictionary<object, object>
+            {
+                ["form"] = new Dictionary<object, object>
+                {
+                    ["userId"] = new Dictionary<object, object>
+                    {
+                        ["regex"] = "^[0-9]{6}$"
+                    }
+                }
+            },
+            form);
+
+        Assert.False(matched);
+    }
+
+    [Fact]
     public void IsMatch_RequiresRepeatedValuesToMatchInOrder()
     {
         var matcher = new FormBodyMatcher();

--- a/tests/SemanticStub.Api.Tests/Unit/MatcherServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/MatcherServiceTests.cs
@@ -162,6 +162,44 @@ public sealed class MatcherServiceTests
     }
 
     [Fact]
+    public void FindBestMatch_MatchesFormUrlEncodedBodyRegexOperatorCondition()
+    {
+        var operation = new OperationDefinition
+        {
+            Matches =
+            [
+                new QueryMatchDefinition
+                {
+                    Body = new Dictionary<object, object>
+                    {
+                        ["form"] = new Dictionary<object, object>
+                        {
+                            ["userId"] = new Dictionary<object, object>
+                            {
+                                ["regex"] = "^[0-9]{6}$"
+                            }
+                        }
+                    }
+                }
+            ]
+        };
+
+        var matcher = CreateMatcherService();
+
+        var match = FindBestMatch(
+            matcher,
+            operation,
+            new Dictionary<string, string>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Content-Type"] = "application/x-www-form-urlencoded"
+            },
+            "userId=123456&extra=allowed");
+
+        Assert.NotNull(match);
+    }
+
+    [Fact]
     public void FindBestMatch_ReturnsNullWhenFormContentTypeIsMissing()
     {
         var operation = new OperationDefinition

--- a/tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs
@@ -631,6 +631,92 @@ public sealed class StubDefinitionLoaderTests
     }
 
     [Fact]
+    public void LoadDefaultDefinition_ThrowsWhenFormBodyOperatorValueIsAnEmptyMap()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+              /login:
+                post:
+                  x-match:
+                    - body:
+                        form:
+                          username: {}
+                      response:
+                        statusCode: 200
+                        content:
+                          application/json:
+                            example:
+                              message: ok
+            """);
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
+
+        Assert.Contains("x-match[0].body.form['username'] must define at least one supported operator", exception.Message);
+    }
+
+    [Fact]
+    public void LoadDefaultDefinition_ThrowsWhenFormBodyMatchOperatorIsUnsupported()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+              /login:
+                post:
+                  x-match:
+                    - body:
+                        form:
+                          username:
+                            contains: demo
+                      response:
+                        statusCode: 200
+                        content:
+                          application/json:
+                            example:
+                              message: ok
+            """);
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
+
+        Assert.Contains("x-match[0].body.form['username'] uses unsupported operator 'contains'", exception.Message);
+    }
+
+    [Fact]
+    public void LoadDefaultDefinition_ThrowsWhenFormBodyRegexOperatorPatternIsInvalid()
+    {
+        using var workspace = TestWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+              /login:
+                post:
+                  x-match:
+                    - body:
+                        form:
+                          username:
+                            regex: "["
+                      response:
+                        statusCode: 200
+                        content:
+                          application/json:
+                            example:
+                              message: ok
+            """);
+
+        var loader = new StubDefinitionLoader(workspace.Environment);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => loader.LoadDefaultDefinition());
+
+        Assert.Contains("x-match[0].body.form['username'].regex must be a valid regex pattern", exception.Message);
+    }
+
+    [Fact]
     public void LoadDefaultDefinition_LoadsScenarioDefinitionFromResponseExtension()
     {
         using var workspace = TestWorkspace.Create(


### PR DESCRIPTION
## Summary
- Add `equals` and `regex` operator matching for `body.form` fields.
- Preserve existing scalar shorthand behavior as exact matching.
- Read real `application/x-www-form-urlencoded` request bodies through the controller path so form body matches work for live HTTP requests.
- Log invalid or timed-out form body regex evaluations consistently with query regex matching.
- Document the new `body.form` operator syntax and add matching sample YAML / `.http` requests.

## Files Changed
- `src/SemanticStub.Api/Services/Matching/FormBodyMatcher.cs`
- `src/SemanticStub.Api/Controllers/StubController.cs`
- `src/SemanticStub.Api/Extensions/StubServiceCollectionExtensions.cs`
- `tests/SemanticStub.Api.Tests/Unit/FormBodyMatcherTests.cs`
- `tests/SemanticStub.Api.Tests/Unit/MatcherServiceTests.cs`
- `tests/SemanticStub.Api.Tests/Unit/StubDefinitionLoaderTests.cs`
- `tests/SemanticStub.Api.Tests/Integration/BasicRoutingStubTests.cs`
- `samples/basic-routing.yaml`
- `SemanticStub.http`
- `README.md`
- `README.ja.md`

## Tests
- `dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj`
- `dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter FullyQualifiedName~FormBodyMatcherTests`
- `git diff --check`

## Notes
- Closes #170
- No YAML structure changes or new dependencies.