### PR TITLE
refactor: remove public StubService test constructor

### DIFF
--- a/src/SemanticStub.Api/Services/Resolution/StubService.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubService.cs
@@ -1,7 +1,6 @@
 using SemanticStub.Api.Infrastructure.Yaml;
 using SemanticStub.Api.Inspection;
 using SemanticStub.Api.Models;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 
 namespace SemanticStub.Api.Services;
@@ -32,37 +31,6 @@ public sealed class StubService : IStubService
         StubInspectionProjectionBuilder inspectionProjectionBuilder)
         : this(state.GetCurrentDocument, matcherService, scenarioService, dispatchSelector, inspectionProjectionBuilder)
     {
-    }
-
-    /// <summary>
-    /// Creates a service over an already loaded stub document.
-    /// </summary>
-    /// <param name="document">The validated stub document to evaluate.</param>
-    /// <param name="responseFileReader">Loads the contents of a relative response file selected by the matching stub. Use a throwing delegate when response files are not needed.</param>
-    /// <param name="matcherService">The matcher used to evaluate <c>x-match</c> candidates when a route and method have been resolved.</param>
-    /// <param name="scenarioService">Stores in-memory scenario transitions for responses that opt into <c>x-scenario</c>.</param>
-    /// <param name="semanticMatcherService">When supplied, enables semantic fallback matching for candidates that define <c>x-semantic-match</c>.</param>
-    /// <param name="logger">When supplied, emits structured log events for match selection and semantic scoring.</param>
-    public StubService(
-        StubDocument document,
-        Func<string, string> responseFileReader,
-        MatcherService matcherService,
-        ScenarioService scenarioService,
-        ISemanticMatcherService? semanticMatcherService = null,
-        ILogger<StubService>? logger = null)
-    {
-        this.documentAccessor = () => document;
-        var responseBuilder = new StubResponseBuilder(responseFileReader);
-        this.dispatchSelector = new StubDispatchSelector(
-            matcherService,
-            semanticMatcherService,
-            responseBuilder,
-            new StubDefaultResponseSelector(responseBuilder, scenarioService),
-            scenarioService,
-            logger);
-        this.inspectionProjectionBuilder = new StubInspectionProjectionBuilder(scenarioService);
-        this.matcherService = matcherService;
-        this.scenarioService = scenarioService;
     }
 
     private StubService(

--- a/tests/SemanticStub.Api.Tests/Unit/StubInspectionServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubInspectionServiceTests.cs
@@ -59,11 +59,10 @@ public sealed class StubInspectionServiceTests
         {
             SemanticMatching = new SemanticMatchingSettings { Enabled = semanticMatchingEnabled },
         });
-        var stubService = new StubService(
-            document,
-            _ => throw new InvalidOperationException("Not used in inspection tests"),
-            matcherService ?? CreateMatcherService(),
+        var stubService = CreateStubService(
+            state,
             scenarioService,
+            matcherService ?? CreateMatcherService(),
             semanticMatcherService ?? new NoOpSemanticMatcherService());
         return new StubInspectionService(
             state,
@@ -72,6 +71,28 @@ public sealed class StubInspectionServiceTests
             stubService,
             new StubInspectionRuntimeStore(),
             new StubInspectionScenarioCoordinator(state, scenarioService));
+    }
+
+    private static StubService CreateStubService(
+        StubDefinitionState state,
+        ScenarioService scenarioService,
+        MatcherService matcherService,
+        ISemanticMatcherService semanticMatcherService)
+    {
+        var responseBuilder = new StubResponseBuilder(state.LoadResponseFileContent);
+
+        return new StubService(
+            state,
+            matcherService,
+            scenarioService,
+            new StubDispatchSelector(
+                matcherService,
+                semanticMatcherService,
+                responseBuilder,
+                new StubDefaultResponseSelector(responseBuilder, scenarioService),
+                scenarioService,
+                NullLogger<StubDispatchSelector>.Instance),
+            new StubInspectionProjectionBuilder(scenarioService));
     }
 
     private static StubDocument EmptyDocument() => new StubDocument
@@ -1175,12 +1196,7 @@ public sealed class StubInspectionServiceTests
         var scenarioService = new ScenarioService();
         var state = new StubDefinitionState(loader, scenarioService, NullLogger<StubDefinitionState>.Instance);
         var settings = Options.Create(new StubSettings());
-        var stubService = new StubService(
-            initialDocument,
-            _ => throw new InvalidOperationException("Not used in inspection tests"),
-            CreateMatcherService(),
-            scenarioService,
-            new NoOpSemanticMatcherService());
+        var stubService = CreateStubService(state, scenarioService, CreateMatcherService(), new NoOpSemanticMatcherService());
         var service = new StubInspectionService(
             state,
             loader,
@@ -1271,7 +1287,7 @@ public sealed class StubInspectionServiceTests
         var scenarioService = new ScenarioService();
         var state = new StubDefinitionState(loader, scenarioService, NullLogger<StubDefinitionState>.Instance);
         var settings = Options.Create(new StubSettings());
-        var stubService = new StubService(document, _ => throw new InvalidOperationException("Not used in inspection tests"), CreateMatcherService(), scenarioService, new NoOpSemanticMatcherService());
+        var stubService = CreateStubService(state, scenarioService, CreateMatcherService(), new NoOpSemanticMatcherService());
         var service = new StubInspectionService(
             state,
             loader,
@@ -1350,7 +1366,7 @@ public sealed class StubInspectionServiceTests
         var scenarioService = new ScenarioService();
         var state = new StubDefinitionState(loader, scenarioService, NullLogger<StubDefinitionState>.Instance);
         var settings = Options.Create(new StubSettings());
-        var stubService = new StubService(document, _ => throw new InvalidOperationException("Not used in inspection tests"), CreateMatcherService(), scenarioService, new NoOpSemanticMatcherService());
+        var stubService = CreateStubService(state, scenarioService, CreateMatcherService(), new NoOpSemanticMatcherService());
         var service = new StubInspectionService(
             state,
             loader,
@@ -1477,7 +1493,7 @@ public sealed class StubInspectionServiceTests
         var loader = new TestStubDefinitionLoader(document);
         var scenarioService = new ScenarioService();
         var state = new StubDefinitionState(loader, scenarioService, NullLogger<StubDefinitionState>.Instance);
-        var stubService = new StubService(document, _ => throw new InvalidOperationException("Not used in inspection tests"), CreateMatcherService(), scenarioService, new NoOpSemanticMatcherService());
+        var stubService = CreateStubService(state, scenarioService, CreateMatcherService(), new NoOpSemanticMatcherService());
         var service = new StubInspectionService(
             state,
             loader,

--- a/tests/SemanticStub.Api.Tests/Unit/StubServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubServiceTests.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Primitives;
+using SemanticStub.Api.Inspection;
 using SemanticStub.Api.Infrastructure.Yaml;
 using SemanticStub.Api.Models;
 using SemanticStub.Api.Services;
@@ -118,12 +120,24 @@ public sealed class StubServiceTests
         MatcherService? matcherService = null,
         ISemanticMatcherService? semanticMatcherService = null)
     {
+        var resolvedScenarioService = scenarioService ?? new ScenarioService();
+        var resolvedMatcherService = matcherService ?? CreateMatcherService();
+        var loader = new TestStubDefinitionLoader(document, responseFileReader ?? ThrowingResponseFileReader);
+        var state = new StubDefinitionState(loader, resolvedScenarioService, NullLogger<StubDefinitionState>.Instance);
+        var responseBuilder = new StubResponseBuilder(state.LoadResponseFileContent);
+
         return new StubService(
-            document,
-            responseFileReader ?? ThrowingResponseFileReader,
-            matcherService ?? CreateMatcherService(),
-            scenarioService ?? new ScenarioService(),
-            semanticMatcherService);
+            state,
+            resolvedMatcherService,
+            resolvedScenarioService,
+            new StubDispatchSelector(
+                resolvedMatcherService,
+                semanticMatcherService,
+                responseBuilder,
+                new StubDefaultResponseSelector(responseBuilder, resolvedScenarioService),
+                resolvedScenarioService,
+                NullLogger<StubDispatchSelector>.Instance),
+            new StubInspectionProjectionBuilder(resolvedScenarioService));
     }
 
     [Fact]
@@ -185,7 +199,13 @@ public sealed class StubServiceTests
     }
 
     [Fact]
-    public void InterfaceContract_ExposesFullConstructorForLoaderBackedDocuments()
+    public void ConstructorContract_DoesNotExposePublicConstructors()
+    {
+        Assert.Empty(typeof(StubService).GetConstructors());
+    }
+
+    [Fact]
+    public void ConstructorContract_UsesLoaderBackedDocumentState()
     {
         var document = new StubDocument
         {
@@ -216,11 +236,7 @@ public sealed class StubServiceTests
             }
         };
 
-        var loader = new TestStubDefinitionLoader(document);
-        var service = CreateService(
-            loader.LoadDefaultDefinition(),
-            responseFileReader: loader.LoadResponseFileContent,
-            matcherService: CreateMatcherService());
+        var service = CreateService(document, matcherService: CreateMatcherService());
 
         var (matched, response) = Dispatch(service, HttpMethods.Get, "/hello");
         var matchedResponse = AssertMatchedResponse(matched, response);
@@ -1929,7 +1945,7 @@ public sealed class StubServiceTests
         Assert.Equal([HttpMethods.Get, HttpMethods.Patch], allowedMethods);
     }
 
-    private sealed class TestStubDefinitionLoader(StubDocument document) : IStubDefinitionLoader
+    private sealed class TestStubDefinitionLoader(StubDocument document, Func<string, string> responseFileReader) : IStubDefinitionLoader
     {
         public string GetDefinitionsDirectoryPath()
         {
@@ -1943,7 +1959,7 @@ public sealed class StubServiceTests
 
         public string LoadResponseFileContent(string fileName)
         {
-            throw new InvalidOperationException("Response-file loading is not used in this test.");
+            return responseFileReader(fileName);
         }
     }
 
@@ -2044,12 +2060,7 @@ public sealed class StubServiceTests
         };
 
         var semanticMatcher = new SpySemanticMatcherService(semanticCandidate);
-        var service = new StubService(
-            document,
-            _ => throw new InvalidOperationException("No response file loading expected."),
-            CreateMatcherService(),
-            new ScenarioService(),
-            semanticMatcher);
+        var service = CreateService(document, semanticMatcherService: semanticMatcher);
         var query = new Dictionary<string, string>(StringComparer.Ordinal)
         {
             ["role"] = "guest"
@@ -2104,12 +2115,7 @@ public sealed class StubServiceTests
         };
 
         var semanticMatcher = new SpySemanticMatcherService(semanticCandidate);
-        var service = new StubService(
-            document,
-            _ => throw new InvalidOperationException("No response file loading expected."),
-            CreateMatcherService(),
-            new ScenarioService(),
-            semanticMatcher);
+        var service = CreateService(document, semanticMatcherService: semanticMatcher);
         var query = new Dictionary<string, string>(StringComparer.Ordinal)
         {
             ["role"] = "admin"


### PR DESCRIPTION
## Summary
- Remove the public StubService constructor used only by tests.
- Update unit test helpers to construct StubService through loader-backed StubDefinitionState and dispatch dependencies.
- Add a regression assertion that StubService exposes no public constructors.

## Files Changed
- src/SemanticStub.Api/Services/Resolution/StubService.cs
- tests/SemanticStub.Api.Tests/Unit/StubServiceTests.cs
- tests/SemanticStub.Api.Tests/Unit/StubInspectionServiceTests.cs

## Tests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --no-restore

## Notes
- Closes #182
- Existing local SKILLS.md changes were left uncommitted and excluded from this PR.