### PR TITLE
refactor: remove unused query conversion overload

### DIFF
--- a/src/SemanticStub.Api/Services/Resolution/StubService.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubService.cs
@@ -212,14 +212,6 @@ public sealed class StubService : IStubService
             selection.SelectionReason);
     }
 
-    private static IReadOnlyDictionary<string, StringValues> ConvertQueryValues(IReadOnlyDictionary<string, string> query)
-    {
-        return query.ToDictionary(
-            entry => entry.Key,
-            entry => new StringValues(entry.Value),
-            StringComparer.Ordinal);
-    }
-
     private static IReadOnlyDictionary<string, StringValues> ConvertQueryValues(IReadOnlyDictionary<string, string[]> query)
     {
         return query.ToDictionary(


### PR DESCRIPTION
## Summary
- Remove the unused string-dictionary ConvertQueryValues overload from StubService.
- Leave the string-array overload used by ExplainMatchAsync intact.

## Files Changed
- src/SemanticStub.Api/Services/Resolution/StubService.cs

## Tests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --no-restore

## Notes
- Closes #183
- Existing local SKILLS.md changes were left uncommitted and excluded from this PR.