### PR TITLE
refactor: remove semantic best match wrapper

### DIFF
--- a/src/SemanticStub.Api/Services/Semantic/ISemanticMatcherService.cs
+++ b/src/SemanticStub.Api/Services/Semantic/ISemanticMatcherService.cs
@@ -9,26 +9,6 @@ namespace SemanticStub.Api.Services;
 public interface ISemanticMatcherService
 {
     /// <summary>
-    /// Finds the best semantic match among the supplied conditional candidates.
-    /// </summary>
-    /// <param name="method">The HTTP method being evaluated.</param>
-    /// <param name="path">The request path being evaluated.</param>
-    /// <param name="query">The request query values keyed by parameter name.</param>
-    /// <param name="headers">The request headers keyed by header name.</param>
-    /// <param name="body">The optional request body.</param>
-    /// <param name="candidates">The semantic candidates attached to the resolved operation.</param>
-    /// <param name="candidateFilter">An optional filter that excludes ineligible candidates before scoring.</param>
-    /// <returns>The best acceptable semantic match, or <see langword="null"/> when semantic matching is disabled or no candidate satisfies the threshold.</returns>
-    Task<QueryMatchDefinition?> FindBestMatchAsync(
-        string method,
-        string path,
-        IReadOnlyDictionary<string, StringValues> query,
-        IReadOnlyDictionary<string, string> headers,
-        string? body,
-        IReadOnlyCollection<QueryMatchDefinition> candidates,
-        Func<QueryMatchDefinition, bool>? candidateFilter = null);
-
-    /// <summary>
     /// Evaluates semantic fallback candidates and returns explanation details for the selection.
     /// </summary>
     /// <param name="method">The HTTP method being evaluated.</param>

--- a/src/SemanticStub.Api/Services/Semantic/SemanticMatcherService.cs
+++ b/src/SemanticStub.Api/Services/Semantic/SemanticMatcherService.cs
@@ -25,31 +25,6 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
         this.logger = logger;
     }
 
-    /// <summary>
-    /// Finds the best semantic match among the supplied conditional candidates.
-    /// </summary>
-    public async Task<QueryMatchDefinition?> FindBestMatchAsync(
-        string method,
-        string path,
-        IReadOnlyDictionary<string, StringValues> query,
-        IReadOnlyDictionary<string, string> headers,
-        string? body,
-        IReadOnlyCollection<QueryMatchDefinition> candidates,
-        Func<QueryMatchDefinition, bool>? candidateFilter = null)
-    {
-        var explanation = await ExplainMatchAsync(
-            method,
-            path,
-            query,
-            headers,
-            body,
-            candidates,
-            candidateFilter,
-            includeCandidateScores: false);
-
-        return explanation.SelectedCandidate;
-    }
-
     /// <inheritdoc/>
     public async Task<SemanticMatchExplanation> ExplainMatchAsync(
         string method,

--- a/tests/SemanticStub.Api.Tests/Unit/SemanticMatcherServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/SemanticMatcherServiceTests.cs
@@ -16,13 +16,13 @@ namespace SemanticStub.Api.Tests.Unit;
 public sealed class SemanticMatcherServiceTests
 {
     [Fact]
-    public async Task FindBestMatchAsync_ReturnsNullWhenSemanticMatchingIsDisabled()
+    public async Task ExplainMatchAsync_ReturnsNullSelectedCandidateWhenSemanticMatchingIsDisabled()
     {
         var service = CreateService(
             new StubSettings(),
             (_, _) => throw new InvalidOperationException("The HTTP client should not be called when semantic matching is disabled."));
 
-        var match = await service.FindBestMatchAsync(
+        var explanation = await service.ExplainMatchAsync(
             "POST",
             "/search",
             new Dictionary<string, StringValues>(StringComparer.Ordinal),
@@ -30,7 +30,7 @@ public sealed class SemanticMatcherServiceTests
             "admin search",
             [CreateCandidate("find admin users")]);
 
-        Assert.Null(match);
+        Assert.Null(explanation.SelectedCandidate);
     }
 
     [Fact]
@@ -61,7 +61,7 @@ public sealed class SemanticMatcherServiceTests
     }
 
     [Fact]
-    public async Task FindBestMatchAsync_ReturnsHighestScoringCandidateAboveThreshold()
+    public async Task ExplainMatchAsync_ReturnsHighestScoringCandidateAboveThreshold()
     {
         var service = CreateService(
             new StubSettings
@@ -82,7 +82,7 @@ public sealed class SemanticMatcherServiceTests
         var adminCandidate = CreateCandidate("find admin users");
         var invoiceCandidate = CreateCandidate("show invoices");
 
-        var match = await service.FindBestMatchAsync(
+        var explanation = await service.ExplainMatchAsync(
             "POST",
             "/search",
             new Dictionary<string, StringValues>(StringComparer.Ordinal),
@@ -90,11 +90,11 @@ public sealed class SemanticMatcherServiceTests
             "admin search",
             [adminCandidate, invoiceCandidate]);
 
-        Assert.Same(adminCandidate, match);
+        Assert.Same(adminCandidate, explanation.SelectedCandidate);
     }
 
     [Fact]
-    public async Task FindBestMatchAsync_ReturnsNullWhenEmbeddingCallFails()
+    public async Task ExplainMatchAsync_ReturnsNullSelectedCandidateWhenEmbeddingCallFails()
     {
         var service = CreateService(
             new StubSettings
@@ -107,7 +107,7 @@ public sealed class SemanticMatcherServiceTests
             },
             (_, _) => throw new HttpRequestException("boom"));
 
-        var match = await service.FindBestMatchAsync(
+        var explanation = await service.ExplainMatchAsync(
             "POST",
             "/search",
             new Dictionary<string, StringValues>(StringComparer.Ordinal),
@@ -115,7 +115,7 @@ public sealed class SemanticMatcherServiceTests
             "admin search",
             [CreateCandidate("find admin users")]);
 
-        Assert.Null(match);
+        Assert.Null(explanation.SelectedCandidate);
     }
 
     [Fact]
@@ -150,7 +150,7 @@ public sealed class SemanticMatcherServiceTests
     }
 
     [Fact]
-    public async Task FindBestMatchAsync_ReturnsNullWhenBestScoreIsBelowThreshold()
+    public async Task ExplainMatchAsync_ReturnsNullSelectedCandidateWhenBestScoreIsBelowThreshold()
     {
         var service = CreateService(
             new StubSettings
@@ -168,7 +168,7 @@ public sealed class SemanticMatcherServiceTests
                 ["find admin users"] = "[0.9,0.1]"
             }));
 
-        var match = await service.FindBestMatchAsync(
+        var explanation = await service.ExplainMatchAsync(
             "POST",
             "/search",
             new Dictionary<string, StringValues>(StringComparer.Ordinal),
@@ -176,11 +176,11 @@ public sealed class SemanticMatcherServiceTests
             "admin search",
             [CreateCandidate("find admin users")]);
 
-        Assert.Null(match);
+        Assert.Null(explanation.SelectedCandidate);
     }
 
     [Fact]
-    public async Task FindBestMatchAsync_UsesDefaultThresholdWhenNoneIsConfigured()
+    public async Task ExplainMatchAsync_UsesDefaultThresholdWhenNoneIsConfigured()
     {
         var service = CreateService(
             new StubSettings
@@ -197,7 +197,7 @@ public sealed class SemanticMatcherServiceTests
                 ["show unpaid billing invoices"] = "[0.84,0.5425863986500215]"
             }));
 
-        var match = await service.FindBestMatchAsync(
+        var explanation = await service.ExplainMatchAsync(
             "POST",
             "/search",
             new Dictionary<string, StringValues>(StringComparer.Ordinal),
@@ -205,11 +205,11 @@ public sealed class SemanticMatcherServiceTests
             "coffee shop search",
             [CreateCandidate("show unpaid billing invoices")]);
 
-        Assert.Null(match);
+        Assert.Null(explanation.SelectedCandidate);
     }
 
     [Fact]
-    public async Task FindBestMatchAsync_ReturnsNullWhenTopScoreMarginIsTooSmall()
+    public async Task ExplainMatchAsync_ReturnsNullSelectedCandidateWhenTopScoreMarginIsTooSmall()
     {
         var service = CreateService(
             new StubSettings
@@ -229,7 +229,7 @@ public sealed class SemanticMatcherServiceTests
                 ["find administrator accounts"] = "[0.93,0.07]"
             }));
 
-        var match = await service.FindBestMatchAsync(
+        var explanation = await service.ExplainMatchAsync(
             "POST",
             "/search",
             new Dictionary<string, StringValues>(StringComparer.Ordinal),
@@ -237,11 +237,11 @@ public sealed class SemanticMatcherServiceTests
             "admin search",
             [CreateCandidate("find admin users"), CreateCandidate("find administrator accounts")]);
 
-        Assert.Null(match);
+        Assert.Null(explanation.SelectedCandidate);
     }
 
     [Fact]
-    public async Task FindBestMatchAsync_ReturnsBestCandidateWhenTopScoreMarginIsSatisfied()
+    public async Task ExplainMatchAsync_ReturnsBestCandidateWhenTopScoreMarginIsSatisfied()
     {
         var service = CreateService(
             new StubSettings
@@ -264,7 +264,7 @@ public sealed class SemanticMatcherServiceTests
         var adminCandidate = CreateCandidate("find admin users");
         var invoiceCandidate = CreateCandidate("show invoices");
 
-        var match = await service.FindBestMatchAsync(
+        var explanation = await service.ExplainMatchAsync(
             "POST",
             "/search",
             new Dictionary<string, StringValues>(StringComparer.Ordinal),
@@ -272,7 +272,7 @@ public sealed class SemanticMatcherServiceTests
             "admin search",
             [adminCandidate, invoiceCandidate]);
 
-        Assert.Same(adminCandidate, match);
+        Assert.Same(adminCandidate, explanation.SelectedCandidate);
     }
 
     [Fact]
@@ -389,7 +389,7 @@ public sealed class SemanticMatcherServiceTests
     }
 
     [Fact]
-    public async Task FindBestMatchAsync_ReturnsNullWhenEmbeddingVectorHasZeroMagnitude()
+    public async Task ExplainMatchAsync_ReturnsNullSelectedCandidateWhenEmbeddingVectorHasZeroMagnitude()
     {
         var service = CreateService(
             new StubSettings
@@ -402,7 +402,7 @@ public sealed class SemanticMatcherServiceTests
             },
             (_, _) => CreateEmbeddingResponse("[[0.0,0.0],[0.9,0.1]]"));
 
-        var match = await service.FindBestMatchAsync(
+        var explanation = await service.ExplainMatchAsync(
             "POST",
             "/search",
             new Dictionary<string, StringValues>(StringComparer.Ordinal),
@@ -410,11 +410,11 @@ public sealed class SemanticMatcherServiceTests
             "admin search",
             [CreateCandidate("find admin users")]);
 
-        Assert.Null(match);
+        Assert.Null(explanation.SelectedCandidate);
     }
 
     [Fact]
-    public async Task FindBestMatchAsync_ReturnsNullWhenEmbeddingVectorDimensionsDoNotMatch()
+    public async Task ExplainMatchAsync_ReturnsNullSelectedCandidateWhenEmbeddingVectorDimensionsDoNotMatch()
     {
         var service = CreateService(
             new StubSettings
@@ -427,7 +427,7 @@ public sealed class SemanticMatcherServiceTests
             },
             (_, _) => CreateEmbeddingResponse("[[1.0,0.0],[0.9,0.1,0.2]]"));
 
-        var match = await service.FindBestMatchAsync(
+        var explanation = await service.ExplainMatchAsync(
             "POST",
             "/search",
             new Dictionary<string, StringValues>(StringComparer.Ordinal),
@@ -435,7 +435,7 @@ public sealed class SemanticMatcherServiceTests
             "admin search",
             [CreateCandidate("find admin users")]);
 
-        Assert.Null(match);
+        Assert.Null(explanation.SelectedCandidate);
     }
 
     [Theory]
@@ -443,7 +443,7 @@ public sealed class SemanticMatcherServiceTests
     [InlineData("http://tei/", "http://tei/embed")]
     [InlineData("http://tei/embed", "http://tei/embed")]
     [InlineData("http://tei/embed/", "http://tei/embed")]
-    public async Task FindBestMatchAsync_NormalizesEmbeddingEndpointWithoutChangingBehavior(string configuredEndpoint, string expectedEndpoint)
+    public async Task ExplainMatchAsync_NormalizesEmbeddingEndpointWithoutChangingBehavior(string configuredEndpoint, string expectedEndpoint)
     {
         Uri? actualRequestUri = null;
 
@@ -464,7 +464,7 @@ public sealed class SemanticMatcherServiceTests
 
         var candidate = CreateCandidate("find admin users");
 
-        var match = await service.FindBestMatchAsync(
+        var explanation = await service.ExplainMatchAsync(
             "POST",
             "/search",
             new Dictionary<string, StringValues>(StringComparer.Ordinal),
@@ -472,12 +472,12 @@ public sealed class SemanticMatcherServiceTests
             "admin search",
             [candidate]);
 
-        Assert.Same(candidate, match);
+        Assert.Same(candidate, explanation.SelectedCandidate);
         Assert.Equal(expectedEndpoint, actualRequestUri?.ToString());
     }
 
     [Fact]
-    public async Task FindBestMatchAsync_BuildsRequestTextFromMethodPathQueryHeadersAndTrimmedBody()
+    public async Task ExplainMatchAsync_BuildsRequestTextFromMethodPathQueryHeadersAndTrimmedBody()
     {
         string? capturedRequestText = null;
 
@@ -499,7 +499,7 @@ public sealed class SemanticMatcherServiceTests
 
         var candidate = CreateCandidate("find admin users");
 
-        var match = await service.FindBestMatchAsync(
+        var explanation = await service.ExplainMatchAsync(
             "post",
             "/search",
             new Dictionary<string, StringValues>(StringComparer.Ordinal)
@@ -515,14 +515,14 @@ public sealed class SemanticMatcherServiceTests
             "  admin search  ",
             [candidate]);
 
-        Assert.Same(candidate, match);
+        Assert.Same(candidate, explanation.SelectedCandidate);
         Assert.Equal(
             "method: POST\npath: /search\nquery:\n  a: first\n  z: last, value\nheaders:\n  Accept: application/json\n  x-tenant: tenant-a\nbody:\nadmin search",
             capturedRequestText);
     }
 
     [Fact]
-    public async Task FindBestMatchAsync_ReturnsNullWhenEmbeddingResponseShapeIsUnexpected()
+    public async Task ExplainMatchAsync_ReturnsNullSelectedCandidateWhenEmbeddingResponseShapeIsUnexpected()
     {
         var service = CreateService(
             new StubSettings
@@ -538,7 +538,7 @@ public sealed class SemanticMatcherServiceTests
                 Content = new StringContent("{\"embeddings\":[[1.0,0.0]]}", Encoding.UTF8, "application/json")
             });
 
-        var match = await service.FindBestMatchAsync(
+        var explanation = await service.ExplainMatchAsync(
             "POST",
             "/search",
             new Dictionary<string, StringValues>(StringComparer.Ordinal),
@@ -546,7 +546,7 @@ public sealed class SemanticMatcherServiceTests
             "admin search",
             [CreateCandidate("find admin users")]);
 
-        Assert.Null(match);
+        Assert.Null(explanation.SelectedCandidate);
     }
 
     private static QueryMatchDefinition CreateCandidate(string semanticMatch)

--- a/tests/SemanticStub.Api.Tests/Unit/SemanticMatcherServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/SemanticMatcherServiceTests.cs
@@ -94,31 +94,6 @@ public sealed class SemanticMatcherServiceTests
     }
 
     [Fact]
-    public async Task ExplainMatchAsync_ReturnsNullSelectedCandidateWhenEmbeddingCallFails()
-    {
-        var service = CreateService(
-            new StubSettings
-            {
-                SemanticMatching = new SemanticMatchingSettings
-                {
-                    Enabled = true,
-                    Endpoint = "http://tei"
-                }
-            },
-            (_, _) => throw new HttpRequestException("boom"));
-
-        var explanation = await service.ExplainMatchAsync(
-            "POST",
-            "/search",
-            new Dictionary<string, StringValues>(StringComparer.Ordinal),
-            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
-            "admin search",
-            [CreateCandidate("find admin users")]);
-
-        Assert.Null(explanation.SelectedCandidate);
-    }
-
-    [Fact]
     public async Task ExplainMatchAsync_ReturnsAttemptedNonMatchWhenEmbeddingCallFails()
     {
         var service = CreateService(
@@ -206,73 +181,6 @@ public sealed class SemanticMatcherServiceTests
             [CreateCandidate("show unpaid billing invoices")]);
 
         Assert.Null(explanation.SelectedCandidate);
-    }
-
-    [Fact]
-    public async Task ExplainMatchAsync_ReturnsNullSelectedCandidateWhenTopScoreMarginIsTooSmall()
-    {
-        var service = CreateService(
-            new StubSettings
-            {
-                SemanticMatching = new SemanticMatchingSettings
-                {
-                    Enabled = true,
-                    Endpoint = "http://tei",
-                    Threshold = 0.8d,
-                    TopScoreMargin = 0.03d
-                }
-            },
-            CreateEmbeddingHandler(new Dictionary<string, string>(StringComparer.Ordinal)
-            {
-                ["method: POST\npath: /search\nbody:\nadmin search"] = "[1.0,0.0]",
-                ["find admin users"] = "[0.95,0.05]",
-                ["find administrator accounts"] = "[0.93,0.07]"
-            }));
-
-        var explanation = await service.ExplainMatchAsync(
-            "POST",
-            "/search",
-            new Dictionary<string, StringValues>(StringComparer.Ordinal),
-            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
-            "admin search",
-            [CreateCandidate("find admin users"), CreateCandidate("find administrator accounts")]);
-
-        Assert.Null(explanation.SelectedCandidate);
-    }
-
-    [Fact]
-    public async Task ExplainMatchAsync_ReturnsBestCandidateWhenTopScoreMarginIsSatisfied()
-    {
-        var service = CreateService(
-            new StubSettings
-            {
-                SemanticMatching = new SemanticMatchingSettings
-                {
-                    Enabled = true,
-                    Endpoint = "http://tei",
-                    Threshold = 0.8d,
-                    TopScoreMargin = 0.03d
-                }
-            },
-            CreateEmbeddingHandler(new Dictionary<string, string>(StringComparer.Ordinal)
-            {
-                ["method: POST\npath: /search\nbody:\nadmin search"] = "[1.0,0.0]",
-                ["find admin users"] = "[0.95,0.05]",
-                ["show invoices"] = "[0.60,0.40]"
-            }));
-
-        var adminCandidate = CreateCandidate("find admin users");
-        var invoiceCandidate = CreateCandidate("show invoices");
-
-        var explanation = await service.ExplainMatchAsync(
-            "POST",
-            "/search",
-            new Dictionary<string, StringValues>(StringComparer.Ordinal),
-            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
-            "admin search",
-            [adminCandidate, invoiceCandidate]);
-
-        Assert.Same(adminCandidate, explanation.SelectedCandidate);
     }
 
     [Fact]
@@ -375,16 +283,19 @@ public sealed class SemanticMatcherServiceTests
                 ["find admin users"] = "[0.95,0.05]"
             }));
 
+        var candidate = CreateCandidate("find admin users");
+
         var explanation = await service.ExplainMatchAsync(
             "POST",
             "/search",
             new Dictionary<string, StringValues>(StringComparer.Ordinal),
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
             "admin search",
-            [CreateCandidate("find admin users")],
+            [candidate],
             includeCandidateScores: false);
 
         Assert.True(explanation.Attempted);
+        Assert.Same(candidate, explanation.SelectedCandidate);
         Assert.Empty(explanation.CandidateScores);
     }
 

--- a/tests/SemanticStub.Api.Tests/Unit/StubDispatchSelectorTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubDispatchSelectorTests.cs
@@ -246,18 +246,6 @@ public sealed class StubDispatchSelectorTests
 
     private sealed class StubSemanticMatcherService(SemanticMatchExplanation explanation) : ISemanticMatcherService
     {
-        public Task<QueryMatchDefinition?> FindBestMatchAsync(
-            string method,
-            string path,
-            IReadOnlyDictionary<string, StringValues> query,
-            IReadOnlyDictionary<string, string> headers,
-            string? body,
-            IReadOnlyCollection<QueryMatchDefinition> candidates,
-            Func<QueryMatchDefinition, bool>? candidateFilter = null)
-        {
-            return Task.FromResult(explanation.SelectedCandidate);
-        }
-
         public Task<SemanticMatchExplanation> ExplainMatchAsync(
             string method,
             string path,

--- a/tests/SemanticStub.Api.Tests/Unit/StubInspectionServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubInspectionServiceTests.cs
@@ -139,18 +139,6 @@ public sealed class StubInspectionServiceTests
 
     private sealed class NoOpSemanticMatcherService : ISemanticMatcherService
     {
-        public Task<QueryMatchDefinition?> FindBestMatchAsync(
-            string method,
-            string path,
-            IReadOnlyDictionary<string, Microsoft.Extensions.Primitives.StringValues> query,
-            IReadOnlyDictionary<string, string> headers,
-            string? body,
-            IReadOnlyCollection<QueryMatchDefinition> candidates,
-            Func<QueryMatchDefinition, bool>? candidateFilter = null)
-        {
-            return Task.FromResult<QueryMatchDefinition?>(null);
-        }
-
         public Task<SemanticMatchExplanation> ExplainMatchAsync(
             string method,
             string path,
@@ -167,18 +155,6 @@ public sealed class StubInspectionServiceTests
 
     private sealed class StubSemanticMatcherService(SemanticMatchExplanation explanation) : ISemanticMatcherService
     {
-        public Task<QueryMatchDefinition?> FindBestMatchAsync(
-            string method,
-            string path,
-            IReadOnlyDictionary<string, Microsoft.Extensions.Primitives.StringValues> query,
-            IReadOnlyDictionary<string, string> headers,
-            string? body,
-            IReadOnlyCollection<QueryMatchDefinition> candidates,
-            Func<QueryMatchDefinition, bool>? candidateFilter = null)
-        {
-            return Task.FromResult(explanation.SelectedCandidate);
-        }
-
         public Task<SemanticMatchExplanation> ExplainMatchAsync(
             string method,
             string path,

--- a/tests/SemanticStub.Api.Tests/Unit/StubServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubServiceTests.cs
@@ -1967,29 +1967,6 @@ public sealed class StubServiceTests
     {
         public int CallCount { get; private set; }
 
-        public Task<QueryMatchDefinition?> FindBestMatchAsync(
-            string method,
-            string path,
-            IReadOnlyDictionary<string, StringValues> query,
-            IReadOnlyDictionary<string, string> headers,
-            string? body,
-            IReadOnlyCollection<QueryMatchDefinition> candidates,
-            Func<QueryMatchDefinition, bool>? candidateFilter = null)
-        {
-            CallCount++;
-
-            if (nextMatch is null)
-            {
-                return Task.FromResult<QueryMatchDefinition?>(null);
-            }
-
-            var result = candidateFilter is null || candidateFilter(nextMatch)
-                ? nextMatch
-                : null;
-
-            return Task.FromResult<QueryMatchDefinition?>(result);
-        }
-
         public Task<SemanticMatchExplanation> ExplainMatchAsync(
             string method,
             string path,


### PR DESCRIPTION
## Summary
- Remove FindBestMatchAsync from ISemanticMatcherService and SemanticMatcherService
- Update semantic matcher tests to assert ExplainMatchAsync.SelectedCandidate directly
- Remove obsolete FindBestMatchAsync implementations from test stubs

## Files Changed
- src/SemanticStub.Api/Services/Semantic/ISemanticMatcherService.cs
- src/SemanticStub.Api/Services/Semantic/SemanticMatcherService.cs
- tests/SemanticStub.Api.Tests/Unit/SemanticMatcherServiceTests.cs
- tests/SemanticStub.Api.Tests/Unit/StubDispatchSelectorTests.cs
- tests/SemanticStub.Api.Tests/Unit/StubInspectionServiceTests.cs
- tests/SemanticStub.Api.Tests/Unit/StubServiceTests.cs

## Tests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj

## Notes
- Closes #184
- Existing local SKILLS.md changes were left uncommitted and excluded from this PR