### PR TITLE
refactor: remove unused query match evaluation result

### DIFF
--- a/src/SemanticStub.Api/Models/QueryMatchEvaluationResult.cs
+++ b/src/SemanticStub.Api/Models/QueryMatchEvaluationResult.cs
@@ -1,8 +1,0 @@
-namespace SemanticStub.Api.Models;
-
-public enum QueryMatchEvaluationResult
-{
-    NoMatch,
-    Matched,
-    MatchedButInvalidResponse
-}


### PR DESCRIPTION
## Summary
- Remove the unused QueryMatchEvaluationResult enum.

## Validation
- dotnet build --no-restore
- dotnet test --no-build