### PR TITLE
docs: add development guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,3 +68,15 @@ Ask before:
 - Follow Conventional Commits in English (e.g. feat:, fix:, refactor:)
 - Inline code comments may be written in Japanese if it improves clarity
 - Do not mix Japanese and English in the same commit message or PR description
+
+## Development Guides
+
+Follow the detailed development guidelines in the following documents when relevant:
+
+- docs/development/testing-strategy.md
+- docs/development/naming-conventions.md
+- docs/development/dependency-injection.md
+- docs/development/tech-stack.md
+- docs/development/project-structure.md
+
+These documents define project-specific standards for testing, naming, dependency injection, technology choices, and structure. Always follow them when making related changes.

--- a/docs/development/dependency-injection.md
+++ b/docs/development/dependency-injection.md
@@ -1,0 +1,88 @@
+
+
+## Dependency Injection
+
+This project uses dependency injection to keep composition explicit, support testing where appropriate, and maintain a clear separation between application code and external dependencies.
+
+### Interface Usage
+- External dependencies must be abstracted behind interfaces.
+  - Examples: database access, HTTP clients, email sending, file storage, message brokers, clock abstractions
+- Dependencies that need to be mocked in unit tests should be represented by interfaces.
+- Models, DTOs, and simple data containers should not be abstracted behind interfaces.
+- Do not introduce interfaces for every class by default.
+- Do not add interfaces solely for naming symmetry or speculative future reuse.
+
+### When to Introduce an Interface
+Introduce an interface when at least one of the following is true:
+- The implementation depends on an external system or process boundary.
+- The dependency is expected to be replaced in unit tests.
+- Multiple implementations are meaningful in the design.
+- The abstraction improves separation between layers.
+
+Do not introduce an interface when:
+- The type is a model, DTO, options class, or simple value holder.
+- The class is an internal implementation detail with no real abstraction value.
+- The only reason is to satisfy a blanket rule that every service must have an interface.
+
+### Service Lifetimes
+- Use `Scoped` by default.
+- Use `Singleton` for stateless shared services that are safe to reuse across the application lifetime.
+- Use `Transient` for lightweight, short-lived processing components.
+- Do not inject `Scoped` services into `Singleton` services.
+  - Avoid captive dependencies.
+
+### Lifetime Guidelines
+#### Scoped
+Use `Scoped` for most application services, especially when:
+- they participate in request-level work
+- they depend on other scoped services
+- per-request consistency is desirable
+
+#### Singleton
+Use `Singleton` only when the service:
+- is stateless or safely shared
+- does not depend on scoped services
+- is designed for concurrent use
+
+Examples:
+- configuration readers with immutable state
+- reusable registries or caches when appropriate
+
+#### Transient
+Use `Transient` for:
+- lightweight helpers
+- short-lived processors
+- objects that do not need shared state
+
+Do not use `Transient` by default without a reason.
+
+### Registration Style
+- Keep `Program.cs` focused on application composition and startup flow.
+- Do not place large numbers of individual service registrations directly in `Program.cs`.
+- Group registrations into extension methods.
+- Organize registration methods by layer or responsibility.
+
+Examples:
+- `AddApplicationServices()`
+- `AddInfrastructureServices()`
+- `AddApiServices()`
+
+### Layered Registration
+Prefer separating registration by layer, such as:
+- Application
+- Infrastructure
+- API / Web
+
+This keeps dependencies explicit and makes startup code easier to maintain.
+
+### Testing Considerations
+- Prefer mocking external dependencies rather than internal business logic.
+- Do not introduce extra interfaces solely to satisfy mocking preferences.
+- Prefer real implementations for simple internal services when that keeps tests clearer.
+
+### Design Principles
+- Prefer explicit, purposeful abstractions.
+- Keep dependency graphs simple.
+- Choose lifetimes intentionally.
+- Avoid over-abstraction.
+- Follow existing project patterns when extending DI configuration.

--- a/docs/development/naming-conventions.md
+++ b/docs/development/naming-conventions.md
@@ -1,0 +1,84 @@
+## Naming Conventions
+
+This project follows Microsoft C# naming conventions as the baseline, with a few project-specific rules to improve consistency and readability.
+
+### General Rules
+- Use clear, descriptive, intention-revealing names.
+- Prefer full words over unclear abbreviations.
+- Avoid ambiguous or overly generic names such as `data`, `value`, or `item`.
+- Keep naming consistent across the codebase.
+
+### Casing Rules
+- Use PascalCase for:
+  - Classes, records, structs, enums, delegates
+  - Public and protected members
+  - Namespaces
+- Use camelCase for:
+  - Method parameters
+  - Local variables
+- Use `_camelCase` for private fields.
+
+### Type Naming
+- Class, record, struct, enum, and delegate names use PascalCase.
+- Interface names:
+  - Must start with `I`
+  - Use PascalCase
+
+Examples:
+- `StubConfiguration`
+- `RouteMatcher`
+- `ISemanticMatcher`
+
+### Member Naming
+- Methods use PascalCase and should be verbs or verb phrases.
+- Properties use PascalCase and should be nouns or adjectives.
+- Boolean members should read naturally (e.g., `IsEnabled`, `HasRoutes`).
+
+Examples:
+- `GetEffectiveConfiguration()`
+- `TryMatchRoute()`
+- `IsEnabled`
+- `HasScenarioState`
+
+### Field and Variable Naming
+- Private fields use `_camelCase`.
+- Local variables and parameters use camelCase.
+- Avoid one-letter variable names except for trivial loop counters.
+
+Examples:
+- `_logger`
+- `_routeTable`
+- `requestPath`
+- `matchedRoute`
+
+### Test Naming
+- Test class names should match the target type and end with `Tests`.
+- Test method names should clearly describe behavior.
+- Prefer the pattern:
+  - `MethodName_Condition_ExpectedResult`
+
+Examples:
+- `TryMatchRoute_WhenPatternMatches_ReturnsTrue`
+- `Next_WhenScenarioHasNoResponses_ReturnsNull`
+
+### Common Suffixes
+Use consistent suffixes when they improve clarity:
+
+- `Options` → configuration classes used with DI/config binding
+- `Request` / `Response` → API models
+- `Exception` → custom exception types
+- `Provider`, `Factory`, `Service` → when they reflect real responsibilities
+
+### Abbreviations
+- Prefer full words unless the abbreviation is widely accepted.
+- Use standard .NET-style abbreviations:
+  - `Id` (not `ID`)
+  - `Http`, `Url`, `Xml`
+
+### Interfaces and Abstraction
+- Do not introduce interfaces solely for naming symmetry.
+- Only create interfaces when they provide real architectural or testing value.
+
+### Consistency
+- Follow existing naming patterns in the codebase when modifying or extending functionality.
+- Avoid introducing new naming styles that conflict with established conventions.

--- a/docs/development/project-structure.md
+++ b/docs/development/project-structure.md
@@ -1,0 +1,110 @@
+
+
+## Project Structure
+
+This project follows a layered structure to keep responsibilities clear and maintainable.
+
+### Overview
+The solution is organized into logical layers:
+
+- API / Web → HTTP entry point
+- Application → business logic and orchestration
+- Infrastructure → external systems and I/O
+- Domain (optional) → core domain models and logic
+
+### Directory Layout
+
+Example structure:
+
+```
+/src
+  /SemanticStub.Api
+  /SemanticStub.Application
+  /SemanticStub.Infrastructure
+  /SemanticStub.Domain (optional)
+
+/tests
+  /SemanticStub.Api.Tests
+  /SemanticStub.Application.Tests
+  /SemanticStub.Infrastructure.Tests
+```
+
+### Layer Responsibilities
+
+#### API / Web
+- Handles HTTP requests and responses
+- Contains controllers, middleware, filters
+- Performs request validation and response shaping
+- Should not contain business logic
+
+#### Application
+- Contains business logic and orchestration
+- Coordinates between components
+- Implements use cases and workflows
+- Depends on abstractions (interfaces), not concrete infrastructure
+
+#### Infrastructure
+- Implements external dependencies
+- Examples:
+  - HTTP clients
+  - file system access
+  - persistence
+  - external APIs
+- Contains concrete implementations of interfaces defined in Application
+
+#### Domain (Optional)
+- Contains core domain models and rules
+- Should be independent of frameworks
+- Used when domain complexity justifies separation
+
+### Dependency Rules
+
+- API can depend on Application
+- Application can depend on Domain
+- Infrastructure can depend on Application
+- Domain should not depend on other layers
+
+Disallowed:
+- Application must not depend on Infrastructure implementations
+- Domain must not depend on Application or Infrastructure
+
+### Test Project Structure
+
+- Each main project should have a corresponding test project
+- Test projects should mirror the structure of the target project where practical
+
+Examples:
+- `SemanticStub.Application.Tests`
+- `SemanticStub.Infrastructure.Tests`
+
+Guidelines:
+- Unit tests primarily target Application and Domain
+- Integration tests target API and Infrastructure behavior
+
+### File Organization
+
+- Group files by feature or responsibility rather than by technical type when appropriate
+- Avoid overly deep folder nesting
+- Keep related classes close together
+
+Examples:
+- Route-related logic grouped together
+- Scenario-related logic grouped together
+
+### Naming Conventions for Structure
+
+- Project names should follow `SemanticStub.<Layer>` pattern
+- Test projects should follow `SemanticStub.<Layer>.Tests`
+
+### Adding New Code
+
+- Place new code in the appropriate layer based on responsibility
+- Do not introduce cross-layer dependencies that violate the rules
+- Follow existing folder patterns and naming conventions
+
+### Design Goals
+
+- Clear separation of concerns
+- Maintainable and scalable structure
+- Easy navigation for both humans and tools
+- Predictable placement of new code

--- a/docs/development/tech-stack.md
+++ b/docs/development/tech-stack.md
@@ -1,0 +1,46 @@
+## Tech Stack
+
+This project uses a modern, pragmatic .NET-based technology stack. The goal is to prefer stable, well-supported, and widely adopted libraries while avoiding unnecessary complexity.
+
+### Core Platform
+- .NET (latest stable LTS or current version)
+- ASP.NET Core
+
+### Testing
+- xUnit → test framework
+- Moq → mocking library
+- Shouldly → assertion library
+
+### Configuration / Serialization
+- System.Text.Json → default JSON serialization
+- YamlDotNet → YAML parsing and configuration
+
+### Dependency Injection
+- Microsoft.Extensions.DependencyInjection (built-in)
+
+### Logging
+- Microsoft.Extensions.Logging (baseline)
+- Optional: Serilog (for structured logging when needed)
+
+### HTTP / Networking
+- HttpClient via IHttpClientFactory
+
+### Development Tools
+- Visual Studio / VS Code
+- Git + GitHub
+
+### Guidelines for Adding Libraries
+- Prefer built-in .NET libraries when sufficient.
+- Choose widely adopted and actively maintained libraries.
+- Avoid adding libraries for trivial functionality.
+- Avoid introducing multiple libraries that solve the same problem.
+- Ensure new dependencies provide clear value (performance, readability, maintainability, or capability).
+
+### Versioning Strategy
+- Prefer stable releases over preview versions.
+- Keep dependencies reasonably up to date.
+- Avoid unnecessary upgrades that do not provide clear benefits.
+
+### Notes
+- This project prioritizes simplicity and maintainability over trend-driven choices.
+- New technologies can be adopted when they provide clear, practical benefits.

--- a/docs/development/testing-strategy.md
+++ b/docs/development/testing-strategy.md
@@ -1,0 +1,83 @@
+
+
+## Test Strategy
+
+### Principles
+- Cover business logic with unit tests.
+- Test API endpoints with integration tests using `WebApplicationFactory`.
+- Limit end-to-end tests to major user scenarios.
+- Use mocks only for external dependencies that already have interfaces.
+
+### Unit Tests
+Use unit tests as the default for domain logic, matching rules, scenario transitions, route compilation, configuration handling, and other business logic.
+
+Guidelines:
+- Unit tests should be fast and deterministic.
+- Prefer testing behavior through public APIs.
+- Avoid unnecessary mocking of internal collaborators.
+- Add regression tests for bug fixes.
+- Cover edge cases and failure cases when they affect observable behavior.
+
+Examples of code that should usually be covered by unit tests:
+- matchers
+- route/template parsing and compilation
+- scenario state transitions
+- configuration merge logic
+- response selection logic
+- helper classes with meaningful logic
+
+### Integration Tests
+Use integration tests for HTTP pipeline behavior and API endpoint verification.
+
+Guidelines:
+- Use `WebApplicationFactory` for endpoint tests.
+- Verify routing, model binding, filters, middleware interaction, status codes, and response shapes.
+- Prefer real application wiring unless isolation is required for external systems.
+- Replace only truly external dependencies when needed.
+
+Examples of code that should usually be covered by integration tests:
+- admin or inspection endpoints
+- stub execution through HTTP requests
+- middleware behavior
+- serialization/deserialization behavior
+- DI wiring that affects runtime behavior
+
+### End-to-End Tests
+Use end-to-end tests only for major scenarios that validate the system as a whole.
+
+Guidelines:
+- Keep the number of E2E tests small.
+- Focus on critical flows that provide confidence across multiple layers.
+- Do not use E2E tests as a substitute for unit or integration coverage.
+
+Examples:
+- loading stub definitions and serving responses end-to-end
+- scenario progression across multiple requests
+- semantic matching flow when enabled in a realistic environment
+
+### Mocking Policy
+Use mocks only for external dependencies that already have interfaces.
+
+Guidelines:
+- Mock external systems such as API clients, storage clients, clock abstractions, or other process boundaries when needed.
+- Do not introduce interfaces only to make mocking easier unless the abstraction is justified by design.
+- Prefer real implementations for simple internal services.
+- Prefer fakes or test doubles over deep mock setups when they make tests easier to understand.
+
+### Coverage Expectations
+- Business logic should be covered primarily by unit tests.
+- API behavior should be covered by integration tests.
+- Critical user flows should have selective end-to-end coverage.
+- Bug fixes should include regression tests when practical.
+
+### Test Design Guidelines
+- Write tests that describe behavior clearly.
+- Keep each test focused on one behavior.
+- Avoid brittle assertions tied to incidental implementation details.
+- Name tests so the intended behavior is easy to understand.
+- Prefer readable test setup over overly clever reuse.
+
+### Preferred Libraries
+- xUnit
+- Moq
+- Shouldly


### PR DESCRIPTION
## Summary

- Add project development guidelines for testing, naming, dependency injection, project structure, and tech stack decisions.
- Update `AGENTS.md` to point contributors and agents to the new development guide documents.

## Validation

- Not run; documentation-only change.
