### PR TITLE
docs: document YAML model classes

### DIFF
--- a/src/SemanticStub.Api/Infrastructure/Yaml/StubSettings.cs
+++ b/src/SemanticStub.Api/Infrastructure/Yaml/StubSettings.cs
@@ -1,8 +1,17 @@
 namespace SemanticStub.Api.Infrastructure.Yaml;
 
+/// <summary>
+/// Configures the YAML stub definition source and optional matching features.
+/// </summary>
 public sealed class StubSettings
 {
+    /// <summary>
+    /// Gets the path to the YAML stub definition file or directory.
+    /// </summary>
     public string? DefinitionsPath { get; init; }
 
+    /// <summary>
+    /// Gets the semantic matching configuration.
+    /// </summary>
     public SemanticMatchingSettings SemanticMatching { get; init; } = new();
 }

--- a/src/SemanticStub.Api/Models/HeaderDefinition.cs
+++ b/src/SemanticStub.Api/Models/HeaderDefinition.cs
@@ -1,10 +1,22 @@
 namespace SemanticStub.Api.Models;
 
+/// <summary>
+/// Describes an OpenAPI response header exposed by a stub response.
+/// </summary>
 public sealed class HeaderDefinition
 {
+    /// <summary>
+    /// Gets the human-readable description of the response header.
+    /// </summary>
     public string Description { get; init; } = string.Empty;
 
+    /// <summary>
+    /// Gets the example value associated with the response header.
+    /// </summary>
     public object? Example { get; init; }
 
+    /// <summary>
+    /// Gets the schema metadata associated with the response header.
+    /// </summary>
     public HeaderSchemaDefinition? Schema { get; init; }
 }

--- a/src/SemanticStub.Api/Models/OperationDefinition.cs
+++ b/src/SemanticStub.Api/Models/OperationDefinition.cs
@@ -2,14 +2,29 @@ using YamlDotNet.Serialization;
 
 namespace SemanticStub.Api.Models;
 
+/// <summary>
+/// Describes an OpenAPI operation and its stub-specific match definitions.
+/// </summary>
 public sealed class OperationDefinition
 {
+    /// <summary>
+    /// Gets the OpenAPI operation identifier used to distinguish the operation.
+    /// </summary>
     public string OperationId { get; init; } = string.Empty;
 
+    /// <summary>
+    /// Gets the OpenAPI parameters accepted by the operation.
+    /// </summary>
     public List<ParameterDefinition> Parameters { get; init; } = [];
 
+    /// <summary>
+    /// Gets the ordered stub match definitions declared by the <c>x-match</c> extension.
+    /// </summary>
     [YamlMember(Alias = "x-match", ApplyNamingConventions = false)]
     public List<QueryMatchDefinition> Matches { get; init; } = [];
 
+    /// <summary>
+    /// Gets the OpenAPI responses keyed by status code.
+    /// </summary>
     public Dictionary<string, ResponseDefinition> Responses { get; init; } = new(StringComparer.Ordinal);
 }

--- a/src/SemanticStub.Api/Models/QueryMatchDefinition.cs
+++ b/src/SemanticStub.Api/Models/QueryMatchDefinition.cs
@@ -2,22 +2,46 @@ using YamlDotNet.Serialization;
 
 namespace SemanticStub.Api.Models;
 
+/// <summary>
+/// Describes the request conditions and response selected by a stub match entry.
+/// </summary>
 public sealed class QueryMatchDefinition
 {
+    /// <summary>
+    /// Gets the query parameters that must match exactly.
+    /// </summary>
     public Dictionary<string, object?> Query { get; init; } = new(StringComparer.Ordinal);
 
+    /// <summary>
+    /// Gets the query parameters that must be present with partially matching values.
+    /// </summary>
     [YamlMember(Alias = "x-query-partial", ApplyNamingConventions = false)]
     public Dictionary<string, object?> PartialQuery { get; init; } = new(StringComparer.Ordinal);
 
+    /// <summary>
+    /// Gets the query parameters whose values are matched by regular expressions.
+    /// </summary>
     [YamlMember(Alias = "x-query-regex", ApplyNamingConventions = false)]
     public Dictionary<string, object?> RegexQuery { get; init; } = new(StringComparer.Ordinal);
 
+    /// <summary>
+    /// Gets the optional semantic match text declared by the <c>x-semantic-match</c> extension.
+    /// </summary>
     [YamlMember(Alias = "x-semantic-match", ApplyNamingConventions = false)]
     public string? SemanticMatch { get; init; }
 
+    /// <summary>
+    /// Gets the request headers that must match, using case-insensitive header names.
+    /// </summary>
     public Dictionary<string, object?> Headers { get; init; } = new(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// Gets the request body that must match.
+    /// </summary>
     public object? Body { get; init; }
 
+    /// <summary>
+    /// Gets the response definition returned when this match entry is selected.
+    /// </summary>
     public QueryMatchResponseDefinition Response { get; init; } = new();
 }

--- a/src/SemanticStub.Api/Models/StubDocument.cs
+++ b/src/SemanticStub.Api/Models/StubDocument.cs
@@ -2,10 +2,19 @@ using YamlDotNet.Serialization;
 
 namespace SemanticStub.Api.Models;
 
+/// <summary>
+/// Represents the OpenAPI document used as the YAML source of truth for stub definitions.
+/// </summary>
 public sealed class StubDocument
 {
+    /// <summary>
+    /// Gets the OpenAPI version declared by the document.
+    /// </summary>
     [YamlMember(Alias = "openapi")]
     public string OpenApi { get; init; } = string.Empty;
 
+    /// <summary>
+    /// Gets the OpenAPI path definitions keyed by route template.
+    /// </summary>
     public Dictionary<string, PathItemDefinition> Paths { get; init; } = new(StringComparer.Ordinal);
 }


### PR DESCRIPTION
## Summary
- Add XML docs to public YAML-facing model classes and settings.
- Preserve existing YAML aliases, property names, and defaults.

## Files Changed
- src/SemanticStub.Api/Models/HeaderDefinition.cs
- src/SemanticStub.Api/Models/OperationDefinition.cs
- src/SemanticStub.Api/Models/QueryMatchDefinition.cs
- src/SemanticStub.Api/Models/StubDocument.cs
- src/SemanticStub.Api/Infrastructure/Yaml/StubSettings.cs

## Tests
- dotnet build
- dotnet test

## Notes
- Closes #198