### PR TITLE
test: add stub definition infrastructure unit tests

### DIFF
--- a/tests/SemanticStub.Api.Tests/Unit/StubDefinitionNormalizerTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubDefinitionNormalizerTests.cs
@@ -1,0 +1,318 @@
+using SemanticStub.Api.Infrastructure.Yaml;
+using SemanticStub.Api.Models;
+using Xunit;
+
+namespace SemanticStub.Api.Tests.Unit;
+
+public sealed class StubDefinitionNormalizerTests
+{
+    [Fact]
+    public void NormalizeDocument_PreservesDocumentShapeAndParameterSchemas()
+    {
+        var normalizer = new StubDefinitionNormalizer();
+        var document = new StubDocument
+        {
+            OpenApi = "3.1.0",
+            Paths = new(StringComparer.Ordinal)
+            {
+                ["/users"] = new()
+                {
+                    Parameters =
+                    [
+                        new()
+                        {
+                            Name = "trace",
+                            In = "query",
+                            Schema = new()
+                            {
+                                Type = "string"
+                            }
+                        }
+                    ],
+                    Get = new()
+                    {
+                        OperationId = "listUsers",
+                        Parameters =
+                        [
+                            new()
+                            {
+                                Name = "page",
+                                In = "query",
+                                Schema = new()
+                                {
+                                    Type = "integer"
+                                }
+                            }
+                        ],
+                        Responses = new(StringComparer.Ordinal)
+                        {
+                            ["200"] = CreateResponse()
+                        }
+                    }
+                }
+            }
+        };
+
+        var normalized = normalizer.NormalizeDocument(document, Directory.GetCurrentDirectory());
+
+        Assert.Equal("3.1.0", normalized.OpenApi);
+        var path = normalized.Paths["/users"];
+        var pathParameter = Assert.Single(path.Parameters);
+        Assert.Equal("trace", pathParameter.Name);
+        Assert.Equal("query", pathParameter.In);
+        Assert.Equal("string", pathParameter.Schema?.Type);
+
+        var operation = Assert.IsType<OperationDefinition>(path.Get);
+        Assert.Equal("listUsers", operation.OperationId);
+        var operationParameter = Assert.Single(operation.Parameters);
+        Assert.Equal("page", operationParameter.Name);
+        Assert.Equal("integer", operationParameter.Schema?.Type);
+    }
+
+    [Fact]
+    public void NormalizeDocument_NormalizesMatchQueryHeadersAndBodyValues()
+    {
+        var normalizer = new StubDefinitionNormalizer();
+        var document = CreateDocument(new()
+        {
+            Matches =
+            [
+                new()
+                {
+                    Query = new(StringComparer.Ordinal)
+                    {
+                        ["filter"] = new Dictionary<object, object>
+                        {
+                            ["equals"] = "active"
+                        },
+                        ["tag"] = new List<object>
+                        {
+                            "alpha",
+                            1
+                        }
+                    },
+                    Headers = new(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["X-Env"] = new Dictionary<object, object>
+                        {
+                            ["regex"] = "^stage"
+                        }
+                    },
+                    Body = new Dictionary<object, object>
+                    {
+                        ["form"] = new Dictionary<object, object>
+                        {
+                            ["username"] = "demo"
+                        }
+                    },
+                    Response = CreateMatchResponse()
+                }
+            ]
+        });
+
+        var normalized = normalizer.NormalizeDocument(document, Directory.GetCurrentDirectory());
+        var match = Assert.Single(normalized.Paths["/hello"].Get!.Matches);
+
+        var filter = Assert.IsType<Dictionary<string, object?>>(match.Query["filter"]);
+        Assert.Equal("active", filter["equals"]);
+
+        var tag = Assert.IsType<List<object?>>(match.Query["tag"]);
+        Assert.Equal(["alpha", 1], tag);
+
+        var header = Assert.IsType<Dictionary<string, object?>>(match.Headers["x-env"]);
+        Assert.Equal("^stage", header["regex"]);
+
+        var body = Assert.IsType<Dictionary<string, object?>>(match.Body);
+        var form = Assert.IsType<Dictionary<string, object?>>(body["form"]);
+        Assert.Equal("demo", form["username"]);
+    }
+
+    [Fact]
+    public void NormalizeDocument_PreservesSemanticMatchAndMatchResponseDetails()
+    {
+        var normalizer = new StubDefinitionNormalizer();
+        var definitionDirectory = Directory.GetCurrentDirectory();
+        var document = CreateDocument(new()
+        {
+            Matches =
+            [
+                new()
+                {
+                    SemanticMatch = "find active users",
+                    Response = new()
+                    {
+                        StatusCode = 202,
+                        DelayMilliseconds = 50,
+                        ResponseFile = "responses/active-users.json",
+                        Headers = new(StringComparer.OrdinalIgnoreCase)
+                        {
+                            ["X-Stub-Source"] = new()
+                            {
+                                Example = "matched"
+                            }
+                        },
+                        Scenario = new()
+                        {
+                            Name = "user-search",
+                            State = "initial",
+                            Next = "done"
+                        },
+                        Content = new(StringComparer.Ordinal)
+                        {
+                            ["application/json"] = new()
+                        }
+                    }
+                }
+            ]
+        });
+
+        var normalized = normalizer.NormalizeDocument(document, definitionDirectory);
+        var match = Assert.Single(normalized.Paths["/hello"].Get!.Matches);
+
+        Assert.Equal("find active users", match.SemanticMatch);
+        Assert.Equal(202, match.Response.StatusCode);
+        Assert.Equal(50, match.Response.DelayMilliseconds);
+        Assert.Equal(Path.Combine(definitionDirectory, "responses", "active-users.json"), match.Response.ResponseFile);
+        Assert.Equal("matched", match.Response.Headers["x-stub-source"].Example);
+        Assert.Equal("user-search", match.Response.Scenario?.Name);
+        Assert.Equal("initial", match.Response.Scenario?.State);
+        Assert.Equal("done", match.Response.Scenario?.Next);
+        Assert.True(match.Response.Content.ContainsKey("application/json"));
+    }
+
+    [Fact]
+    public void NormalizeDocument_NormalizesResponses()
+    {
+        var normalizer = new StubDefinitionNormalizer();
+        var definitionDirectory = Directory.GetCurrentDirectory();
+        var document = CreateDocument(new()
+        {
+            Responses = new(StringComparer.Ordinal)
+            {
+                ["200"] = new()
+                {
+                    Description = "ok",
+                    DelayMilliseconds = 25,
+                    ResponseFile = "payloads/users.json",
+                    Headers = new(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["X-Stub-Source"] = new()
+                        {
+                            Example = "default"
+                        }
+                    },
+                    Scenario = new()
+                    {
+                        Name = "users",
+                        State = "ready",
+                        Next = "served"
+                    },
+                    Content = new(StringComparer.Ordinal)
+                    {
+                        ["application/json"] = new()
+                        {
+                            Example = new Dictionary<object, object>
+                            {
+                                ["users"] = new List<object>()
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        var normalized = normalizer.NormalizeDocument(document, definitionDirectory);
+        var response = normalized.Paths["/hello"].Get!.Responses["200"];
+
+        Assert.Equal("ok", response.Description);
+        Assert.Equal(25, response.DelayMilliseconds);
+        Assert.Equal(Path.Combine(definitionDirectory, "payloads", "users.json"), response.ResponseFile);
+        Assert.Equal("default", response.Headers["x-stub-source"].Example);
+        Assert.Equal("users", response.Scenario?.Name);
+        Assert.Equal("ready", response.Scenario?.State);
+        Assert.Equal("served", response.Scenario?.Next);
+        Assert.True(response.Content.ContainsKey("application/json"));
+    }
+
+    [Fact]
+    public void NormalizeDocument_PreservesNullOperations()
+    {
+        var normalizer = new StubDefinitionNormalizer();
+        var document = new StubDocument
+        {
+            OpenApi = "3.1.0",
+            Paths = new(StringComparer.Ordinal)
+            {
+                ["/hello"] = new()
+                {
+                    Post = new()
+                    {
+                        Responses = new(StringComparer.Ordinal)
+                        {
+                            ["201"] = CreateResponse()
+                        }
+                    }
+                }
+            }
+        };
+
+        var normalized = normalizer.NormalizeDocument(document, Directory.GetCurrentDirectory());
+        var path = normalized.Paths["/hello"];
+
+        Assert.Null(path.Get);
+        Assert.NotNull(path.Post);
+        Assert.Null(path.Put);
+        Assert.Null(path.Patch);
+        Assert.Null(path.Delete);
+    }
+
+    private static StubDocument CreateDocument(OperationDefinition operation)
+    {
+        return new()
+        {
+            OpenApi = "3.1.0",
+            Paths = new(StringComparer.Ordinal)
+            {
+                ["/hello"] = new()
+                {
+                    Get = operation
+                }
+            }
+        };
+    }
+
+    private static ResponseDefinition CreateResponse()
+    {
+        return new()
+        {
+            Content = new(StringComparer.Ordinal)
+            {
+                ["application/json"] = new()
+                {
+                    Example = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    {
+                        ["message"] = "ok"
+                    }
+                }
+            }
+        };
+    }
+
+    private static QueryMatchResponseDefinition CreateMatchResponse()
+    {
+        return new()
+        {
+            StatusCode = 200,
+            Content = new(StringComparer.Ordinal)
+            {
+                ["application/json"] = new()
+                {
+                    Example = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    {
+                        ["message"] = "matched"
+                    }
+                }
+            }
+        };
+    }
+}

--- a/tests/SemanticStub.Api.Tests/Unit/StubDefinitionNormalizerTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubDefinitionNormalizerTests.cs
@@ -128,6 +128,36 @@ public sealed class StubDefinitionNormalizerTests
     }
 
     [Fact]
+    public void NormalizeDocument_DoesNotCarryLegacyQueryMatchFields()
+    {
+        var normalizer = new StubDefinitionNormalizer();
+        var document = CreateDocument(new()
+        {
+            Matches =
+            [
+                new()
+                {
+                    PartialQuery = new(StringComparer.Ordinal)
+                    {
+                        ["role"] = "admin"
+                    },
+                    RegexQuery = new(StringComparer.Ordinal)
+                    {
+                        ["tag"] = "^beta$"
+                    },
+                    Response = CreateMatchResponse()
+                }
+            ]
+        });
+
+        var normalized = normalizer.NormalizeDocument(document, Directory.GetCurrentDirectory());
+        var match = Assert.Single(normalized.Paths["/hello"].Get!.Matches);
+
+        Assert.Empty(match.PartialQuery);
+        Assert.Empty(match.RegexQuery);
+    }
+
+    [Fact]
     public void NormalizeDocument_PreservesSemanticMatchAndMatchResponseDetails()
     {
         var normalizer = new StubDefinitionNormalizer();

--- a/tests/SemanticStub.Api.Tests/Unit/StubDefinitionValidatorTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubDefinitionValidatorTests.cs
@@ -1,0 +1,484 @@
+using SemanticStub.Api.Infrastructure.Yaml;
+using SemanticStub.Api.Models;
+using Xunit;
+
+namespace SemanticStub.Api.Tests.Unit;
+
+public sealed class StubDefinitionValidatorTests
+{
+    [Fact]
+    public void ValidateDocument_AllowsValidResponseDefinition()
+    {
+        var validator = new StubDefinitionValidator();
+        var document = CreateDocument(
+            CreateOperation(responses: new()
+            {
+                ["200"] = CreateResponse()
+            }));
+
+        validator.ValidateDocument(document, Directory.GetCurrentDirectory());
+    }
+
+    [Fact]
+    public void ValidateDocument_ThrowsWhenOpenApiIsMissing()
+    {
+        var validator = new StubDefinitionValidator();
+        var document = new StubDocument
+        {
+            OpenApi = string.Empty,
+            Paths = new(StringComparer.Ordinal)
+            {
+                ["/hello"] = new()
+                {
+                    Get = CreateOperation(responses: new()
+                    {
+                        ["200"] = CreateResponse()
+                    })
+                }
+            }
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => validator.ValidateDocument(document, Directory.GetCurrentDirectory()));
+
+        Assert.Contains("The 'openapi' field is required.", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateDocument_ThrowsWhenPathsIsEmpty()
+    {
+        var validator = new StubDefinitionValidator();
+        var document = new StubDocument
+        {
+            OpenApi = "3.1.0"
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => validator.ValidateDocument(document, Directory.GetCurrentDirectory()));
+
+        Assert.Contains("At least one path must be configured under 'paths'.", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateDocument_ThrowsWhenPathHasNoSupportedOperation()
+    {
+        var validator = new StubDefinitionValidator();
+        var document = new StubDocument
+        {
+            OpenApi = "3.1.0",
+            Paths = new(StringComparer.Ordinal)
+            {
+                ["/hello"] = new()
+            }
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => validator.ValidateDocument(document, Directory.GetCurrentDirectory()));
+
+        Assert.Contains("Path '/hello' must define at least one supported operation.", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateDocument_ThrowsWhenOperationHasNoResponsesOrMatches()
+    {
+        var validator = new StubDefinitionValidator();
+        var document = CreateDocument(new OperationDefinition());
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => validator.ValidateDocument(document, Directory.GetCurrentDirectory()));
+
+        Assert.Contains("Path '/hello' GET must define at least one response or x-match entry.", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateDocument_ThrowsForUnsupportedResponseStatusKey()
+    {
+        var validator = new StubDefinitionValidator();
+        var document = CreateDocument(
+            CreateOperation(responses: new()
+            {
+                ["default"] = CreateResponse()
+            }));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => validator.ValidateDocument(document, Directory.GetCurrentDirectory()));
+
+        Assert.Contains("Path '/hello' GET responses['default'] uses unsupported response key 'default'.", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateDocument_ThrowsForOutOfRangeResponseStatusKey()
+    {
+        var validator = new StubDefinitionValidator();
+        var document = CreateDocument(
+            CreateOperation(responses: new()
+            {
+                ["700"] = CreateResponse()
+            }));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => validator.ValidateDocument(document, Directory.GetCurrentDirectory()));
+
+        Assert.Contains("Path '/hello' GET responses['700'] must use an HTTP status code between 100 and 599.", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateDocument_ThrowsWhenResponseHasNoContentOrResponseFile()
+    {
+        var validator = new StubDefinitionValidator();
+        var document = CreateDocument(
+            CreateOperation(responses: new()
+            {
+                ["200"] = new ResponseDefinition()
+            }));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => validator.ValidateDocument(document, Directory.GetCurrentDirectory()));
+
+        Assert.Contains("Path '/hello' GET responses['200'] must define content or 'x-response-file'.", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateDocument_ThrowsWhenResponseContentHasNoExample()
+    {
+        var validator = new StubDefinitionValidator();
+        var document = CreateDocument(
+            CreateOperation(responses: new()
+            {
+                ["200"] = new ResponseDefinition
+                {
+                    Content = new(StringComparer.Ordinal)
+                    {
+                        ["application/json"] = new()
+                    }
+                }
+            }));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => validator.ValidateDocument(document, Directory.GetCurrentDirectory()));
+
+        Assert.Contains("Path '/hello' GET responses['200'] must define an example for 'application/json'.", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateDocument_ThrowsWhenResponseFileIsMissing()
+    {
+        var validator = new StubDefinitionValidator();
+        var document = CreateDocument(
+            CreateOperation(responses: new()
+            {
+                ["200"] = new ResponseDefinition
+                {
+                    ResponseFile = "missing.json"
+                }
+            }));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => validator.ValidateDocument(document, Directory.GetCurrentDirectory()));
+
+        Assert.Contains("Path '/hello' GET responses['200'] references missing response file 'missing.json'.", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateDocument_ThrowsWhenSemanticMatchIsEmpty()
+    {
+        var validator = new StubDefinitionValidator();
+        var document = CreateDocument(
+            CreateOperation(matches:
+            [
+                new()
+                {
+                    SemanticMatch = "   ",
+                    Response = CreateMatchResponse()
+                }
+            ]));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => validator.ValidateDocument(document, Directory.GetCurrentDirectory()));
+
+        Assert.Contains("Path '/hello' GET x-match[0].x-semantic-match must not be empty.", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateDocument_ThrowsWhenSemanticMatchIsCombinedWithDeterministicCondition()
+    {
+        var validator = new StubDefinitionValidator();
+        var document = CreateDocument(
+            CreateOperation(matches:
+            [
+                new()
+                {
+                    SemanticMatch = "find users",
+                    Query = new(StringComparer.Ordinal)
+                    {
+                        ["role"] = "admin"
+                    },
+                    Response = CreateMatchResponse()
+                }
+            ]));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => validator.ValidateDocument(document, Directory.GetCurrentDirectory()));
+
+        Assert.Contains("Path '/hello' GET x-match[0].x-semantic-match cannot be combined with query.", exception.Message);
+        Assert.DoesNotContain("x-match[0].query['role'] must reference a declared query parameter", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateDocument_ThrowsWhenMatchedQueryIsNotDeclared()
+    {
+        var validator = new StubDefinitionValidator();
+        var document = CreateDocument(
+            CreateOperation(
+                parameters:
+                [
+                    new()
+                    {
+                        Name = "status",
+                        In = "query"
+                    }
+                ],
+                matches:
+                [
+                    new()
+                    {
+                        Query = new(StringComparer.Ordinal)
+                        {
+                            ["role"] = "admin"
+                        },
+                        Response = CreateMatchResponse()
+                    }
+                ]));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => validator.ValidateDocument(document, Directory.GetCurrentDirectory()));
+
+        Assert.Contains("Path '/hello' GET x-match[0].query['role'] must reference a declared query parameter.", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateDocument_AllowsMatchedHeaderUsingCaseInsensitiveDeclaredParameter()
+    {
+        var validator = new StubDefinitionValidator();
+        var document = CreateDocument(
+            CreateOperation(
+                parameters:
+                [
+                    new()
+                    {
+                        Name = "X-Env",
+                        In = "header"
+                    }
+                ],
+                matches:
+                [
+                    new()
+                    {
+                        Headers = new(StringComparer.OrdinalIgnoreCase)
+                        {
+                            ["x-env"] = "staging"
+                        },
+                        Response = CreateMatchResponse()
+                    }
+                ]));
+
+        validator.ValidateDocument(document, Directory.GetCurrentDirectory());
+    }
+
+    [Fact]
+    public void ValidateDocument_ThrowsWhenMatchOperatorIsUnsupported()
+    {
+        var validator = new StubDefinitionValidator();
+        var document = CreateDocument(
+            CreateOperation(matches:
+            [
+                new()
+                {
+                    Query = new(StringComparer.Ordinal)
+                    {
+                        ["role"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                        {
+                            ["contains"] = "admin"
+                        }
+                    },
+                    Response = CreateMatchResponse()
+                }
+            ]));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => validator.ValidateDocument(document, Directory.GetCurrentDirectory()));
+
+        Assert.Contains("Path '/hello' GET x-match[0].query['role'] uses unsupported operator 'contains'.", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateDocument_ThrowsWhenMatchOperatorsAreMixed()
+    {
+        var validator = new StubDefinitionValidator();
+        var document = CreateDocument(
+            CreateOperation(matches:
+            [
+                new()
+                {
+                    Query = new(StringComparer.Ordinal)
+                    {
+                        ["role"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                        {
+                            ["equals"] = "admin",
+                            ["regex"] = "^admin$"
+                        }
+                    },
+                    Response = CreateMatchResponse()
+                }
+            ]));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => validator.ValidateDocument(document, Directory.GetCurrentDirectory()));
+
+        Assert.Contains("Path '/hello' GET x-match[0].query['role'] must not combine equals and regex operators.", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateDocument_ThrowsWhenRegexPatternIsInvalid()
+    {
+        var validator = new StubDefinitionValidator();
+        var document = CreateDocument(
+            CreateOperation(matches:
+            [
+                new()
+                {
+                    Query = new(StringComparer.Ordinal)
+                    {
+                        ["role"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                        {
+                            ["regex"] = "["
+                        }
+                    },
+                    Response = CreateMatchResponse()
+                }
+            ]));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => validator.ValidateDocument(document, Directory.GetCurrentDirectory()));
+
+        Assert.Contains("Path '/hello' GET x-match[0].query['role'].regex must be a valid regex pattern.", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateDocument_ThrowsWhenMatchedResponseStatusCodeIsNotPositive()
+    {
+        var validator = new StubDefinitionValidator();
+        var document = CreateDocument(
+            CreateOperation(matches:
+            [
+                new()
+                {
+                    Query = new(StringComparer.Ordinal)
+                    {
+                        ["role"] = "admin"
+                    },
+                    Response = CreateMatchResponse(statusCode: 0)
+                }
+            ]));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => validator.ValidateDocument(document, Directory.GetCurrentDirectory()));
+
+        Assert.Contains("Path '/hello' GET x-match[0] must define a positive statusCode.", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateDocument_ThrowsWhenScenarioNameIsMissing()
+    {
+        var validator = new StubDefinitionValidator();
+        var document = CreateDocument(
+            CreateOperation(responses: new()
+            {
+                ["409"] = new ResponseDefinition
+                {
+                    Content = new(StringComparer.Ordinal)
+                    {
+                        ["application/json"] = new()
+                        {
+                            Example = new Dictionary<string, object?>(StringComparer.Ordinal)
+                            {
+                                ["message"] = "conflict"
+                            }
+                        }
+                    },
+                    Scenario = new()
+                    {
+                        State = "initial"
+                    }
+                }
+            }));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => validator.ValidateDocument(document, Directory.GetCurrentDirectory()));
+
+        Assert.Contains("Path '/hello' GET responses['409'].x-scenario.name is required.", exception.Message);
+    }
+
+    private static StubDocument CreateDocument(OperationDefinition operation)
+    {
+        return new()
+        {
+            OpenApi = "3.1.0",
+            Paths = new(StringComparer.Ordinal)
+            {
+                ["/hello"] = new()
+                {
+                    Get = operation
+                }
+            }
+        };
+    }
+
+    private static OperationDefinition CreateOperation(
+        List<ParameterDefinition>? parameters = null,
+        Dictionary<string, ResponseDefinition>? responses = null,
+        List<QueryMatchDefinition>? matches = null)
+    {
+        return new()
+        {
+            Parameters = parameters ?? [],
+            Responses = responses ?? new(StringComparer.Ordinal),
+            Matches = matches ?? []
+        };
+    }
+
+    private static ResponseDefinition CreateResponse()
+    {
+        return new()
+        {
+            Content = new(StringComparer.Ordinal)
+            {
+                ["application/json"] = new()
+                {
+                    Example = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    {
+                        ["message"] = "ok"
+                    }
+                }
+            }
+        };
+    }
+
+    private static QueryMatchResponseDefinition CreateMatchResponse(int statusCode = 200)
+    {
+        return new()
+        {
+            StatusCode = statusCode,
+            Content = new(StringComparer.Ordinal)
+            {
+                ["application/json"] = new()
+                {
+                    Example = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    {
+                        ["message"] = "matched"
+                    }
+                }
+            }
+        };
+    }
+}

--- a/tests/SemanticStub.Api.Tests/Unit/StubDefinitionValidatorTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubDefinitionValidatorTests.cs
@@ -199,28 +199,24 @@ public sealed class StubDefinitionValidatorTests
         Assert.Contains("Path '/hello' GET x-match[0].x-semantic-match must not be empty.", exception.Message);
     }
 
-    [Fact]
-    public void ValidateDocument_ThrowsWhenSemanticMatchIsCombinedWithDeterministicCondition()
+    [Theory]
+    [MemberData(nameof(SemanticMatchDeterministicConditions))]
+    public void ValidateDocument_ThrowsWhenSemanticMatchIsCombinedWithDeterministicCondition(
+        QueryMatchDefinition match,
+        string deterministicField)
     {
         var validator = new StubDefinitionValidator();
+        match = WithResponse(match, CreateMatchResponse());
         var document = CreateDocument(
             CreateOperation(matches:
             [
-                new()
-                {
-                    SemanticMatch = "find users",
-                    Query = new(StringComparer.Ordinal)
-                    {
-                        ["role"] = "admin"
-                    },
-                    Response = CreateMatchResponse()
-                }
+                match
             ]));
 
         var exception = Assert.Throws<InvalidOperationException>(
             () => validator.ValidateDocument(document, Directory.GetCurrentDirectory()));
 
-        Assert.Contains("Path '/hello' GET x-match[0].x-semantic-match cannot be combined with query.", exception.Message);
+        Assert.Contains($"Path '/hello' GET x-match[0].x-semantic-match cannot be combined with {deterministicField}.", exception.Message);
         Assert.DoesNotContain("x-match[0].query['role'] must reference a declared query parameter", exception.Message);
     }
 
@@ -365,6 +361,151 @@ public sealed class StubDefinitionValidatorTests
     }
 
     [Fact]
+    public void ValidateDocument_ThrowsWhenFormBodyIsCombinedWithJsonBody()
+    {
+        var validator = new StubDefinitionValidator();
+        var document = CreateDocument(
+            CreateOperation(matches:
+            [
+                new()
+                {
+                    Body = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    {
+                        ["form"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                        {
+                            ["username"] = "demo"
+                        },
+                        ["json"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                        {
+                            ["username"] = "demo"
+                        }
+                    },
+                    Response = CreateMatchResponse()
+                }
+            ]));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => validator.ValidateDocument(document, Directory.GetCurrentDirectory()));
+
+        Assert.Contains("Path '/hello' GET x-match[0].body.form cannot be combined with body.json.", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateDocument_ThrowsWhenFormBodyIsCombinedWithTextBody()
+    {
+        var validator = new StubDefinitionValidator();
+        var document = CreateDocument(
+            CreateOperation(matches:
+            [
+                new()
+                {
+                    Body = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    {
+                        ["form"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                        {
+                            ["username"] = "demo"
+                        },
+                        ["text"] = "demo"
+                    },
+                    Response = CreateMatchResponse()
+                }
+            ]));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => validator.ValidateDocument(document, Directory.GetCurrentDirectory()));
+
+        Assert.Contains("Path '/hello' GET x-match[0].body.form cannot be combined with body.text.", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateDocument_ThrowsWhenFormBodyMatchOperatorIsUnsupported()
+    {
+        var validator = new StubDefinitionValidator();
+        var document = CreateDocument(
+            CreateOperation(matches:
+            [
+                new()
+                {
+                    Body = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    {
+                        ["form"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                        {
+                            ["username"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                            {
+                                ["contains"] = "demo"
+                            }
+                        }
+                    },
+                    Response = CreateMatchResponse()
+                }
+            ]));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => validator.ValidateDocument(document, Directory.GetCurrentDirectory()));
+
+        Assert.Contains("Path '/hello' GET x-match[0].body.form['username'] uses unsupported operator 'contains'.", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateDocument_ThrowsWhenFormBodyMatchOperatorsAreMixed()
+    {
+        var validator = new StubDefinitionValidator();
+        var document = CreateDocument(
+            CreateOperation(matches:
+            [
+                new()
+                {
+                    Body = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    {
+                        ["form"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                        {
+                            ["username"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                            {
+                                ["equals"] = "demo",
+                                ["regex"] = "^demo$"
+                            }
+                        }
+                    },
+                    Response = CreateMatchResponse()
+                }
+            ]));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => validator.ValidateDocument(document, Directory.GetCurrentDirectory()));
+
+        Assert.Contains("Path '/hello' GET x-match[0].body.form['username'] must not combine equals and regex operators.", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateDocument_ThrowsWhenFormBodyRegexPatternIsInvalid()
+    {
+        var validator = new StubDefinitionValidator();
+        var document = CreateDocument(
+            CreateOperation(matches:
+            [
+                new()
+                {
+                    Body = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    {
+                        ["form"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                        {
+                            ["username"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                            {
+                                ["regex"] = "["
+                            }
+                        }
+                    },
+                    Response = CreateMatchResponse()
+                }
+            ]));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => validator.ValidateDocument(document, Directory.GetCurrentDirectory()));
+
+        Assert.Contains("Path '/hello' GET x-match[0].body.form['username'].regex must be a valid regex pattern.", exception.Message);
+    }
+
+    [Fact]
     public void ValidateDocument_ThrowsWhenMatchedResponseStatusCodeIsNotPositive()
     {
         var validator = new StubDefinitionValidator();
@@ -478,6 +619,87 @@ public sealed class StubDefinitionValidatorTests
                         ["message"] = "matched"
                     }
                 }
+            }
+        };
+    }
+
+    private static QueryMatchDefinition WithResponse(
+        QueryMatchDefinition match,
+        QueryMatchResponseDefinition response)
+    {
+        return new()
+        {
+            Query = match.Query,
+            PartialQuery = match.PartialQuery,
+            RegexQuery = match.RegexQuery,
+            SemanticMatch = match.SemanticMatch,
+            Headers = match.Headers,
+            Body = match.Body,
+            Response = response
+        };
+    }
+
+    public static TheoryData<QueryMatchDefinition, string> SemanticMatchDeterministicConditions()
+    {
+        return new()
+        {
+            {
+                new()
+                {
+                    SemanticMatch = "find users",
+                    Query = new(StringComparer.Ordinal)
+                    {
+                        ["role"] = "admin"
+                    }
+                },
+                "query"
+            },
+            {
+                new()
+                {
+                    SemanticMatch = "find users",
+                    PartialQuery = new(StringComparer.Ordinal)
+                    {
+                        ["role"] = "admin"
+                    }
+                },
+                "x-query-partial"
+            },
+            {
+                new()
+                {
+                    SemanticMatch = "find users",
+                    RegexQuery = new(StringComparer.Ordinal)
+                    {
+                        ["role"] = "^admin$"
+                    }
+                },
+                "x-query-regex"
+            },
+            {
+                new()
+                {
+                    SemanticMatch = "find users",
+                    Headers = new(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["X-Env"] = "staging"
+                    }
+                },
+                "headers"
+            },
+            {
+                new()
+                {
+                    SemanticMatch = "find users",
+                    Body = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    {
+                        ["json"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                        {
+                            ["role"] = "admin"
+                        }
+                    }
+                },
+                "body"
             }
         };
     }


### PR DESCRIPTION
## Summary
- Add direct unit tests for StubDefinitionValidator representative validation rules.
- Add direct unit tests for StubDefinitionNormalizer representative normalization behavior.
- Keep loader tests focused on YAML parsing, discovery, merging, and file-system behavior without changing runtime behavior.

## Files Changed
- tests/SemanticStub.Api.Tests/Unit/StubDefinitionValidatorTests.cs
- tests/SemanticStub.Api.Tests/Unit/StubDefinitionNormalizerTests.cs

## Tests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj

## Notes
- Closes #210
- Closes #211