### PR TITLE
docs: expand development guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,5 +78,10 @@ Follow the detailed development guidelines in the following documents when relev
 - docs/development/dependency-injection.md
 - docs/development/tech-stack.md
 - docs/development/project-structure.md
+- docs/development/error-handling.md
+- docs/development/logging.md
+- docs/development/api-design.md
+- docs/development/configuration.md
+- docs/development/async-guidelines.md
 
-These documents define project-specific standards for testing, naming, dependency injection, technology choices, and structure. Always follow them when making related changes.
+These documents define project-specific standards for testing, naming, dependency injection, technology choices, and structure. Always follow them when making related changes. If multiple guidelines apply, prioritize correctness, safety, and consistency.

--- a/docs/development/api-design.md
+++ b/docs/development/api-design.md
@@ -1,0 +1,93 @@
+## API Design
+
+This project follows consistent API design principles to ensure clarity, predictability, and maintainability.
+
+### General Principles
+- Keep APIs simple and predictable.
+- Follow RESTful conventions where appropriate.
+- Design APIs for clarity over cleverness.
+- Maintain consistency across all endpoints.
+
+### Routing
+- Use clear and consistent route naming.
+- Prefer nouns over verbs in route paths.
+- Use plural resource names when appropriate.
+
+Examples:
+- `/stubs`
+- `/scenarios`
+- `/metrics`
+
+- Avoid deeply nested routes unless necessary.
+- Use route parameters for resource identification.
+
+Examples:
+- `/stubs/{id}`
+- `/scenarios/{scenarioName}`
+
+- Prefer explicit endpoints for operations instead of overloading a single endpoint.
+
+### HTTP Methods
+Use HTTP methods consistently:
+
+- `GET` → retrieve data
+- `POST` → create or trigger processing
+- `PUT` → replace/update a resource
+- `PATCH` → partial update
+- `DELETE` → remove a resource
+
+Avoid using incorrect methods for convenience.
+
+### Status Codes
+Return appropriate HTTP status codes:
+
+- `200 OK` → successful request
+- `201 Created` → resource created
+- `204 No Content` → successful with no response body
+- `400 Bad Request` → validation or client error
+- `404 Not Found` → resource not found
+- `500 Internal Server Error` → unexpected error
+- Do not return 200 OK for error cases.
+
+- Use consistent status codes across endpoints.
+
+### Request and Response Models
+- Use DTOs for request and response models.
+- Do not expose internal domain models directly.
+- Keep request and response shapes simple and explicit.
+
+Examples:
+- `CreateStubRequest`
+- `StubResponse`
+
+### Controllers
+- Controllers should be thin.
+- Do not implement business logic in controllers.
+- Delegate logic to application services.
+- Focus on request handling, validation, and response formatting.
+
+### Validation
+- Validate inputs at the API boundary.
+- Return clear and consistent validation errors.
+- Avoid relying on exceptions for validation flow.
+
+### Error Responses
+- Return consistent error response formats.
+- Do not expose internal exception details.
+- Use appropriate status codes for expected errors.
+- Use a consistent error response structure (e.g., code, message).
+
+### Consistency
+- Use consistent naming across routes, parameters, and DTOs.
+- Follow existing API patterns when adding new endpoints.
+- Avoid introducing conflicting styles.
+
+### Versioning (Optional)
+- Introduce API versioning when breaking changes are required.
+- Keep versioning strategy consistent once introduced.
+
+### Design Goals
+- Predictable API behavior
+- Clear and consistent structure
+- Separation of concerns (API vs business logic)
+- Ease of use for clients

--- a/docs/development/async-guidelines.md
+++ b/docs/development/async-guidelines.md
@@ -1,0 +1,63 @@
+## Async Guidelines
+
+This project uses async/await to handle I/O-bound operations efficiently while keeping code clear and maintainable.
+
+### General Principles
+- Use async/await for I/O-bound operations.
+- Keep asynchronous code simple and easy to follow.
+- Avoid unnecessary async usage for purely CPU-bound logic.
+
+### When to Use Async
+Use async/await when dealing with:
+- HTTP calls
+- File I/O
+- Database access
+- External services
+
+Do not use async when:
+- The operation is purely in-memory and fast
+- There is no real asynchronous work
+
+### Avoid Blocking Calls
+- Do not use `.Result` or `.Wait()` on tasks.
+- Avoid blocking the thread in asynchronous flows.
+- Do not mix synchronous and asynchronous calls within the same execution flow.
+
+### Method Design
+- Asynchronous methods should return `Task` or `Task<T>`.
+- Avoid `async void` except for event handlers.
+- Use clear method names when helpful (e.g., `GetStubAsync`).
+
+### Cancellation
+- Accept `CancellationToken` in asynchronous methods when appropriate.
+- Pass the token through to downstream async calls.
+- Respect cancellation requests when it is safe to do so.
+
+### Error Handling
+- Let exceptions propagate naturally in async methods.
+- Avoid wrapping async code in unnecessary try-catch blocks.
+- Handle exceptions only when you can add meaningful context or recovery.
+
+### Parallelism
+- Use parallelism carefully.
+- Avoid starting multiple tasks without awaiting them.
+- Prefer `Task.WhenAll` when running multiple independent async operations.
+
+### ConfigureAwait
+- Use `ConfigureAwait(false)` in library or reusable code if needed.
+- It is generally not required in ASP.NET Core application code.
+
+### Performance Considerations
+- Avoid excessive task allocations in hot paths.
+- Do not over-parallelize small operations.
+- Keep async flows simple and predictable.
+
+### Consistency
+- Follow existing async patterns in the codebase.
+- Avoid mixing synchronous and asynchronous styles unnecessarily.
+
+### Design Goals
+- Efficient use of asynchronous I/O
+- Clear and maintainable async code
+- Avoidance of deadlocks and blocking
+- Predictable execution behavior

--- a/docs/development/configuration.md
+++ b/docs/development/configuration.md
@@ -1,0 +1,67 @@
+## Configuration
+
+This project uses a consistent and maintainable approach to configuration management.
+
+### General Principles
+- Use strongly-typed configuration via Options classes.
+- Avoid accessing `IConfiguration` directly in application or domain services.
+- Keep configuration simple, explicit, and predictable.
+- Centralize configuration binding and validation.
+
+### Options Pattern
+- Use the Options pattern (`IOptions<T>`, `IOptionsSnapshot<T>`, or `IOptionsMonitor<T>`) for configuration.
+- Group related settings into a single Options class.
+- Name configuration classes with the `Options` suffix.
+
+Examples:
+- `StubOptions`
+- `MatchingOptions`
+
+### Binding and Registration
+- Bind configuration in a single place (e.g., in `Program.cs` or extension methods).
+- Avoid scattering configuration binding across multiple files.
+- Validate configuration at startup when possible.
+
+Example:
+- `services.Configure<StubOptions>(configuration.GetSection("Stub"))`
+
+### Accessing Configuration
+- Inject strongly-typed Options into services.
+- Do not inject `IConfiguration` into business logic.
+
+Preferred:
+- `IOptions<StubOptions>`
+
+Avoid:
+- Direct calls to `IConfiguration["SomeKey"]` inside services
+
+- Do not pass configuration values through multiple layers unnecessarily.
+
+### Validation
+- Validate configuration values during application startup.
+- Fail fast if critical configuration is missing or invalid.
+- Use data annotations or custom validation when appropriate.
+
+### Environment-Specific Configuration
+- Use environment-specific configuration files when needed.
+  - e.g., `appsettings.Development.json`
+- Keep environment overrides minimal and explicit.
+
+### Secrets Management
+- Do not store secrets in source-controlled configuration files.
+- Use environment variables or external secret stores.
+- Ensure sensitive values are not logged.
+
+### Defaults
+- Provide sensible default values where appropriate.
+- Avoid hidden or implicit defaults that are difficult to trace.
+
+### Consistency
+- Use consistent naming for configuration keys and sections.
+- Follow existing patterns when adding new configuration.
+
+### Design Goals
+- Clear and maintainable configuration structure
+- Strong typing and validation
+- Safe handling of sensitive data
+- Predictable configuration behavior

--- a/docs/development/dependency-injection.md
+++ b/docs/development/dependency-injection.md
@@ -12,6 +12,8 @@ This project uses dependency injection to keep composition explicit, support tes
 - Do not introduce interfaces for every class by default.
 - Do not add interfaces solely for naming symmetry or speculative future reuse.
 
+- Prefer constructor injection over property injection.
+
 ### When to Introduce an Interface
 Introduce an interface when at least one of the following is true:
 - The implementation depends on an external system or process boundary.
@@ -24,12 +26,18 @@ Do not introduce an interface when:
 - The class is an internal implementation detail with no real abstraction value.
 - The only reason is to satisfy a blanket rule that every service must have an interface.
 
+
+### Service Resolution
+- Do not resolve services manually using IServiceProvider (avoid Service Locator pattern).
+
 ### Service Lifetimes
 - Use `Scoped` by default.
 - Use `Singleton` for stateless shared services that are safe to reuse across the application lifetime.
 - Use `Transient` for lightweight, short-lived processing components.
 - Do not inject `Scoped` services into `Singleton` services.
   - Avoid captive dependencies.
+
+- Avoid constructors with too many dependencies (consider refactoring responsibilities).
 
 ### Lifetime Guidelines
 #### Scoped
@@ -79,6 +87,8 @@ This keeps dependencies explicit and makes startup code easier to maintain.
 - Prefer mocking external dependencies rather than internal business logic.
 - Do not introduce extra interfaces solely to satisfy mocking preferences.
 - Prefer real implementations for simple internal services when that keeps tests clearer.
+
+- Inject configuration via Options classes instead of passing raw values.
 
 ### Design Principles
 - Prefer explicit, purposeful abstractions.

--- a/docs/development/error-handling.md
+++ b/docs/development/error-handling.md
@@ -1,0 +1,68 @@
+
+
+## Error Handling
+
+This project defines a consistent approach to handling errors to ensure reliability, clarity, and maintainability.
+
+### General Principles
+- Do not swallow exceptions silently.
+- Handle only exceptions you can meaningfully respond to.
+- Let unexpected exceptions propagate to a centralized handler.
+- Keep error handling simple and predictable.
+- Do not use exceptions for normal control flow.
+
+### Expected vs Unexpected Errors
+
+#### Expected Errors
+- Represent known failure conditions (e.g., validation failures, not found, invalid state).
+- Should be handled explicitly.
+- Should result in appropriate responses (e.g., 400, 404).
+
+#### Unexpected Errors
+- Represent bugs or system failures.
+- Should not be handled locally unless necessary.
+- Should be logged and handled by a global exception handler.
+
+### API Layer Behavior
+- Return appropriate HTTP status codes.
+- Do not expose internal exception details to clients.
+- Use clear and consistent error response formats.
+- Keep controllers thin; avoid complex error handling logic in controllers.
+- Map domain-specific exceptions to appropriate HTTP status codes in a centralized handler.
+
+### Exception Design
+- Use specific exception types when they add clarity.
+- Prefer domain-specific exceptions for business logic errors.
+- Avoid overusing custom exceptions without clear purpose.
+
+Examples:
+- `RouteNotFoundException`
+- `InvalidScenarioStateException`
+
+### Logging
+- Log unexpected exceptions.
+- Include useful context when logging (e.g., route, request data, identifiers).
+- Do not log sensitive information.
+
+### When to Catch Exceptions
+Catch exceptions only when you can:
+- Recover from the error
+- Translate the error into a meaningful domain or API response
+- Add useful context before rethrowing
+
+Otherwise, allow the exception to propagate.
+
+### Rethrowing Exceptions
+- Preserve the original stack trace when rethrowing.
+- Do not use `throw ex;`
+- Use `throw;` to rethrow the original exception.
+
+### Validation
+- Prefer validating inputs early rather than relying on exceptions.
+- Use clear validation errors for client mistakes.
+
+### Design Goals
+- Predictable error handling behavior
+- Clear separation between expected and unexpected failures
+- Minimal duplication of error handling logic
+- Safe and secure error responses

--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -1,0 +1,81 @@
+
+
+## Logging
+
+This project uses logging to support observability, troubleshooting, and operational clarity without adding unnecessary noise.
+
+### General Principles
+- Log important events, warnings, and errors.
+- Prefer structured logging over interpolated or concatenated log messages.
+- Keep logs clear, consistent, and useful.
+- Avoid excessive logging in hot paths or frequently executed code.
+- Prefer logs that explain what happened and why.
+
+### What to Log
+Log when it helps diagnose behavior, failures, or significant system events.
+
+Examples:
+- application startup and shutdown
+- configuration loading results
+- request handling milestones when useful
+- scenario state transitions
+- external dependency failures
+- unexpected exceptions
+- important warnings or fallback behavior
+
+### What Not to Log
+- Do not log sensitive information.
+- Do not log secrets, credentials, tokens, or private keys.
+- Do not log full request or response bodies unless clearly justified and safe.
+- Do not add noisy logs for trivial internal steps.
+
+### Structured Logging
+- Prefer structured log parameters instead of embedding values directly into strings.
+- Include relevant identifiers and context when useful.
+
+Examples of useful context:
+- route
+- scenario name
+- request path
+- request id / trace id
+- response status code
+- external dependency name
+
+- Include identifiers (e.g., request id, scenario name) to correlate logs.
+
+### Log Levels
+Use log levels intentionally:
+
+- `Trace` → very detailed diagnostic information
+- `Debug` → development-focused diagnostic details
+- `Information` → normal important application events
+- `Warning` → unexpected but recoverable situations
+- `Error` → failures that affect the current operation
+- `Critical` → severe failures affecting application stability
+
+### Exception Logging
+- Log unexpected exceptions.
+- Do not log and rethrow the same exception repeatedly without adding value.
+- When catching exceptions, add useful context only when it improves diagnosis.
+
+### API and Request Logging
+- Log request-related information at an appropriate level.
+- Avoid duplicating logs that are already captured by middleware or framework-level logging.
+- Keep controller-level logging minimal when the same information is already available elsewhere.
+- Avoid logging the same event at multiple layers.
+
+### Performance Considerations
+- Avoid excessive logging inside tight loops or frequently executed match paths.
+- Be careful with large object serialization in logs.
+- Prefer concise, high-value log events.
+
+### Consistency
+- Use consistent message patterns across the codebase.
+- Follow existing logging conventions when extending functionality.
+- Keep log messages readable and action-oriented.
+
+### Design Goals
+- Useful operational visibility
+- Clear diagnostics for failures
+- Minimal unnecessary noise
+- Safe handling of sensitive information

--- a/docs/development/naming-conventions.md
+++ b/docs/development/naming-conventions.md
@@ -7,6 +7,7 @@ This project follows Microsoft C# naming conventions as the baseline, with a few
 - Prefer full words over unclear abbreviations.
 - Avoid ambiguous or overly generic names such as `data`, `value`, or `item`.
 - Keep naming consistent across the codebase.
+- Avoid unnecessary abbreviations unless they are domain-specific and well understood.
 
 ### Casing Rules
 - Use PascalCase for:
@@ -34,6 +35,9 @@ Examples:
 - Properties use PascalCase and should be nouns or adjectives.
 - Boolean members should read naturally (e.g., `IsEnabled`, `HasRoutes`).
 
+- Asynchronous methods should use the `Async` suffix.
+- Avoid negative boolean names when possible (prefer `IsEnabled` over `IsNotDisabled`).
+
 Examples:
 - `GetEffectiveConfiguration()`
 - `TryMatchRoute()`
@@ -51,6 +55,14 @@ Examples:
 - `requestPath`
 - `matchedRoute`
 
+### Constants and Static Members
+- Use PascalCase for constants and static readonly fields.
+- Avoid ALL_CAPS naming.
+
+Examples:
+- `MaxRetryCount`
+- `DefaultTimeout`
+
 ### Test Naming
 - Test class names should match the target type and end with `Tests`.
 - Test method names should clearly describe behavior.
@@ -60,6 +72,14 @@ Examples:
 Examples:
 - `TryMatchRoute_WhenPatternMatches_ReturnsTrue`
 - `Next_WhenScenarioHasNoResponses_ReturnsNull`
+
+### File Naming
+- File names should match the primary type defined in the file.
+- Avoid multiple unrelated types in a single file.
+
+Examples:
+- `RouteMatcher.cs`
+- `ScenarioService.cs`
 
 ### Common Suffixes
 Use consistent suffixes when they improve clarity:

--- a/docs/development/project-structure.md
+++ b/docs/development/project-structure.md
@@ -1,5 +1,3 @@
-
-
 ## Project Structure
 
 This project follows a layered structure to keep responsibilities clear and maintainable.
@@ -67,6 +65,7 @@ Example structure:
 Disallowed:
 - Application must not depend on Infrastructure implementations
 - Domain must not depend on Application or Infrastructure
+- Avoid circular dependencies between layers.
 
 ### Test Project Structure
 
@@ -86,6 +85,8 @@ Guidelines:
 - Group files by feature or responsibility rather than by technical type when appropriate
 - Avoid overly deep folder nesting
 - Keep related classes close together
+- Prefer grouping related interfaces and implementations together.
+- Avoid creating separate `Interfaces` and `Implementations` folders by default.
 
 Examples:
 - Route-related logic grouped together
@@ -102,9 +103,21 @@ Examples:
 - Do not introduce cross-layer dependencies that violate the rules
 - Follow existing folder patterns and naming conventions
 
+### Feature Organization
+
+- Prefer organizing code by feature within each layer.
+- Keep related types (services, models, helpers) close together.
+- Avoid scattering related logic across multiple unrelated folders.
+
+Examples:
+- Matching feature (matcher, related models, helpers)
+- Scenario feature (state, transitions, services)
+
 ### Design Goals
 
 - Clear separation of concerns
 - Maintainable and scalable structure
 - Easy navigation for both humans and tools
 - Predictable placement of new code
+- Minimize cross-layer coupling
+- Encourage feature-level cohesion

--- a/docs/development/tech-stack.md
+++ b/docs/development/tech-stack.md
@@ -22,8 +22,22 @@ This project uses a modern, pragmatic .NET-based technology stack. The goal is t
 - Microsoft.Extensions.Logging (baseline)
 - Optional: Serilog (for structured logging when needed)
 
+
 ### HTTP / Networking
 - HttpClient via IHttpClientFactory
+
+### API Documentation
+- Swagger / OpenAPI (Swashbuckle) → API documentation and testing
+
+### Validation
+- Built-in model validation (DataAnnotations)
+- Optional: FluentValidation
+
+### Resilience (Optional)
+- Polly → retry, circuit breaker, timeout handling
+
+### Utilities
+- Time abstraction (e.g., IClock) when needed for testing
 
 ### Development Tools
 - Visual Studio / VS Code

--- a/docs/development/testing-strategy.md
+++ b/docs/development/testing-strategy.md
@@ -1,5 +1,3 @@
-
-
 ## Test Strategy
 
 ### Principles
@@ -17,6 +15,8 @@ Guidelines:
 - Avoid unnecessary mocking of internal collaborators.
 - Add regression tests for bug fixes.
 - Cover edge cases and failure cases when they affect observable behavior.
+- Avoid testing private methods directly; test through public behavior.
+- Keep tests independent; they should not rely on execution order.
 
 Examples of code that should usually be covered by unit tests:
 - matchers
@@ -34,6 +34,8 @@ Guidelines:
 - Verify routing, model binding, filters, middleware interaction, status codes, and response shapes.
 - Prefer real application wiring unless isolation is required for external systems.
 - Replace only truly external dependencies when needed.
+- Use realistic configuration and data where possible.
+- Avoid excessive mocking in integration tests.
 
 Examples of code that should usually be covered by integration tests:
 - admin or inspection endpoints
@@ -70,14 +72,30 @@ Guidelines:
 - Critical user flows should have selective end-to-end coverage.
 - Bug fixes should include regression tests when practical.
 
+### Test Data
+
+- Use clear and minimal test data focused on the behavior being tested.
+- Avoid large or overly complex test fixtures.
+- Prefer inline test data when it improves readability.
+- Use builders or helpers when setup becomes repetitive.
+
 ### Test Design Guidelines
 - Write tests that describe behavior clearly.
 - Keep each test focused on one behavior.
 - Avoid brittle assertions tied to incidental implementation details.
 - Name tests so the intended behavior is easy to understand.
 - Prefer readable test setup over overly clever reuse.
+- Prefer Arrange-Act-Assert structure.
+- Avoid excessive assertions in a single test.
+- Tests should fail for a single clear reason.
 
 ### Preferred Libraries
 - xUnit
 - Moq
 - Shouldly
+
+### Naming Conventions for Tests
+
+- Follow naming patterns defined in `naming-conventions.md`.
+- Test names should clearly describe behavior and expected outcome.
+- Avoid vague test names such as `Test1` or `ShouldWork`.


### PR DESCRIPTION
## Summary
- Add development guides for API design, async usage, configuration, error handling, and logging.
- Expand existing development guides for testing, naming, dependency injection, project structure, and tech stack.
- Update AGENTS.md to reference the new guide documents.

## Files Changed
- AGENTS.md
- docs/development/*.md

## Tests
- Not run; documentation-only change.

## Notes
- Documentation-only PR.