### PR TITLE
test: document singleton runtime state lifetimes

### DIFF
--- a/src/SemanticStub.Api/Extensions/StubServiceCollectionExtensions.cs
+++ b/src/SemanticStub.Api/Extensions/StubServiceCollectionExtensions.cs
@@ -47,6 +47,7 @@ public static class StubServiceCollectionExtensions
     private static IServiceCollection AddYamlInfrastructureServices(this IServiceCollection services)
     {
         services.AddSingleton<IStubDefinitionLoader, StubDefinitionLoader>();
+        // The loaded YAML definition is process-wide runtime state and is replaced atomically on reload.
         services.AddSingleton<StubDefinitionState>();
 
         return services;
@@ -54,6 +55,7 @@ public static class StubServiceCollectionExtensions
 
     private static IServiceCollection AddInspectionServices(this IServiceCollection services)
     {
+        // Runtime inspection metrics and recent request history are process-wide by design.
         services.AddSingleton<StubInspectionRuntimeStore>();
         services.AddSingleton<StubInspectionScenarioCoordinator>();
         services.AddSingleton<IStubInspectionService>(serviceProvider => new StubInspectionService(
@@ -94,6 +96,7 @@ public static class StubServiceCollectionExtensions
 
     private static IServiceCollection AddScenarioServices(this IServiceCollection services)
     {
+        // YAML scenario progress is shared across requests for the current process.
         services.AddSingleton<ScenarioService>();
 
         return services;

--- a/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionState.cs
+++ b/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionState.cs
@@ -3,6 +3,9 @@ using SemanticStub.Api.Services;
 
 namespace SemanticStub.Api.Infrastructure.Yaml;
 
+/// <summary>
+/// Holds the current process-wide YAML definition snapshot and swaps it atomically during reloads.
+/// </summary>
 internal sealed class StubDefinitionState
 {
     private readonly IStubDefinitionLoader loader;

--- a/src/SemanticStub.Api/Services/Inspection/StubInspectionRuntimeStore.cs
+++ b/src/SemanticStub.Api/Services/Inspection/StubInspectionRuntimeStore.cs
@@ -2,6 +2,9 @@ using SemanticStub.Api.Inspection;
 
 namespace SemanticStub.Api.Services;
 
+/// <summary>
+/// Stores process-wide runtime inspection state such as metrics, recent requests, and the latest match explanation.
+/// </summary>
 internal sealed class StubInspectionRuntimeStore
 {
     private const int MaxRecentRequestCount = 100;

--- a/src/SemanticStub.Api/Services/Scenario/ScenarioService.cs
+++ b/src/SemanticStub.Api/Services/Scenario/ScenarioService.cs
@@ -4,6 +4,7 @@ namespace SemanticStub.Api.Services;
 
 /// <summary>
 /// Stores scenario state transitions in memory so YAML-defined stateful flows can advance deterministically across requests.
+/// The state is intentionally shared for the current process lifetime.
 /// </summary>
 public sealed class ScenarioService
 {

--- a/tests/SemanticStub.Api.Tests/Integration/StubServiceCollectionExtensionsTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/StubServiceCollectionExtensionsTests.cs
@@ -16,6 +16,53 @@ public sealed class StubServiceCollectionExtensionsTests
     public void AddStubServices_RegistersProductionCompositionGraph()
     {
         using var workspace = StubWorkspace.Create();
+        var services = CreateServiceCollection(workspace);
+
+        services.AddStubServices();
+
+        using var serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true
+        });
+
+        Assert.NotNull(serviceProvider.GetRequiredService<IStubService>());
+        Assert.NotNull(serviceProvider.GetRequiredService<IStubInspectionService>());
+        Assert.NotNull(serviceProvider.GetRequiredService<IStubDefinitionLoader>());
+        Assert.NotEmpty(serviceProvider.GetServices<IHostedService>());
+    }
+
+    [Fact]
+    public void AddStubServices_RegistersProcessWideStateServicesAsSingletons()
+    {
+        using var workspace = StubWorkspace.Create();
+        var services = CreateServiceCollection(workspace);
+
+        services.AddStubServices();
+
+        AssertServiceLifetime<ScenarioService>(services, ServiceLifetime.Singleton);
+        AssertServiceLifetime<StubDefinitionState>(services, ServiceLifetime.Singleton);
+        AssertServiceLifetime<StubInspectionRuntimeStore>(services, ServiceLifetime.Singleton);
+
+        using var serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true
+        });
+
+        Assert.Same(
+            serviceProvider.GetRequiredService<ScenarioService>(),
+            serviceProvider.GetRequiredService<ScenarioService>());
+        Assert.Same(
+            serviceProvider.GetRequiredService<StubDefinitionState>(),
+            serviceProvider.GetRequiredService<StubDefinitionState>());
+        Assert.Same(
+            serviceProvider.GetRequiredService<StubInspectionRuntimeStore>(),
+            serviceProvider.GetRequiredService<StubInspectionRuntimeStore>());
+    }
+
+    private static ServiceCollection CreateServiceCollection(StubWorkspace workspace)
+    {
         var services = new ServiceCollection();
 
         services.AddLogging();
@@ -29,18 +76,15 @@ public sealed class StubServiceCollectionExtensionsTests
             WebRootPath = workspace.RootPath,
             WebRootFileProvider = new PhysicalFileProvider(workspace.RootPath)
         });
-        services.AddStubServices();
 
-        using var serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions
-        {
-            ValidateOnBuild = true,
-            ValidateScopes = true
-        });
+        return services;
+    }
 
-        Assert.NotNull(serviceProvider.GetRequiredService<IStubService>());
-        Assert.NotNull(serviceProvider.GetRequiredService<IStubInspectionService>());
-        Assert.NotNull(serviceProvider.GetRequiredService<IStubDefinitionLoader>());
-        Assert.NotEmpty(serviceProvider.GetServices<IHostedService>());
+    private static void AssertServiceLifetime<TService>(IServiceCollection services, ServiceLifetime expectedLifetime)
+    {
+        var descriptor = Assert.Single(services, descriptor => descriptor.ServiceType == typeof(TService));
+
+        Assert.Equal(expectedLifetime, descriptor.Lifetime);
     }
 
     private sealed class StubWorkspace(string rootPath, string samplesPath) : IDisposable


### PR DESCRIPTION
## Summary
- Document why ScenarioService, StubDefinitionState, and StubInspectionRuntimeStore stay process-wide singletons.
- Add DI coverage that fixes those state services as singleton registrations and validates the provider with scope checks.

## Files Changed
- src/SemanticStub.Api/Extensions/StubServiceCollectionExtensions.cs
- src/SemanticStub.Api/Services/Scenario/ScenarioService.cs
- src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionState.cs
- src/SemanticStub.Api/Services/Inspection/StubInspectionRuntimeStore.cs
- tests/SemanticStub.Api.Tests/Integration/StubServiceCollectionExtensionsTests.cs

## Tests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter StubServiceCollectionExtensionsTests
- dotnet test SemanticStub.sln

## Notes
- No runtime lifetime changes were made; actual lifetime changes should remain separate follow-up work if needed.

Closes #194