### PR TITLE
refactor: abstract semantic embedding client

### DIFF
--- a/src/SemanticStub.Api/Extensions/StubServiceCollectionExtensions.cs
+++ b/src/SemanticStub.Api/Extensions/StubServiceCollectionExtensions.cs
@@ -35,9 +35,9 @@ public static class StubServiceCollectionExtensions
             var settings = serviceProvider.GetRequiredService<IOptions<StubSettings>>().Value;
             client.Timeout = TimeSpan.FromSeconds(settings.SemanticMatching.TimeoutSeconds);
         });
-        services.AddSingleton<SemanticEmbeddingClient>();
+        services.AddSingleton<ISemanticEmbeddingClient, SemanticEmbeddingClient>();
         services.AddSingleton<ISemanticMatcherService>(serviceProvider => new SemanticMatcherService(
-            serviceProvider.GetRequiredService<SemanticEmbeddingClient>(),
+            serviceProvider.GetRequiredService<ISemanticEmbeddingClient>(),
             serviceProvider.GetRequiredService<IOptions<StubSettings>>(),
             serviceProvider.GetRequiredService<ILogger<SemanticMatcherService>>()));
 

--- a/src/SemanticStub.Api/Services/Semantic/ISemanticEmbeddingClient.cs
+++ b/src/SemanticStub.Api/Services/Semantic/ISemanticEmbeddingClient.cs
@@ -1,0 +1,14 @@
+namespace SemanticStub.Api.Services;
+
+/// <summary>
+/// Provides embeddings from the configured semantic embedding provider.
+/// </summary>
+internal interface ISemanticEmbeddingClient
+{
+    /// <summary>
+    /// Gets embeddings for the supplied inputs.
+    /// </summary>
+    /// <param name="inputs">The request and candidate texts to embed.</param>
+    /// <returns>The returned embedding vectors in request order.</returns>
+    Task<IReadOnlyList<float[]>> GetEmbeddingsAsync(IReadOnlyList<string> inputs);
+}

--- a/src/SemanticStub.Api/Services/Semantic/SemanticEmbeddingClient.cs
+++ b/src/SemanticStub.Api/Services/Semantic/SemanticEmbeddingClient.cs
@@ -36,7 +36,7 @@ internal sealed class SemanticEmbeddingClient : ISemanticEmbeddingClient
     public async Task<IReadOnlyList<float[]>> GetEmbeddingsAsync(IReadOnlyList<string> inputs)
     {
         var httpClient = httpClientFactory.CreateClient(HttpClientName);
-        var endpoint = NormalizeEndpoint(settings.Endpoint!);
+        var endpoint = SemanticEmbeddingEndpoint.Normalize(settings.Endpoint!);
         var response = await httpClient.PostAsJsonAsync(endpoint, new EmbedRequest(inputs));
         response.EnsureSuccessStatusCode();
 
@@ -49,14 +49,6 @@ internal sealed class SemanticEmbeddingClient : ISemanticEmbeddingClient
         }
 
         throw new InvalidOperationException("The embedding endpoint returned an unexpected response shape.");
-    }
-
-    internal static string NormalizeEndpoint(string endpoint)
-    {
-        var normalized = endpoint.TrimEnd('/');
-        return normalized.EndsWith("/embed", StringComparison.OrdinalIgnoreCase)
-            ? normalized
-            : normalized + "/embed";
     }
 
     private static bool TryReadEmbeddings(JsonElement root, int expectedCount, out IReadOnlyList<float[]> embeddings)

--- a/src/SemanticStub.Api/Services/Semantic/SemanticEmbeddingClient.cs
+++ b/src/SemanticStub.Api/Services/Semantic/SemanticEmbeddingClient.cs
@@ -8,7 +8,7 @@ namespace SemanticStub.Api.Services;
 /// <summary>
 /// Calls the configured embedding endpoint and validates the returned embedding payloads.
 /// </summary>
-internal sealed class SemanticEmbeddingClient
+internal sealed class SemanticEmbeddingClient : ISemanticEmbeddingClient
 {
     private const string HttpClientName = "SemanticEmbedding";
     private readonly IHttpClientFactory httpClientFactory;

--- a/src/SemanticStub.Api/Services/Semantic/SemanticEmbeddingEndpoint.cs
+++ b/src/SemanticStub.Api/Services/Semantic/SemanticEmbeddingEndpoint.cs
@@ -1,0 +1,12 @@
+namespace SemanticStub.Api.Services;
+
+internal static class SemanticEmbeddingEndpoint
+{
+    internal static string Normalize(string endpoint)
+    {
+        var normalized = endpoint.TrimEnd('/');
+        return normalized.EndsWith("/embed", StringComparison.OrdinalIgnoreCase)
+            ? normalized
+            : normalized + "/embed";
+    }
+}

--- a/src/SemanticStub.Api/Services/Semantic/SemanticMatcherService.cs
+++ b/src/SemanticStub.Api/Services/Semantic/SemanticMatcherService.cs
@@ -62,7 +62,7 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
 
         try
         {
-            var endpoint = NormalizeEndpoint(semanticSettings.Endpoint!);
+            var endpoint = SemanticEmbeddingEndpoint.Normalize(semanticSettings.Endpoint!);
 
             logger.LogInformation(
                 "Semantic matching started for '{Path}' {Method}. Endpoint={Endpoint}, Threshold={Threshold}, TopScoreMargin={TopScoreMargin}, Candidates={CandidateCount}.",
@@ -234,11 +234,4 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
         };
     }
 
-    private static string NormalizeEndpoint(string endpoint)
-    {
-        var normalized = endpoint.TrimEnd('/');
-        return normalized.EndsWith("/embed", StringComparison.OrdinalIgnoreCase)
-            ? normalized
-            : normalized + "/embed";
-    }
 }

--- a/src/SemanticStub.Api/Services/Semantic/SemanticMatcherService.cs
+++ b/src/SemanticStub.Api/Services/Semantic/SemanticMatcherService.cs
@@ -11,12 +11,12 @@ namespace SemanticStub.Api.Services;
 /// </summary>
 public sealed class SemanticMatcherService : ISemanticMatcherService
 {
-    private readonly SemanticEmbeddingClient embeddingClient;
+    private readonly ISemanticEmbeddingClient embeddingClient;
     private readonly StubSettings settings;
     private readonly ILogger<SemanticMatcherService> logger;
 
     internal SemanticMatcherService(
-        SemanticEmbeddingClient embeddingClient,
+        ISemanticEmbeddingClient embeddingClient,
         IOptions<StubSettings> settings,
         ILogger<SemanticMatcherService> logger)
     {
@@ -62,7 +62,7 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
 
         try
         {
-            var endpoint = SemanticEmbeddingClient.NormalizeEndpoint(semanticSettings.Endpoint!);
+            var endpoint = NormalizeEndpoint(semanticSettings.Endpoint!);
 
             logger.LogInformation(
                 "Semantic matching started for '{Path}' {Method}. Endpoint={Endpoint}, Threshold={Threshold}, TopScoreMargin={TopScoreMargin}, Candidates={CandidateCount}.",
@@ -232,5 +232,13 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
             Threshold = semanticSettings.Threshold,
             RequiredMargin = semanticSettings.TopScoreMargin,
         };
+    }
+
+    private static string NormalizeEndpoint(string endpoint)
+    {
+        var normalized = endpoint.TrimEnd('/');
+        return normalized.EndsWith("/embed", StringComparison.OrdinalIgnoreCase)
+            ? normalized
+            : normalized + "/embed";
     }
 }

--- a/tests/SemanticStub.Api.Tests/Integration/StubServiceCollectionExtensionsTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/StubServiceCollectionExtensionsTests.cs
@@ -43,6 +43,7 @@ public sealed class StubServiceCollectionExtensionsTests
         AssertServiceLifetime<ScenarioService>(services, ServiceLifetime.Singleton);
         AssertServiceLifetime<StubDefinitionState>(services, ServiceLifetime.Singleton);
         AssertServiceLifetime<StubInspectionRuntimeStore>(services, ServiceLifetime.Singleton);
+        AssertServiceLifetime<ISemanticEmbeddingClient>(services, ServiceLifetime.Singleton);
 
         using var serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions
         {

--- a/tests/SemanticStub.Api.Tests/Unit/SemanticMatcherServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/SemanticMatcherServiceTests.cs
@@ -490,9 +490,9 @@ public sealed class SemanticMatcherServiceTests
         services.AddSingleton(Options.Create(settings));
         services.AddLogging();
         services.AddSingleton<IHttpClientFactory>(_ => new TestHttpClientFactory(new HttpClient(new DelegatingTestHandler(handler))));
-        services.AddSingleton<SemanticEmbeddingClient>();
+        services.AddSingleton<ISemanticEmbeddingClient, SemanticEmbeddingClient>();
         services.AddSingleton<ISemanticMatcherService>(serviceProvider => new SemanticMatcherService(
-            serviceProvider.GetRequiredService<SemanticEmbeddingClient>(),
+            serviceProvider.GetRequiredService<ISemanticEmbeddingClient>(),
             serviceProvider.GetRequiredService<IOptions<StubSettings>>(),
             serviceProvider.GetRequiredService<ILogger<SemanticMatcherService>>()));
 


### PR DESCRIPTION
## Summary
- Add ISemanticEmbeddingClient for the external embedding process boundary
- Make SemanticMatcherService depend on the embedding interface instead of the HTTP-backed implementation
- Register SemanticEmbeddingClient as the interface implementation and cover the DI registration

## Files Changed
- src/SemanticStub.Api/Services/Semantic/ISemanticEmbeddingClient.cs
- src/SemanticStub.Api/Services/Semantic/SemanticEmbeddingClient.cs
- src/SemanticStub.Api/Services/Semantic/SemanticMatcherService.cs
- src/SemanticStub.Api/Extensions/StubServiceCollectionExtensions.cs
- tests/SemanticStub.Api.Tests/Unit/SemanticMatcherServiceTests.cs
- tests/SemanticStub.Api.Tests/Integration/StubServiceCollectionExtensionsTests.cs

## Tests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter "FullyQualifiedName~SemanticMatcherServiceTests|FullyQualifiedName~StubServiceCollectionExtensionsTests"
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj

## Notes
- Closes #192
- Untracked CLAUDE.md was left untouched.