### PR TITLE
refactor: extract stub request body reader

### DIFF
--- a/src/SemanticStub.Api/Controllers/StubController.cs
+++ b/src/SemanticStub.Api/Controllers/StubController.cs
@@ -13,7 +13,6 @@ namespace SemanticStub.Api.Controllers;
 [Route("{*path}")]
 public sealed class StubController : ControllerBase
 {
-    private const string FormUrlEncodedMediaType = "application/x-www-form-urlencoded";
     private readonly IStubService stubService;
     private readonly IStubInspectionService inspectionService;
 
@@ -99,8 +98,7 @@ public sealed class StubController : ControllerBase
     {
         var query = Request.Query.ToDictionary(entry => entry.Key, entry => entry.Value, StringComparer.Ordinal);
         var headers = Request.Headers.ToDictionary(entry => entry.Key, entry => entry.Value.ToString(), StringComparer.OrdinalIgnoreCase);
-        Request.EnableBuffering();
-        var requestBody = await ReadRequestBodyAsync();
+        var requestBody = await StubRequestBodyReader.ReadAsync(Request);
         return await stubService.DispatchAsync(method, requestPath, query, headers, requestBody);
     }
 
@@ -189,68 +187,4 @@ public sealed class StubController : ControllerBase
             elapsed);
     }
 
-    private async Task<string?> ReadRequestBodyAsync()
-    {
-        try
-        {
-            if (IsFormUrlEncoded(Request.ContentType))
-            {
-                var form = await Request.ReadFormAsync();
-                return SerializeFormBody(form);
-            }
-
-            using var reader = new StreamReader(Request.Body, leaveOpen: true);
-            if (Request.Body.CanSeek)
-            {
-                Request.Body.Position = 0;
-            }
-
-            var body = await reader.ReadToEndAsync();
-
-            if (Request.Body.CanSeek)
-            {
-                Request.Body.Position = 0;
-            }
-
-            return string.IsNullOrWhiteSpace(body) ? null : body;
-        }
-        catch (IOException)
-        {
-            return null;
-        }
-        catch (OperationCanceledException) when (Request.HttpContext.RequestAborted.IsCancellationRequested)
-        {
-            return null;
-        }
-    }
-
-    private static bool IsFormUrlEncoded(string? contentType)
-    {
-        if (string.IsNullOrWhiteSpace(contentType))
-        {
-            return false;
-        }
-
-        var mediaType = contentType.Split(';', count: 2)[0].Trim();
-        return string.Equals(mediaType, FormUrlEncodedMediaType, StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static string? SerializeFormBody(IFormCollection form)
-    {
-        if (form.Count == 0)
-        {
-            return null;
-        }
-
-        var pairs = new List<string>();
-        foreach (var field in form)
-        {
-            foreach (var value in field.Value)
-            {
-                pairs.Add($"{Uri.EscapeDataString(field.Key)}={Uri.EscapeDataString(value ?? string.Empty)}");
-            }
-        }
-
-        return string.Join("&", pairs);
-    }
 }

--- a/src/SemanticStub.Api/Controllers/StubController.cs
+++ b/src/SemanticStub.Api/Controllers/StubController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using SemanticStub.Api.Inspection;
 using SemanticStub.Api.Models;
 using SemanticStub.Api.Services;
@@ -15,11 +16,13 @@ public sealed class StubController : ControllerBase
 {
     private readonly IStubService stubService;
     private readonly IStubInspectionService inspectionService;
+    private readonly ILogger<StubController> logger;
 
-    public StubController(IStubService stubService, IStubInspectionService inspectionService)
+    public StubController(IStubService stubService, IStubInspectionService inspectionService, ILogger<StubController> logger)
     {
         this.stubService = stubService;
         this.inspectionService = inspectionService;
+        this.logger = logger;
     }
 
     /// <summary>
@@ -98,7 +101,7 @@ public sealed class StubController : ControllerBase
     {
         var query = Request.Query.ToDictionary(entry => entry.Key, entry => entry.Value, StringComparer.Ordinal);
         var headers = Request.Headers.ToDictionary(entry => entry.Key, entry => entry.Value.ToString(), StringComparer.OrdinalIgnoreCase);
-        var requestBody = await StubRequestBodyReader.ReadAsync(Request);
+        var requestBody = await StubRequestBodyReader.ReadAsync(Request, logger);
         return await stubService.DispatchAsync(method, requestPath, query, headers, requestBody);
     }
 

--- a/src/SemanticStub.Api/Controllers/StubRequestBodyReader.cs
+++ b/src/SemanticStub.Api/Controllers/StubRequestBodyReader.cs
@@ -19,6 +19,7 @@ internal static class StubRequestBodyReader
                 return SerializeFormBody(form);
             }
 
+            // Keep the request body open so it can be rewound for downstream readers after matching.
             using var reader = new StreamReader(request.Body, leaveOpen: true);
             if (request.Body.CanSeek)
             {

--- a/src/SemanticStub.Api/Controllers/StubRequestBodyReader.cs
+++ b/src/SemanticStub.Api/Controllers/StubRequestBodyReader.cs
@@ -1,0 +1,75 @@
+using Microsoft.AspNetCore.Http;
+
+namespace SemanticStub.Api.Controllers;
+
+internal static class StubRequestBodyReader
+{
+    private const string FormUrlEncodedMediaType = "application/x-www-form-urlencoded";
+
+    internal static async Task<string?> ReadAsync(HttpRequest request)
+    {
+        try
+        {
+            request.EnableBuffering();
+
+            if (IsFormUrlEncoded(request.ContentType))
+            {
+                var form = await request.ReadFormAsync();
+                return SerializeFormBody(form);
+            }
+
+            using var reader = new StreamReader(request.Body, leaveOpen: true);
+            if (request.Body.CanSeek)
+            {
+                request.Body.Position = 0;
+            }
+
+            var body = await reader.ReadToEndAsync();
+
+            if (request.Body.CanSeek)
+            {
+                request.Body.Position = 0;
+            }
+
+            return string.IsNullOrWhiteSpace(body) ? null : body;
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (OperationCanceledException) when (request.HttpContext.RequestAborted.IsCancellationRequested)
+        {
+            return null;
+        }
+    }
+
+    private static bool IsFormUrlEncoded(string? contentType)
+    {
+        if (string.IsNullOrWhiteSpace(contentType))
+        {
+            return false;
+        }
+
+        var mediaType = contentType.Split(';', count: 2)[0].Trim();
+        return string.Equals(mediaType, FormUrlEncodedMediaType, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string? SerializeFormBody(IFormCollection form)
+    {
+        if (form.Count == 0)
+        {
+            return null;
+        }
+
+        var pairs = new List<string>();
+        foreach (var field in form)
+        {
+            foreach (var value in field.Value)
+            {
+                pairs.Add($"{Uri.EscapeDataString(field.Key)}={Uri.EscapeDataString(value ?? string.Empty)}");
+            }
+        }
+
+        return string.Join("&", pairs);
+    }
+}

--- a/src/SemanticStub.Api/Controllers/StubRequestBodyReader.cs
+++ b/src/SemanticStub.Api/Controllers/StubRequestBodyReader.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 
 namespace SemanticStub.Api.Controllers;
 
@@ -6,12 +7,12 @@ internal static class StubRequestBodyReader
 {
     private const string FormUrlEncodedMediaType = "application/x-www-form-urlencoded";
 
-    internal static async Task<string?> ReadAsync(HttpRequest request)
+    internal static async Task<string?> ReadAsync(HttpRequest request, ILogger logger)
     {
+        request.EnableBuffering();
+
         try
         {
-            request.EnableBuffering();
-
             if (IsFormUrlEncoded(request.ContentType))
             {
                 var form = await request.ReadFormAsync();
@@ -21,6 +22,7 @@ internal static class StubRequestBodyReader
             using var reader = new StreamReader(request.Body, leaveOpen: true);
             if (request.Body.CanSeek)
             {
+                // EnableBuffering may leave the body at its current offset, so read matching must start from the beginning.
                 request.Body.Position = 0;
             }
 
@@ -28,13 +30,15 @@ internal static class StubRequestBodyReader
 
             if (request.Body.CanSeek)
             {
+                // Leave the buffered body reusable for downstream middleware and diagnostics.
                 request.Body.Position = 0;
             }
 
             return string.IsNullOrWhiteSpace(body) ? null : body;
         }
-        catch (IOException)
+        catch (IOException ex)
         {
+            logger.LogWarning(ex, "Failed to read the request body; continuing with a null body for stub matching.");
             return null;
         }
         catch (OperationCanceledException) when (request.HttpContext.RequestAborted.IsCancellationRequested)

--- a/tests/SemanticStub.Api.Tests/Unit/StubControllerTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubControllerTests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Primitives;
 using SemanticStub.Api.Inspection;
 using SemanticStub.Api.Controllers;
@@ -346,7 +347,7 @@ public sealed class StubControllerTests
         controllerInspectionService.LastRecentRequestMethod = null;
         controllerInspectionService.LastRecentRequestPath = null;
 
-        return new StubController(stubService, inspectionService ?? controllerInspectionService)
+        return new StubController(stubService, inspectionService ?? controllerInspectionService, NullLogger<StubController>.Instance)
         {
             ControllerContext = new ControllerContext
             {

--- a/tests/SemanticStub.Api.Tests/Unit/StubRequestBodyReaderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubRequestBodyReaderTests.cs
@@ -1,5 +1,7 @@
 using System.Text;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using SemanticStub.Api.Controllers;
 using Xunit;
 
@@ -12,7 +14,7 @@ public sealed class StubRequestBodyReaderTests
     {
         var request = CreateRequest("name=Ada%20Lovelace&tag=alpha&tag=beta&empty=", "application/x-www-form-urlencoded; charset=utf-8");
 
-        var body = await StubRequestBodyReader.ReadAsync(request);
+        var body = await StubRequestBodyReader.ReadAsync(request, NullLogger.Instance);
 
         Assert.Equal("name=Ada%20Lovelace&tag=alpha&tag=beta&empty=", body);
     }
@@ -22,7 +24,7 @@ public sealed class StubRequestBodyReaderTests
     {
         var request = CreateRequest(string.Empty, "application/x-www-form-urlencoded");
 
-        var body = await StubRequestBodyReader.ReadAsync(request);
+        var body = await StubRequestBodyReader.ReadAsync(request, NullLogger.Instance);
 
         Assert.Null(body);
     }
@@ -32,10 +34,14 @@ public sealed class StubRequestBodyReaderTests
     {
         var context = new DefaultHttpContext();
         context.Request.Body = new ThrowingReadStream();
+        var logger = new ListLogger();
 
-        var body = await StubRequestBodyReader.ReadAsync(context.Request);
+        var body = await StubRequestBodyReader.ReadAsync(context.Request, logger);
 
         Assert.Null(body);
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.LogLevel);
+        Assert.IsType<IOException>(entry.Exception);
     }
 
     [Fact]
@@ -43,7 +49,7 @@ public sealed class StubRequestBodyReaderTests
     {
         var request = CreateRequest("{\"username\":\"demo\"}", "application/json");
 
-        var body = await StubRequestBodyReader.ReadAsync(request);
+        var body = await StubRequestBodyReader.ReadAsync(request, NullLogger.Instance);
 
         Assert.Equal("{\"username\":\"demo\"}", body);
         Assert.Equal(0, request.Body.Position);
@@ -85,4 +91,27 @@ public sealed class StubRequestBodyReaderTests
 
         public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
+
+    private sealed class ListLogger : ILogger
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add(new LogEntry(logLevel, exception));
+        }
+    }
+
+    private sealed record LogEntry(LogLevel LogLevel, Exception? Exception);
+
 }

--- a/tests/SemanticStub.Api.Tests/Unit/StubRequestBodyReaderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/StubRequestBodyReaderTests.cs
@@ -1,0 +1,88 @@
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using SemanticStub.Api.Controllers;
+using Xunit;
+
+namespace SemanticStub.Api.Tests.Unit;
+
+public sealed class StubRequestBodyReaderTests
+{
+    [Fact]
+    public async Task ReadAsync_WhenFormUrlEncoded_SerializesFormValues()
+    {
+        var request = CreateRequest("name=Ada%20Lovelace&tag=alpha&tag=beta&empty=", "application/x-www-form-urlencoded; charset=utf-8");
+
+        var body = await StubRequestBodyReader.ReadAsync(request);
+
+        Assert.Equal("name=Ada%20Lovelace&tag=alpha&tag=beta&empty=", body);
+    }
+
+    [Fact]
+    public async Task ReadAsync_WhenFormIsEmpty_ReturnsNull()
+    {
+        var request = CreateRequest(string.Empty, "application/x-www-form-urlencoded");
+
+        var body = await StubRequestBodyReader.ReadAsync(request);
+
+        Assert.Null(body);
+    }
+
+    [Fact]
+    public async Task ReadAsync_WhenBodyIsUnreadable_ReturnsNull()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Body = new ThrowingReadStream();
+
+        var body = await StubRequestBodyReader.ReadAsync(context.Request);
+
+        Assert.Null(body);
+    }
+
+    [Fact]
+    public async Task ReadAsync_WhenBodyIsSeekable_ResetsStreamPosition()
+    {
+        var request = CreateRequest("{\"username\":\"demo\"}", "application/json");
+
+        var body = await StubRequestBodyReader.ReadAsync(request);
+
+        Assert.Equal("{\"username\":\"demo\"}", body);
+        Assert.Equal(0, request.Body.Position);
+    }
+
+    private static HttpRequest CreateRequest(string body, string contentType)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.ContentType = contentType;
+        context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(body));
+        context.Request.ContentLength = context.Request.Body.Length;
+        return context.Request;
+    }
+
+    private sealed class ThrowingReadStream : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new IOException("Simulated disconnect.");
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+            ValueTask.FromException<int>(new IOException("Simulated disconnect."));
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
## Summary
- Extract request body reading from StubController into an internal API-layer helper
- Preserve existing body parsing behavior for raw bodies, form-url-encoded bodies, and unreadable streams
- Add focused unit tests for form serialization, empty forms, unreadable bodies, and stream reset behavior

## Files Changed
- src/SemanticStub.Api/Controllers/StubController.cs
- src/SemanticStub.Api/Controllers/StubRequestBodyReader.cs
- tests/SemanticStub.Api.Tests/Unit/StubRequestBodyReaderTests.cs

## Tests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj

## Notes
- Closes #200
- Local untracked CLAUDE.md was left untouched