### PR TITLE
refactor: rename yaml private fields

### DIFF
--- a/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionLoader.cs
+++ b/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionLoader.cs
@@ -13,11 +13,11 @@ public sealed class StubDefinitionLoader : IStubDefinitionLoader
     private const string DefaultStubFileName = "basic-routing.yaml";
     private static readonly string[] AdditionalStubFilePatterns = ["*.stub.yaml", "*.stub.yml"];
     private const string DefaultDefinitionsDirectoryName = "samples";
-    private readonly IWebHostEnvironment environment;
-    private readonly StubSettings settings;
-    private readonly IDeserializer deserializer;
-    private readonly StubDefinitionValidator validator;
-    private readonly StubDefinitionNormalizer normalizer;
+    private readonly IWebHostEnvironment _environment;
+    private readonly StubSettings _settings;
+    private readonly IDeserializer _deserializer;
+    private readonly StubDefinitionValidator _validator;
+    private readonly StubDefinitionNormalizer _normalizer;
 
     /// <summary>
     /// Creates a loader that discovers definitions relative to <see cref="IWebHostEnvironment.ContentRootPath"/> and uses the default <c>samples</c> search behavior when no explicit settings are supplied.
@@ -35,14 +35,14 @@ public sealed class StubDefinitionLoader : IStubDefinitionLoader
     /// <param name="settings">Supplies the optional definitions directory override. When unset, the nearest ancestor directory containing <c>samples</c> is used.</param>
     public StubDefinitionLoader(IWebHostEnvironment environment, IOptions<StubSettings> settings)
     {
-        this.environment = environment;
-        this.settings = settings.Value;
-        deserializer = new DeserializerBuilder()
+        _environment = environment;
+        _settings = settings.Value;
+        _deserializer = new DeserializerBuilder()
             .WithNamingConvention(CamelCaseNamingConvention.Instance)
             .IgnoreUnmatchedProperties()
             .Build();
-        validator = new StubDefinitionValidator();
-        normalizer = new StubDefinitionNormalizer();
+        _validator = new StubDefinitionValidator();
+        _normalizer = new StubDefinitionNormalizer();
     }
 
     /// <summary>
@@ -77,7 +77,7 @@ public sealed class StubDefinitionLoader : IStubDefinitionLoader
     private StubDocument LoadDefinition(string path)
     {
         var yaml = File.ReadAllText(path);
-        var document = deserializer.Deserialize<StubDocument>(yaml);
+        var document = _deserializer.Deserialize<StubDocument>(yaml);
         var definitionDirectory = Path.GetDirectoryName(path)
             ?? throw new InvalidOperationException($"Could not determine definition directory for '{path}'.");
 
@@ -86,9 +86,9 @@ public sealed class StubDefinitionLoader : IStubDefinitionLoader
             throw new InvalidOperationException("Failed to deserialize stub definition.");
         }
 
-        validator.ValidateDocument(document, definitionDirectory);
+        _validator.ValidateDocument(document, definitionDirectory);
 
-        return normalizer.NormalizeDocument(document, definitionDirectory);
+        return _normalizer.NormalizeDocument(document, definitionDirectory);
     }
 
     /// <summary>
@@ -182,9 +182,9 @@ public sealed class StubDefinitionLoader : IStubDefinitionLoader
 
     private string ResolveDefinitionsDirectory()
     {
-        if (!string.IsNullOrWhiteSpace(settings.DefinitionsPath))
+        if (!string.IsNullOrWhiteSpace(_settings.DefinitionsPath))
         {
-            var configuredPath = settings.DefinitionsPath!;
+            var configuredPath = _settings.DefinitionsPath!;
 
             if (Path.IsPathRooted(configuredPath))
             {
@@ -196,7 +196,7 @@ public sealed class StubDefinitionLoader : IStubDefinitionLoader
                 throw new DirectoryNotFoundException($"Could not locate configured definitions path '{configuredPath}'.");
             }
 
-            var configuredCurrent = new DirectoryInfo(environment.ContentRootPath);
+            var configuredCurrent = new DirectoryInfo(_environment.ContentRootPath);
 
             while (configuredCurrent is not null)
             {
@@ -213,7 +213,7 @@ public sealed class StubDefinitionLoader : IStubDefinitionLoader
             throw new DirectoryNotFoundException($"Could not locate configured definitions path '{configuredPath}'.");
         }
 
-        var current = new DirectoryInfo(environment.ContentRootPath);
+        var current = new DirectoryInfo(_environment.ContentRootPath);
 
         while (current is not null)
         {
@@ -232,9 +232,9 @@ public sealed class StubDefinitionLoader : IStubDefinitionLoader
 
     private string GetDefinitionsPathLabel()
     {
-        return string.IsNullOrWhiteSpace(settings.DefinitionsPath)
+        return string.IsNullOrWhiteSpace(_settings.DefinitionsPath)
             ? DefaultDefinitionsDirectoryName
-            : settings.DefinitionsPath!;
+            : _settings.DefinitionsPath!;
     }
 
     private static StubDocument MergeDefinitions(IReadOnlyCollection<(string Path, string Label, StubDocument Document)> sources)

--- a/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionState.cs
+++ b/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionState.cs
@@ -8,43 +8,43 @@ namespace SemanticStub.Api.Infrastructure.Yaml;
 /// </summary>
 internal sealed class StubDefinitionState
 {
-    private readonly IStubDefinitionLoader loader;
-    private readonly ScenarioService scenarioService;
-    private readonly ILogger<StubDefinitionState> logger;
-    private readonly object syncRoot = new();
-    private StubDocument currentDocument;
+    private readonly IStubDefinitionLoader _loader;
+    private readonly ScenarioService _scenarioService;
+    private readonly ILogger<StubDefinitionState> _logger;
+    private readonly object _syncRoot = new();
+    private StubDocument _currentDocument;
 
     public StubDefinitionState(IStubDefinitionLoader loader, ScenarioService scenarioService, ILogger<StubDefinitionState> logger)
     {
-        this.loader = loader;
-        this.scenarioService = scenarioService;
-        this.logger = logger;
-        currentDocument = loader.LoadDefaultDefinition();
+        _loader = loader;
+        _scenarioService = scenarioService;
+        _logger = logger;
+        _currentDocument = loader.LoadDefaultDefinition();
     }
 
     public StubDocument GetCurrentDocument()
     {
-        return Volatile.Read(ref currentDocument);
+        return Volatile.Read(ref _currentDocument);
     }
 
     public string LoadResponseFileContent(string fileName)
     {
-        return loader.LoadResponseFileContent(fileName);
+        return _loader.LoadResponseFileContent(fileName);
     }
 
     public bool TryReload()
     {
-        lock (syncRoot)
+        lock (_syncRoot)
         {
             try
             {
-                ApplyReloadedDocument(loader.LoadDefaultDefinition());
-                logger.LogInformation("Reloaded stub definitions from disk.");
+                ApplyReloadedDocument(_loader.LoadDefaultDefinition());
+                _logger.LogInformation("Reloaded stub definitions from disk.");
                 return true;
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Failed to reload stub definitions. Continuing with the last successfully loaded definitions.");
+                _logger.LogError(ex, "Failed to reload stub definitions. Continuing with the last successfully loaded definitions.");
                 return false;
             }
         }
@@ -52,9 +52,9 @@ internal sealed class StubDefinitionState
 
     private void ApplyReloadedDocument(StubDocument reloadedDocument)
     {
-        scenarioService.ExecuteLocked(() =>
+        _scenarioService.ExecuteLocked(() =>
         {
-            Volatile.Write(ref currentDocument, reloadedDocument);
+            Volatile.Write(ref _currentDocument, reloadedDocument);
             ResetScenarioStatesWithinLock(reloadedDocument);
             return 0;
         });
@@ -62,7 +62,7 @@ internal sealed class StubDefinitionState
 
     private void ResetScenarioStatesWithinLock(StubDocument document)
     {
-        scenarioService.ResetScenariosWithinLock(
+        _scenarioService.ResetScenariosWithinLock(
             StubScenarioNameCollector.Collect(document),
             DateTimeOffset.UtcNow);
     }

--- a/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionWatcher.cs
+++ b/src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionWatcher.cs
@@ -3,53 +3,53 @@ namespace SemanticStub.Api.Infrastructure.Yaml;
 internal sealed class StubDefinitionWatcher : IHostedService, IDisposable
 {
     private static readonly TimeSpan ReloadDebounceDelay = TimeSpan.FromMilliseconds(250);
-    private readonly IStubDefinitionLoader loader;
-    private readonly StubDefinitionState state;
-    private readonly ILogger<StubDefinitionWatcher> logger;
-    private readonly object syncRoot = new();
-    private FileSystemWatcher? watcher;
-    private Timer? reloadTimer;
-    private string? pendingPath;
+    private readonly IStubDefinitionLoader _loader;
+    private readonly StubDefinitionState _state;
+    private readonly ILogger<StubDefinitionWatcher> _logger;
+    private readonly object _syncRoot = new();
+    private FileSystemWatcher? _watcher;
+    private Timer? _reloadTimer;
+    private string? _pendingPath;
 
     public StubDefinitionWatcher(
         IStubDefinitionLoader loader,
         StubDefinitionState state,
         ILogger<StubDefinitionWatcher> logger)
     {
-        this.loader = loader;
-        this.state = state;
-        this.logger = logger;
+        _loader = loader;
+        _state = state;
+        _logger = logger;
     }
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        var definitionsPath = loader.GetDefinitionsDirectoryPath();
-        watcher = new FileSystemWatcher(definitionsPath)
+        var definitionsPath = _loader.GetDefinitionsDirectoryPath();
+        _watcher = new FileSystemWatcher(definitionsPath)
         {
             IncludeSubdirectories = true,
             NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.CreationTime | NotifyFilters.DirectoryName
         };
 
-        watcher.Changed += OnFileChanged;
-        watcher.Created += OnFileChanged;
-        watcher.Deleted += OnFileChanged;
-        watcher.Renamed += OnFileRenamed;
-        watcher.EnableRaisingEvents = true;
+        _watcher.Changed += OnFileChanged;
+        _watcher.Created += OnFileChanged;
+        _watcher.Deleted += OnFileChanged;
+        _watcher.Renamed += OnFileRenamed;
+        _watcher.EnableRaisingEvents = true;
 
-        logger.LogInformation("Watching stub definitions under '{DefinitionsPath}'.", definitionsPath);
+        _logger.LogInformation("Watching stub definitions under '{DefinitionsPath}'.", definitionsPath);
         return Task.CompletedTask;
     }
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
-        if (watcher is not null)
+        if (_watcher is not null)
         {
-            watcher.EnableRaisingEvents = false;
+            _watcher.EnableRaisingEvents = false;
         }
 
-        lock (syncRoot)
+        lock (_syncRoot)
         {
-            reloadTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+            _reloadTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
         }
 
         return Task.CompletedTask;
@@ -57,18 +57,18 @@ internal sealed class StubDefinitionWatcher : IHostedService, IDisposable
 
     public void Dispose()
     {
-        if (watcher is not null)
+        if (_watcher is not null)
         {
-            watcher.Changed -= OnFileChanged;
-            watcher.Created -= OnFileChanged;
-            watcher.Deleted -= OnFileChanged;
-            watcher.Renamed -= OnFileRenamed;
-            watcher.Dispose();
+            _watcher.Changed -= OnFileChanged;
+            _watcher.Created -= OnFileChanged;
+            _watcher.Deleted -= OnFileChanged;
+            _watcher.Renamed -= OnFileRenamed;
+            _watcher.Dispose();
         }
 
-        lock (syncRoot)
+        lock (_syncRoot)
         {
-            reloadTimer?.Dispose();
+            _reloadTimer?.Dispose();
         }
     }
 
@@ -95,11 +95,11 @@ internal sealed class StubDefinitionWatcher : IHostedService, IDisposable
 
     private void ScheduleReload(string path)
     {
-        lock (syncRoot)
+        lock (_syncRoot)
         {
-            pendingPath = path;
-            reloadTimer ??= new Timer(_ => ReloadDefinitions(), state: null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
-            reloadTimer.Change(ReloadDebounceDelay, Timeout.InfiniteTimeSpan);
+            _pendingPath = path;
+            _reloadTimer ??= new Timer(_ => ReloadDefinitions(), state: null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+            _reloadTimer.Change(ReloadDebounceDelay, Timeout.InfiniteTimeSpan);
         }
     }
 
@@ -107,14 +107,14 @@ internal sealed class StubDefinitionWatcher : IHostedService, IDisposable
     {
         string? changedPath;
 
-        lock (syncRoot)
+        lock (_syncRoot)
         {
-            changedPath = pendingPath;
-            pendingPath = null;
+            changedPath = _pendingPath;
+            _pendingPath = null;
         }
 
-        logger.LogInformation("Detected stub definition change at '{ChangedPath}'. Reloading definitions.", changedPath);
-        state.TryReload();
+        _logger.LogInformation("Detected stub definition change at '{ChangedPath}'. Reloading definitions.", changedPath);
+        _state.TryReload();
     }
 
     private static bool IsRelevantDefinitionPath(string path)


### PR DESCRIPTION
## Summary
- Rename YAML infrastructure private instance fields to `_camelCase`
- Keep YAML aliases, file discovery, validation, and reload behavior unchanged

## Files Changed
- `src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionLoader.cs`
- `src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionState.cs`
- `src/SemanticStub.Api/Infrastructure/Yaml/StubDefinitionWatcher.cs`

## Tests
- `dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter "FullyQualifiedName~StubDefinitionLoaderTests|FullyQualifiedName~StubDefinitionValidatorTests|FullyQualifiedName~StubDefinitionNormalizerTests"`
- `dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --no-restore --filter "FullyQualifiedName~AutomaticReloadTests|FullyQualifiedName~StartupValidationTests"`

## Notes
- Closes #212
- Part of #196 split rename work