### PR TITLE
refactor: rename service private fields

### DIFF
--- a/src/SemanticStub.Api/Services/Inspection/StubInspectionProjectionBuilder.cs
+++ b/src/SemanticStub.Api/Services/Inspection/StubInspectionProjectionBuilder.cs
@@ -6,11 +6,11 @@ namespace SemanticStub.Api.Services;
 
 internal sealed class StubInspectionProjectionBuilder
 {
-    private readonly ScenarioService scenarioService;
+    private readonly ScenarioService _scenarioService;
 
     public StubInspectionProjectionBuilder(ScenarioService scenarioService)
     {
-        this.scenarioService = scenarioService;
+        _scenarioService = scenarioService;
     }
 
     public MatchRequestInfo CreateInspectionRequest(
@@ -59,7 +59,7 @@ internal sealed class StubInspectionProjectionBuilder
 
         return scenarioNames.ToDictionary(
             scenarioName => scenarioName,
-            scenarioName => scenarioService.GetSnapshotWithinLock(scenarioName),
+            scenarioName => _scenarioService.GetSnapshotWithinLock(scenarioName),
             StringComparer.Ordinal);
     }
 

--- a/src/SemanticStub.Api/Services/Inspection/StubInspectionRuntimeStore.cs
+++ b/src/SemanticStub.Api/Services/Inspection/StubInspectionRuntimeStore.cs
@@ -8,24 +8,24 @@ namespace SemanticStub.Api.Services;
 internal sealed class StubInspectionRuntimeStore
 {
     private const int MaxRecentRequestCount = 100;
-    private readonly object lastMatchSyncRoot = new();
-    private readonly object metricsSyncRoot = new();
-    private readonly Dictionary<int, long> statusCodeCounts = [];
-    private readonly Dictionary<string, long> routeRequestCounts = new(StringComparer.Ordinal);
-    private readonly Queue<RecentRequestInfo> recentRequests = [];
-    private MatchExplanationInfo? lastMatchExplanation;
-    private long totalRequestCount;
-    private long matchedRequestCount;
-    private long unmatchedRequestCount;
-    private long fallbackResponseCount;
-    private long semanticMatchCount;
-    private double totalLatencyMilliseconds;
+    private readonly object _lastMatchSyncRoot = new();
+    private readonly object _metricsSyncRoot = new();
+    private readonly Dictionary<int, long> _statusCodeCounts = [];
+    private readonly Dictionary<string, long> _routeRequestCounts = new(StringComparer.Ordinal);
+    private readonly Queue<RecentRequestInfo> _recentRequests = [];
+    private MatchExplanationInfo? _lastMatchExplanation;
+    private long _totalRequestCount;
+    private long _matchedRequestCount;
+    private long _unmatchedRequestCount;
+    private long _fallbackResponseCount;
+    private long _semanticMatchCount;
+    private double _totalLatencyMilliseconds;
 
     public MatchExplanationInfo? GetLastMatchExplanation()
     {
-        lock (lastMatchSyncRoot)
+        lock (_lastMatchSyncRoot)
         {
-            return lastMatchExplanation;
+            return _lastMatchExplanation;
         }
     }
 
@@ -33,27 +33,27 @@ internal sealed class StubInspectionRuntimeStore
     {
         ArgumentNullException.ThrowIfNull(explanation);
 
-        lock (lastMatchSyncRoot)
+        lock (_lastMatchSyncRoot)
         {
-            lastMatchExplanation = explanation;
+            _lastMatchExplanation = explanation;
         }
     }
 
     public RuntimeMetricsSummaryInfo GetRuntimeMetrics()
     {
-        lock (metricsSyncRoot)
+        lock (_metricsSyncRoot)
         {
             return new RuntimeMetricsSummaryInfo
             {
-                TotalRequestCount = totalRequestCount,
-                MatchedRequestCount = matchedRequestCount,
-                UnmatchedRequestCount = unmatchedRequestCount,
-                FallbackResponseCount = fallbackResponseCount,
-                SemanticMatchCount = semanticMatchCount,
-                AverageLatencyMilliseconds = totalRequestCount == 0
+                TotalRequestCount = _totalRequestCount,
+                MatchedRequestCount = _matchedRequestCount,
+                UnmatchedRequestCount = _unmatchedRequestCount,
+                FallbackResponseCount = _fallbackResponseCount,
+                SemanticMatchCount = _semanticMatchCount,
+                AverageLatencyMilliseconds = _totalRequestCount == 0
                     ? 0
-                    : totalLatencyMilliseconds / totalRequestCount,
-                StatusCodes = statusCodeCounts
+                    : _totalLatencyMilliseconds / _totalRequestCount,
+                StatusCodes = _statusCodeCounts
                     .OrderByDescending(entry => entry.Value)
                     .ThenBy(entry => entry.Key)
                     .Select(entry => new RuntimeStatusCodeMetricInfo
@@ -62,7 +62,7 @@ internal sealed class StubInspectionRuntimeStore
                         RequestCount = entry.Value,
                     })
                     .ToList(),
-                TopRoutes = routeRequestCounts
+                TopRoutes = _routeRequestCounts
                     .OrderByDescending(entry => entry.Value)
                     .ThenBy(entry => entry.Key, StringComparer.Ordinal)
                     .Select(entry => new RouteUsageMetricInfo
@@ -79,58 +79,58 @@ internal sealed class StubInspectionRuntimeStore
     {
         ArgumentNullException.ThrowIfNull(explanation);
 
-        lock (metricsSyncRoot)
+        lock (_metricsSyncRoot)
         {
-            totalRequestCount++;
+            _totalRequestCount++;
 
             if (explanation.Result.Matched)
             {
-                matchedRequestCount++;
+                _matchedRequestCount++;
             }
             else
             {
-                unmatchedRequestCount++;
+                _unmatchedRequestCount++;
             }
 
             if (string.Equals(explanation.Result.MatchMode, "fallback", StringComparison.Ordinal))
             {
-                fallbackResponseCount++;
+                _fallbackResponseCount++;
             }
 
             if (string.Equals(explanation.Result.MatchMode, "semantic", StringComparison.Ordinal))
             {
-                semanticMatchCount++;
+                _semanticMatchCount++;
             }
 
-            totalLatencyMilliseconds += Math.Max(0, elapsed.TotalMilliseconds);
-            statusCodeCounts[statusCode] = statusCodeCounts.GetValueOrDefault(statusCode) + 1;
+            _totalLatencyMilliseconds += Math.Max(0, elapsed.TotalMilliseconds);
+            _statusCodeCounts[statusCode] = _statusCodeCounts.GetValueOrDefault(statusCode) + 1;
 
             if (!string.IsNullOrEmpty(explanation.Result.RouteId))
             {
-                routeRequestCounts[explanation.Result.RouteId] = routeRequestCounts.GetValueOrDefault(explanation.Result.RouteId) + 1;
+                _routeRequestCounts[explanation.Result.RouteId] = _routeRequestCounts.GetValueOrDefault(explanation.Result.RouteId) + 1;
             }
         }
     }
 
     public void ResetMetrics()
     {
-        lock (metricsSyncRoot)
+        lock (_metricsSyncRoot)
         {
-            statusCodeCounts.Clear();
-            routeRequestCounts.Clear();
-            recentRequests.Clear();
-            totalRequestCount = 0;
-            matchedRequestCount = 0;
-            unmatchedRequestCount = 0;
-            fallbackResponseCount = 0;
-            semanticMatchCount = 0;
-            totalLatencyMilliseconds = 0;
+            _statusCodeCounts.Clear();
+            _routeRequestCounts.Clear();
+            _recentRequests.Clear();
+            _totalRequestCount = 0;
+            _matchedRequestCount = 0;
+            _unmatchedRequestCount = 0;
+            _fallbackResponseCount = 0;
+            _semanticMatchCount = 0;
+            _totalLatencyMilliseconds = 0;
         }
     }
 
     public IReadOnlyList<RecentRequestInfo> GetRecentRequests(int limit)
     {
-        lock (metricsSyncRoot)
+        lock (_metricsSyncRoot)
         {
             var normalizedLimit = Math.Clamp(limit, 0, MaxRecentRequestCount);
 
@@ -139,7 +139,7 @@ internal sealed class StubInspectionRuntimeStore
                 return [];
             }
 
-            return recentRequests
+            return _recentRequests
                 .Reverse()
                 .Take(normalizedLimit)
                 .ToList();
@@ -152,14 +152,14 @@ internal sealed class StubInspectionRuntimeStore
         ArgumentException.ThrowIfNullOrEmpty(path);
         ArgumentNullException.ThrowIfNull(explanation);
 
-        lock (metricsSyncRoot)
+        lock (_metricsSyncRoot)
         {
-            if (recentRequests.Count >= MaxRecentRequestCount)
+            if (_recentRequests.Count >= MaxRecentRequestCount)
             {
-                recentRequests.Dequeue();
+                _recentRequests.Dequeue();
             }
 
-            recentRequests.Enqueue(new RecentRequestInfo
+            _recentRequests.Enqueue(new RecentRequestInfo
             {
                 Timestamp = timestamp,
                 Method = method,

--- a/src/SemanticStub.Api/Services/Inspection/StubInspectionScenarioCoordinator.cs
+++ b/src/SemanticStub.Api/Services/Inspection/StubInspectionScenarioCoordinator.cs
@@ -5,18 +5,18 @@ namespace SemanticStub.Api.Services;
 
 internal sealed class StubInspectionScenarioCoordinator
 {
-    private readonly StubDefinitionState state;
-    private readonly ScenarioService scenarioService;
+    private readonly StubDefinitionState _state;
+    private readonly ScenarioService _scenarioService;
 
     public StubInspectionScenarioCoordinator(StubDefinitionState state, ScenarioService scenarioService)
     {
-        this.state = state;
-        this.scenarioService = scenarioService;
+        _state = state;
+        _scenarioService = scenarioService;
     }
 
     public IReadOnlyList<ScenarioStateInfo> GetScenarioStates()
     {
-        return scenarioService.ExecuteLocked(() =>
+        return _scenarioService.ExecuteLocked(() =>
         {
             var scenarioNames = GetCurrentScenarioNames();
 
@@ -28,16 +28,16 @@ internal sealed class StubInspectionScenarioCoordinator
 
     public void ResetScenarioStates()
     {
-        scenarioService.ExecuteLocked(() =>
+        _scenarioService.ExecuteLocked(() =>
         {
-            scenarioService.ResetScenariosWithinLock(GetCurrentScenarioNames(), DateTimeOffset.UtcNow);
+            _scenarioService.ResetScenariosWithinLock(GetCurrentScenarioNames(), DateTimeOffset.UtcNow);
             return 0;
         });
     }
 
     public bool ResetScenarioState(string scenarioName)
     {
-        return scenarioService.ExecuteLocked(() =>
+        return _scenarioService.ExecuteLocked(() =>
         {
             var scenarioNames = GetCurrentScenarioNames();
 
@@ -46,19 +46,19 @@ internal sealed class StubInspectionScenarioCoordinator
                 return false;
             }
 
-            scenarioService.ResetScenarioWithinLock(scenarioName, DateTimeOffset.UtcNow);
+            _scenarioService.ResetScenarioWithinLock(scenarioName, DateTimeOffset.UtcNow);
             return true;
         });
     }
 
     private IReadOnlyList<string> GetCurrentScenarioNames()
     {
-        return StubInspectionDocumentProjector.GetScenarioNames(state.GetCurrentDocument());
+        return StubInspectionDocumentProjector.GetScenarioNames(_state.GetCurrentDocument());
     }
 
     private ScenarioStateInfo CreateScenarioState(string scenarioName)
     {
-        var snapshot = scenarioService.GetSnapshotWithinLock(scenarioName);
+        var snapshot = _scenarioService.GetSnapshotWithinLock(scenarioName);
 
         return new ScenarioStateInfo
         {

--- a/src/SemanticStub.Api/Services/Inspection/StubInspectionService.cs
+++ b/src/SemanticStub.Api/Services/Inspection/StubInspectionService.cs
@@ -7,12 +7,12 @@ namespace SemanticStub.Api.Services;
 
 internal sealed class StubInspectionService : IStubInspectionService
 {
-    private readonly StubDefinitionState state;
-    private readonly IStubDefinitionLoader loader;
-    private readonly IOptions<StubSettings> settings;
-    private readonly IStubService stubService;
-    private readonly StubInspectionRuntimeStore runtimeStore;
-    private readonly StubInspectionScenarioCoordinator scenarioCoordinator;
+    private readonly StubDefinitionState _state;
+    private readonly IStubDefinitionLoader _loader;
+    private readonly IOptions<StubSettings> _settings;
+    private readonly IStubService _stubService;
+    private readonly StubInspectionRuntimeStore _runtimeStore;
+    private readonly StubInspectionScenarioCoordinator _scenarioCoordinator;
 
     internal StubInspectionService(
         StubDefinitionState state,
@@ -22,12 +22,12 @@ internal sealed class StubInspectionService : IStubInspectionService
         StubInspectionRuntimeStore runtimeStore,
         StubInspectionScenarioCoordinator scenarioCoordinator)
     {
-        this.state = state;
-        this.loader = loader;
-        this.settings = settings;
-        this.stubService = stubService;
-        this.runtimeStore = runtimeStore;
-        this.scenarioCoordinator = scenarioCoordinator;
+        _state = state;
+        _loader = loader;
+        _settings = settings;
+        _stubService = stubService;
+        _runtimeStore = runtimeStore;
+        _scenarioCoordinator = scenarioCoordinator;
     }
 
     /// <inheritdoc/>
@@ -40,9 +40,9 @@ internal sealed class StubInspectionService : IStubInspectionService
         {
             SnapshotTimestamp = DateTimeOffset.UtcNow,
             ConfigurationHash = StubInspectionDocumentProjector.ComputeDocumentHash(document),
-            DefinitionsDirectoryPath = loader.GetDefinitionsDirectoryPath(),
+            DefinitionsDirectoryPath = _loader.GetDefinitionsDirectoryPath(),
             RouteCount = routes.Count,
-            SemanticMatchingEnabled = settings.Value.SemanticMatching.Enabled,
+            SemanticMatchingEnabled = _settings.Value.SemanticMatching.Enabled,
         };
     }
 
@@ -63,78 +63,78 @@ internal sealed class StubInspectionService : IStubInspectionService
     /// <inheritdoc/>
     public IReadOnlyList<ScenarioStateInfo> GetScenarioStates()
     {
-        return scenarioCoordinator.GetScenarioStates();
+        return _scenarioCoordinator.GetScenarioStates();
     }
 
     /// <inheritdoc/>
     public RuntimeMetricsSummaryInfo GetRuntimeMetrics()
     {
-        return runtimeStore.GetRuntimeMetrics();
+        return _runtimeStore.GetRuntimeMetrics();
     }
 
     /// <inheritdoc/>
     public IReadOnlyList<RecentRequestInfo> GetRecentRequests(int limit)
     {
-        return runtimeStore.GetRecentRequests(limit);
+        return _runtimeStore.GetRecentRequests(limit);
     }
 
     /// <inheritdoc/>
     public async Task<MatchSimulationInfo> TestMatchAsync(MatchRequestInfo request)
     {
-        var explanation = await stubService.ExplainMatchAsync(request);
+        var explanation = await _stubService.ExplainMatchAsync(request);
         return explanation.Result;
     }
 
     /// <inheritdoc/>
     public Task<MatchExplanationInfo> ExplainMatchAsync(MatchRequestInfo request)
     {
-        return stubService.ExplainMatchAsync(request);
+        return _stubService.ExplainMatchAsync(request);
     }
 
     /// <inheritdoc/>
     public MatchExplanationInfo? GetLastMatchExplanation()
     {
-        return runtimeStore.GetLastMatchExplanation();
+        return _runtimeStore.GetLastMatchExplanation();
     }
 
     /// <inheritdoc/>
     public void RecordLastMatchExplanation(MatchExplanationInfo explanation)
     {
-        runtimeStore.RecordLastMatchExplanation(explanation);
+        _runtimeStore.RecordLastMatchExplanation(explanation);
     }
 
     /// <inheritdoc/>
     public void RecordRequestMetrics(MatchExplanationInfo explanation, int statusCode, TimeSpan elapsed)
     {
-        runtimeStore.RecordRequestMetrics(explanation, statusCode, elapsed);
+        _runtimeStore.RecordRequestMetrics(explanation, statusCode, elapsed);
     }
 
     /// <inheritdoc/>
     public void RecordRecentRequest(DateTimeOffset timestamp, string method, string path, MatchExplanationInfo explanation, int statusCode, TimeSpan elapsed)
     {
-        runtimeStore.RecordRecentRequest(timestamp, method, path, explanation, statusCode, elapsed);
+        _runtimeStore.RecordRecentRequest(timestamp, method, path, explanation, statusCode, elapsed);
     }
 
     /// <inheritdoc/>
     public void ResetRuntimeMetrics()
     {
-        runtimeStore.ResetMetrics();
+        _runtimeStore.ResetMetrics();
     }
 
     /// <inheritdoc/>
     public void ResetScenarioStates()
     {
-        scenarioCoordinator.ResetScenarioStates();
+        _scenarioCoordinator.ResetScenarioStates();
     }
 
     /// <inheritdoc/>
     public bool ResetScenarioState(string scenarioName)
     {
-        return scenarioCoordinator.ResetScenarioState(scenarioName);
+        return _scenarioCoordinator.ResetScenarioState(scenarioName);
     }
 
     private StubDocument GetCurrentDocument()
     {
-        return state.GetCurrentDocument();
+        return _state.GetCurrentDocument();
     }
 }

--- a/src/SemanticStub.Api/Services/Matching/FormBodyMatcher.cs
+++ b/src/SemanticStub.Api/Services/Matching/FormBodyMatcher.cs
@@ -11,11 +11,11 @@ internal sealed class FormBodyMatcher
 {
     private const string FormUrlEncodedMediaType = "application/x-www-form-urlencoded";
     private static readonly TimeSpan RegexMatchTimeout = TimeSpan.FromMilliseconds(100);
-    private readonly ILogger<FormBodyMatcher>? logger;
+    private readonly ILogger<FormBodyMatcher>? _logger;
 
     internal FormBodyMatcher(ILogger<FormBodyMatcher>? logger = null)
     {
-        this.logger = logger;
+        _logger = logger;
     }
 
     internal IReadOnlyDictionary<string, StringValues>? ParseRequestBody(string? body, string? contentType)
@@ -171,12 +171,12 @@ internal sealed class FormBodyMatcher
         }
         catch (ArgumentException ex)
         {
-            logger?.LogWarning(ex, "Invalid regex match pattern '{Pattern}' in stub definition — treating as non-match.", pattern);
+            _logger?.LogWarning(ex, "Invalid regex match pattern '{Pattern}' in stub definition — treating as non-match.", pattern);
             return false;
         }
         catch (RegexMatchTimeoutException)
         {
-            logger?.LogWarning("Regex match pattern '{Pattern}' timed out after {TimeoutMs}ms — treating as non-match.", pattern, RegexMatchTimeout.TotalMilliseconds);
+            _logger?.LogWarning("Regex match pattern '{Pattern}' timed out after {TimeoutMs}ms — treating as non-match.", pattern, RegexMatchTimeout.TotalMilliseconds);
             return false;
         }
     }

--- a/src/SemanticStub.Api/Services/Matching/JsonBodyMatcher.cs
+++ b/src/SemanticStub.Api/Services/Matching/JsonBodyMatcher.cs
@@ -9,14 +9,14 @@ namespace SemanticStub.Api.Services;
 /// </summary>
 internal sealed class JsonBodyMatcher
 {
-    private readonly ILogger<JsonBodyMatcher>? logger;
+    private readonly ILogger<JsonBodyMatcher>? _logger;
 
     /// <summary>
     /// Creates a body matcher with optional warning logging for invalid stub body definitions.
     /// </summary>
     internal JsonBodyMatcher(ILogger<JsonBodyMatcher>? logger = null)
     {
-        this.logger = logger;
+        _logger = logger;
     }
 
     internal JsonDocument? ParseRequestBody(string? body)
@@ -58,12 +58,12 @@ internal sealed class JsonBodyMatcher
         }
         catch (JsonException ex)
         {
-            logger?.LogWarning(ex, "Invalid body match definition in stub YAML — treating as non-match.");
+            _logger?.LogWarning(ex, "Invalid body match definition in stub YAML — treating as non-match.");
             return false;
         }
         catch (NotSupportedException ex)
         {
-            logger?.LogWarning(ex, "Unsupported body match definition in stub YAML — treating as non-match.");
+            _logger?.LogWarning(ex, "Unsupported body match definition in stub YAML — treating as non-match.");
             return false;
         }
     }

--- a/src/SemanticStub.Api/Services/Matching/MatcherService.cs
+++ b/src/SemanticStub.Api/Services/Matching/MatcherService.cs
@@ -10,10 +10,10 @@ namespace SemanticStub.Api.Services;
 public sealed class MatcherService
 {
     private static readonly QueryMatchSpecificityComparer MatchSpecificityComparer = QueryMatchSpecificityComparer.Instance;
-    private readonly FormBodyMatcher formBodyMatcher;
-    private readonly JsonBodyMatcher jsonBodyMatcher;
-    private readonly QueryValueMatcher queryValueMatcher;
-    private readonly RegexQueryMatcher regexQueryMatcher;
+    private readonly FormBodyMatcher _formBodyMatcher;
+    private readonly JsonBodyMatcher _jsonBodyMatcher;
+    private readonly QueryValueMatcher _queryValueMatcher;
+    private readonly RegexQueryMatcher _regexQueryMatcher;
 
     internal MatcherService(
         JsonBodyMatcher jsonBodyMatcher,
@@ -21,10 +21,10 @@ public sealed class MatcherService
         QueryValueMatcher queryValueMatcher,
         RegexQueryMatcher regexQueryMatcher)
     {
-        this.jsonBodyMatcher = jsonBodyMatcher;
-        this.formBodyMatcher = formBodyMatcher;
-        this.queryValueMatcher = queryValueMatcher;
-        this.regexQueryMatcher = regexQueryMatcher;
+        _jsonBodyMatcher = jsonBodyMatcher;
+        _formBodyMatcher = formBodyMatcher;
+        _queryValueMatcher = queryValueMatcher;
+        _regexQueryMatcher = regexQueryMatcher;
     }
 
     /// <summary>
@@ -128,17 +128,17 @@ public sealed class MatcherService
 
     private bool IsBodyMatch(object? expectedBody, MatchEvaluationContext matchContext)
     {
-        return matchContext.RequestForm is not null && formBodyMatcher.HasFormCondition(expectedBody)
-            ? formBodyMatcher.IsMatch(expectedBody, matchContext.RequestForm)
-            : jsonBodyMatcher.IsMatch(expectedBody, matchContext.RequestBody);
+        return matchContext.RequestForm is not null && _formBodyMatcher.HasFormCondition(expectedBody)
+            ? _formBodyMatcher.IsMatch(expectedBody, matchContext.RequestForm)
+            : _jsonBodyMatcher.IsMatch(expectedBody, matchContext.RequestBody);
     }
 
     private bool IsQueryMatch(
         QueryMatchDefinition match,
         MatchEvaluationContext matchContext)
     {
-        return queryValueMatcher.IsExactMatch(match.Query, matchContext.Query, matchContext.QueryParameterTypes) &&
-               regexQueryMatcher.IsMatch(match.Query, matchContext.Query);
+        return _queryValueMatcher.IsExactMatch(match.Query, matchContext.Query, matchContext.QueryParameterTypes) &&
+               _regexQueryMatcher.IsMatch(match.Query, matchContext.Query);
     }
 
     private MatchEvaluationContext CreateMatchContext(
@@ -149,8 +149,8 @@ public sealed class MatcherService
         string? body)
     {
         var queryParameterTypes = QueryParameterTypeMapBuilder.Build(pathParameters, operation.Parameters);
-        var bodyDocument = jsonBodyMatcher.ParseRequestBody(body);
-        var requestForm = formBodyMatcher.ParseRequestBody(body, GetContentType(headers));
+        var bodyDocument = _jsonBodyMatcher.ParseRequestBody(body);
+        var requestForm = _formBodyMatcher.ParseRequestBody(body, GetContentType(headers));
         return new MatchEvaluationContext(query, headers, queryParameterTypes, bodyDocument, requestForm);
     }
 
@@ -174,8 +174,8 @@ public sealed class MatcherService
             entry => new StringValues(entry.Value),
             StringComparer.OrdinalIgnoreCase);
 
-        return queryValueMatcher.IsExactMatch(expected, actualValues, new Dictionary<string, string>(StringComparer.Ordinal)) &&
-               regexQueryMatcher.IsMatch(expected, actualValues);
+        return _queryValueMatcher.IsExactMatch(expected, actualValues, new Dictionary<string, string>(StringComparer.Ordinal)) &&
+               _regexQueryMatcher.IsMatch(expected, actualValues);
     }
 
     private readonly struct MatchEvaluationContext : IDisposable
@@ -190,7 +190,7 @@ public sealed class MatcherService
             Query = query;
             Headers = headers;
             QueryParameterTypes = queryParameterTypes;
-            this.bodyDocument = bodyDocument;
+            _bodyDocument = bodyDocument;
             RequestBody = bodyDocument?.RootElement;
             RequestForm = requestForm;
         }
@@ -205,11 +205,11 @@ public sealed class MatcherService
 
         public IReadOnlyDictionary<string, StringValues>? RequestForm { get; }
 
-        private readonly JsonDocument? bodyDocument;
+        private readonly JsonDocument? _bodyDocument;
 
         public void Dispose()
         {
-            bodyDocument?.Dispose();
+            _bodyDocument?.Dispose();
         }
     }
 

--- a/src/SemanticStub.Api/Services/Matching/RegexQueryMatcher.cs
+++ b/src/SemanticStub.Api/Services/Matching/RegexQueryMatcher.cs
@@ -12,14 +12,14 @@ namespace SemanticStub.Api.Services;
 internal sealed class RegexQueryMatcher
 {
     private static readonly TimeSpan RegexMatchTimeout = TimeSpan.FromMilliseconds(100);
-    private readonly ILogger<RegexQueryMatcher>? logger;
+    private readonly ILogger<RegexQueryMatcher>? _logger;
 
     /// <summary>
     /// Creates a regex query matcher with optional warning logging for invalid or slow regex patterns.
     /// </summary>
     internal RegexQueryMatcher(ILogger<RegexQueryMatcher>? logger = null)
     {
-        this.logger = logger;
+        _logger = logger;
     }
 
     internal bool IsMatch(
@@ -96,12 +96,12 @@ internal sealed class RegexQueryMatcher
         }
         catch (ArgumentException ex)
         {
-            logger?.LogWarning(ex, "Invalid regex match pattern '{Pattern}' in stub definition — treating as non-match.", pattern);
+            _logger?.LogWarning(ex, "Invalid regex match pattern '{Pattern}' in stub definition — treating as non-match.", pattern);
             return false;
         }
         catch (RegexMatchTimeoutException)
         {
-            logger?.LogWarning("Regex match pattern '{Pattern}' timed out after {TimeoutMs}ms — treating as non-match.", pattern, RegexMatchTimeout.TotalMilliseconds);
+            _logger?.LogWarning("Regex match pattern '{Pattern}' timed out after {TimeoutMs}ms — treating as non-match.", pattern, RegexMatchTimeout.TotalMilliseconds);
             return false;
         }
     }

--- a/src/SemanticStub.Api/Services/Matching/StubDefaultResponseSelector.cs
+++ b/src/SemanticStub.Api/Services/Matching/StubDefaultResponseSelector.cs
@@ -4,15 +4,15 @@ namespace SemanticStub.Api.Services;
 
 internal sealed class StubDefaultResponseSelector
 {
-    private readonly StubResponseBuilder responseBuilder;
-    private readonly ScenarioService scenarioService;
+    private readonly StubResponseBuilder _responseBuilder;
+    private readonly ScenarioService _scenarioService;
 
     public StubDefaultResponseSelector(
         StubResponseBuilder responseBuilder,
         ScenarioService scenarioService)
     {
-        this.responseBuilder = responseBuilder;
-        this.scenarioService = scenarioService;
+        _responseBuilder = responseBuilder;
+        _scenarioService = scenarioService;
     }
 
     public bool TrySelect(
@@ -30,14 +30,14 @@ internal sealed class StubDefaultResponseSelector
             return false;
         }
 
-        if (!responseBuilder.TryBuild(statusCode, matchedResponse.Value, out var response))
+        if (!_responseBuilder.TryBuild(statusCode, matchedResponse.Value, out var response))
         {
             return false;
         }
 
         if (mutateScenarioState)
         {
-            scenarioService.Advance(matchedResponse.Value.Scenario);
+            _scenarioService.Advance(matchedResponse.Value.Scenario);
         }
 
         selection = new StubDefaultResponseSelection(
@@ -50,7 +50,7 @@ internal sealed class StubDefaultResponseSelector
     private bool IsEligibleDefaultResponse(string statusCode, ResponseDefinition responseDefinition)
     {
         return int.TryParse(statusCode, out _) &&
-               scenarioService.IsMatch(responseDefinition.Scenario) &&
+               _scenarioService.IsMatch(responseDefinition.Scenario) &&
                (responseDefinition.Content.Count > 0 || !string.IsNullOrEmpty(responseDefinition.ResponseFile));
     }
 }

--- a/src/SemanticStub.Api/Services/Resolution/StubDispatchSelector.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubDispatchSelector.cs
@@ -6,12 +6,12 @@ namespace SemanticStub.Api.Services;
 
 internal sealed class StubDispatchSelector
 {
-    private readonly StubDefaultResponseSelector defaultResponseSelector;
-    private readonly MatcherService matcherService;
-    private readonly ISemanticMatcherService? semanticMatcherService;
-    private readonly StubResponseBuilder responseBuilder;
-    private readonly ScenarioService scenarioService;
-    private readonly ILogger? logger;
+    private readonly StubDefaultResponseSelector _defaultResponseSelector;
+    private readonly MatcherService _matcherService;
+    private readonly ISemanticMatcherService? _semanticMatcherService;
+    private readonly StubResponseBuilder _responseBuilder;
+    private readonly ScenarioService _scenarioService;
+    private readonly ILogger? _logger;
 
     public StubDispatchSelector(
         MatcherService matcherService,
@@ -21,12 +21,12 @@ internal sealed class StubDispatchSelector
         ScenarioService scenarioService,
         ILogger? logger)
     {
-        this.matcherService = matcherService;
-        this.semanticMatcherService = semanticMatcherService;
-        this.responseBuilder = responseBuilder;
-        this.defaultResponseSelector = defaultResponseSelector;
-        this.scenarioService = scenarioService;
-        this.logger = logger;
+        _matcherService = matcherService;
+        _semanticMatcherService = semanticMatcherService;
+        _responseBuilder = responseBuilder;
+        _defaultResponseSelector = defaultResponseSelector;
+        _scenarioService = scenarioService;
+        _logger = logger;
     }
 
     public async Task<StubDispatchSelectionResult> SelectAsync(
@@ -40,19 +40,19 @@ internal sealed class StubDispatchSelector
         bool mutateScenarioState,
         bool includeSemanticCandidates)
     {
-        var selectedDeterministicCandidate = matcherService.FindBestMatch(
+        var selectedDeterministicCandidate = _matcherService.FindBestMatch(
             pathItem.Parameters,
             operation,
             query,
             headers,
             body,
-            candidate => scenarioService.IsMatch(candidate.Response.Scenario) && IsDeterministicCandidate(candidate));
+            candidate => _scenarioService.IsMatch(candidate.Response.Scenario) && IsDeterministicCandidate(candidate));
 
         if (selectedDeterministicCandidate is not null)
         {
             var matchedCandidateIndex = operation.Matches.FindIndex(candidate => ReferenceEquals(candidate, selectedDeterministicCandidate));
 
-            if (!responseBuilder.TryBuild(selectedDeterministicCandidate.Response, out var deterministicResponse))
+            if (!_responseBuilder.TryBuild(selectedDeterministicCandidate.Response, out var deterministicResponse))
             {
                 return new StubDispatchSelectionResult
                 {
@@ -65,7 +65,7 @@ internal sealed class StubDispatchSelector
                 };
             }
 
-            logger?.LogInformation(
+            _logger?.LogInformation(
                 "Deterministic conditional match selected for '{Path}' {Method}. QueryKeys={QueryKeys}, HeaderKeys={HeaderKeys}, HasBody={HasBody}.",
                 path,
                 method.ToUpperInvariant(),
@@ -75,7 +75,7 @@ internal sealed class StubDispatchSelector
 
             if (mutateScenarioState)
             {
-                scenarioService.Advance(selectedDeterministicCandidate.Response.Scenario);
+                _scenarioService.Advance(selectedDeterministicCandidate.Response.Scenario);
             }
 
             return new StubDispatchSelectionResult
@@ -90,21 +90,21 @@ internal sealed class StubDispatchSelector
             };
         }
 
-        var semanticExplanation = semanticMatcherService is null
+        var semanticExplanation = _semanticMatcherService is null
             ? new SemanticMatchExplanation()
-            : await semanticMatcherService.ExplainMatchAsync(
+            : await _semanticMatcherService.ExplainMatchAsync(
                 method,
                 path,
                 query,
                 headers,
                 body,
                 operation.Matches,
-                candidate => scenarioService.IsMatch(candidate.Response.Scenario),
+                candidate => _scenarioService.IsMatch(candidate.Response.Scenario),
                 includeCandidateScores: includeSemanticCandidates);
 
         if (semanticExplanation.SelectedCandidate is not null)
         {
-            if (!responseBuilder.TryBuild(semanticExplanation.SelectedCandidate.Response, out var semanticResponse))
+            if (!_responseBuilder.TryBuild(semanticExplanation.SelectedCandidate.Response, out var semanticResponse))
             {
                 return new StubDispatchSelectionResult
                 {
@@ -119,14 +119,14 @@ internal sealed class StubDispatchSelector
                 };
             }
 
-            logger?.LogInformation(
+            _logger?.LogInformation(
                 "Semantic fallback produced a match for '{Path}' {Method}.",
                 path,
                 method.ToUpperInvariant());
 
             if (mutateScenarioState)
             {
-                scenarioService.Advance(semanticExplanation.SelectedCandidate.Response.Scenario);
+                _scenarioService.Advance(semanticExplanation.SelectedCandidate.Response.Scenario);
             }
 
             return new StubDispatchSelectionResult
@@ -142,7 +142,7 @@ internal sealed class StubDispatchSelector
             };
         }
 
-        if (defaultResponseSelector.TrySelect(operation, mutateScenarioState, out var defaultSelection))
+        if (_defaultResponseSelector.TrySelect(operation, mutateScenarioState, out var defaultSelection))
         {
             return new StubDispatchSelectionResult
             {

--- a/src/SemanticStub.Api/Services/Resolution/StubResponseBuilder.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubResponseBuilder.cs
@@ -6,11 +6,11 @@ namespace SemanticStub.Api.Services;
 internal sealed class StubResponseBuilder
 {
     private const string JsonContentType = "application/json";
-    private readonly Func<string, string> responseFileReader;
+    private readonly Func<string, string> _responseFileReader;
 
     public StubResponseBuilder(Func<string, string> responseFileReader)
     {
-        this.responseFileReader = responseFileReader;
+        _responseFileReader = responseFileReader;
     }
 
     public bool TryBuild(int statusCode, ResponseDefinition responseDefinition, out StubResponse response)
@@ -128,7 +128,7 @@ internal sealed class StubResponseBuilder
             delayMilliseconds,
             content,
             headers,
-            responseFileReader(responseFile),
+            _responseFileReader(responseFile),
             filePath: null);
     }
 

--- a/src/SemanticStub.Api/Services/Resolution/StubService.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubService.cs
@@ -11,11 +11,11 @@ namespace SemanticStub.Api.Services;
 public sealed class StubService : IStubService
 {
     private static readonly string[] SupportedMethodOrder = [HttpMethods.Get, HttpMethods.Post, HttpMethods.Put, HttpMethods.Patch, HttpMethods.Delete];
-    private readonly Func<StubDocument> documentAccessor;
-    private readonly StubDispatchSelector dispatchSelector;
-    private readonly StubInspectionProjectionBuilder inspectionProjectionBuilder;
-    private readonly MatcherService matcherService;
-    private readonly ScenarioService scenarioService;
+    private readonly Func<StubDocument> _documentAccessor;
+    private readonly StubDispatchSelector _dispatchSelector;
+    private readonly StubInspectionProjectionBuilder _inspectionProjectionBuilder;
+    private readonly MatcherService _matcherService;
+    private readonly ScenarioService _scenarioService;
 
     /// <summary>
     /// Creates a service that always evaluates requests against the latest successfully loaded stub document.
@@ -40,11 +40,11 @@ public sealed class StubService : IStubService
         StubDispatchSelector dispatchSelector,
         StubInspectionProjectionBuilder inspectionProjectionBuilder)
     {
-        this.documentAccessor = documentAccessor;
-        this.dispatchSelector = dispatchSelector;
-        this.inspectionProjectionBuilder = inspectionProjectionBuilder;
-        this.matcherService = matcherService;
-        this.scenarioService = scenarioService;
+        _documentAccessor = documentAccessor;
+        _dispatchSelector = dispatchSelector;
+        _inspectionProjectionBuilder = inspectionProjectionBuilder;
+        _matcherService = matcherService;
+        _scenarioService = scenarioService;
     }
 
     /// <summary>
@@ -54,7 +54,7 @@ public sealed class StubService : IStubService
     /// <returns>The configured methods for the resolved path, or an empty list when no path matches.</returns>
     public IReadOnlyList<string> GetAllowedMethods(string path)
     {
-        var pathItem = StubRouteResolver.ResolvePathItem(documentAccessor(), path);
+        var pathItem = StubRouteResolver.ResolvePathItem(_documentAccessor(), path);
 
         if (pathItem is null)
         {
@@ -111,7 +111,7 @@ public sealed class StubService : IStubService
         bool includeCandidates,
         bool includeSemanticCandidates)
     {
-        var document = documentAccessor();
+        var document = _documentAccessor();
 
         if (!StubOperationResolver.TryResolveOperation(document, method, path, out var pathPattern, out var pathItem, out var operation, out var failedMatchResult))
         {
@@ -126,7 +126,7 @@ public sealed class StubService : IStubService
 
         if (OperationUsesScenario(operation))
         {
-            return await scenarioService.ExecuteLockedAsync(
+            return await _scenarioService.ExecuteLockedAsync(
                 () => DispatchCoreAsync(method, path, pathPattern, pathItem, operation, query, headers, body, mutateScenarioState, includeCandidates, includeSemanticCandidates));
         }
 
@@ -153,12 +153,12 @@ public sealed class StubService : IStubService
         bool includeSemanticCandidates)
     {
         var routeId = GetRouteId(method, pathPattern, operation);
-        var request = inspectionProjectionBuilder.CreateInspectionRequest(method, path, query, headers, body, includeCandidates, includeSemanticCandidates);
-        var scenarioSnapshots = inspectionProjectionBuilder.GetScenarioSnapshots(operation);
-        var deterministicEvaluations = matcherService.EvaluateCandidates(pathItem.Parameters, operation, query, headers, body)
-            .Select((evaluation, index) => inspectionProjectionBuilder.CreateCandidateInfo(evaluation, index, scenarioSnapshots))
+        var request = _inspectionProjectionBuilder.CreateInspectionRequest(method, path, query, headers, body, includeCandidates, includeSemanticCandidates);
+        var scenarioSnapshots = _inspectionProjectionBuilder.GetScenarioSnapshots(operation);
+        var deterministicEvaluations = _matcherService.EvaluateCandidates(pathItem.Parameters, operation, query, headers, body)
+            .Select((evaluation, index) => _inspectionProjectionBuilder.CreateCandidateInfo(evaluation, index, scenarioSnapshots))
             .ToList();
-        var selection = await dispatchSelector.SelectAsync(
+        var selection = await _dispatchSelector.SelectAsync(
             method,
             path,
             pathItem,
@@ -172,7 +172,7 @@ public sealed class StubService : IStubService
         SemanticMatchInfo? semanticEvaluationInfo = null;
         if (selection.SemanticExplanation.Attempted)
         {
-            semanticEvaluationInfo = inspectionProjectionBuilder.CreateSemanticMatchInfo(selection.SemanticExplanation, operation, includeSemanticCandidates);
+            semanticEvaluationInfo = _inspectionProjectionBuilder.CreateSemanticMatchInfo(selection.SemanticExplanation, operation, includeSemanticCandidates);
         }
 
         string? selectedResponseId = selection.SelectedResponseId;
@@ -182,7 +182,7 @@ public sealed class StubService : IStubService
         {
             var selectedCandidate = deterministicEvaluations.FirstOrDefault(candidate =>
                     ReferenceEquals(operation.Matches[candidate.CandidateIndex], selection.SelectedCandidate))
-                ?? inspectionProjectionBuilder.CreateCandidateInfo(
+                ?? _inspectionProjectionBuilder.CreateCandidateInfo(
                     new QueryMatchCandidateEvaluation
                     {
                         Candidate = selection.SelectedCandidate,

--- a/src/SemanticStub.Api/Services/Scenario/ScenarioService.cs
+++ b/src/SemanticStub.Api/Services/Scenario/ScenarioService.cs
@@ -8,8 +8,8 @@ namespace SemanticStub.Api.Services;
 /// </summary>
 public sealed class ScenarioService
 {
-    private readonly ScenarioStateStore stateStore = new();
-    private readonly SemaphoreSlim semaphore = new(1, 1);
+    private readonly ScenarioStateStore _stateStore = new();
+    private readonly SemaphoreSlim _semaphore = new(1, 1);
 
     /// <summary>
     /// Returns whether the supplied scenario definition is eligible for the current in-memory state.
@@ -22,7 +22,7 @@ public sealed class ScenarioService
             return true;
         }
 
-        return stateStore.IsMatch(scenario);
+        return _stateStore.IsMatch(scenario);
     }
 
     /// <summary>
@@ -31,7 +31,7 @@ public sealed class ScenarioService
     /// <param name="scenario">The scenario definition attached to the selected response.</param>
     public void Advance(ScenarioDefinition? scenario)
     {
-        stateStore.Advance(scenario, DateTimeOffset.UtcNow);
+        _stateStore.Advance(scenario, DateTimeOffset.UtcNow);
     }
 
     /// <summary>
@@ -44,7 +44,7 @@ public sealed class ScenarioService
 
     internal void ResetWithinLock()
     {
-        stateStore.Clear();
+        _stateStore.Clear();
     }
 
     /// <summary>
@@ -95,17 +95,17 @@ public sealed class ScenarioService
 
     internal ScenarioStateSnapshot GetSnapshotWithinLock(string scenarioName)
     {
-        return stateStore.GetSnapshot(scenarioName);
+        return _stateStore.GetSnapshot(scenarioName);
     }
 
     internal void ResetScenarioWithinLock(string scenarioName, DateTimeOffset timestamp)
     {
-        stateStore.ResetScenario(scenarioName, timestamp);
+        _stateStore.ResetScenario(scenarioName, timestamp);
     }
 
     internal void ResetScenariosWithinLock(IEnumerable<string> scenarioNames, DateTimeOffset timestamp)
     {
-        stateStore.ResetScenarios(scenarioNames, timestamp);
+        _stateStore.ResetScenarios(scenarioNames, timestamp);
     }
 
     /// <summary>
@@ -127,14 +127,14 @@ public sealed class ScenarioService
     /// <param name="action">The scenario-aware operation to run atomically.</param>
     public T ExecuteLocked<T>(Func<T> action)
     {
-        semaphore.Wait();
+        _semaphore.Wait();
         try
         {
             return action();
         }
         finally
         {
-            semaphore.Release();
+            _semaphore.Release();
         }
     }
 
@@ -144,14 +144,14 @@ public sealed class ScenarioService
     /// <param name="action">The scenario-aware async operation to run atomically.</param>
     public async Task<T> ExecuteLockedAsync<T>(Func<Task<T>> action)
     {
-        await semaphore.WaitAsync();
+        await _semaphore.WaitAsync();
         try
         {
             return await action();
         }
         finally
         {
-            semaphore.Release();
+            _semaphore.Release();
         }
     }
 

--- a/src/SemanticStub.Api/Services/Scenario/ScenarioStateStore.cs
+++ b/src/SemanticStub.Api/Services/Scenario/ScenarioStateStore.cs
@@ -9,7 +9,7 @@ namespace SemanticStub.Api.Services;
 internal sealed class ScenarioStateStore
 {
     private const string InitialState = "initial";
-    private readonly ConcurrentDictionary<string, ScenarioStateSnapshot> currentStates = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, ScenarioStateSnapshot> _currentStates = new(StringComparer.Ordinal);
 
     public bool IsMatch(ScenarioDefinition scenario)
     {
@@ -24,36 +24,36 @@ internal sealed class ScenarioStateStore
             return;
         }
 
-        currentStates[scenario.Name] = CreateSnapshot(scenario.Next, timestamp);
+        _currentStates[scenario.Name] = CreateSnapshot(scenario.Next, timestamp);
     }
 
     public ScenarioStateSnapshot GetSnapshot(string scenarioName)
     {
-        return currentStates.TryGetValue(scenarioName, out var snapshot)
+        return _currentStates.TryGetValue(scenarioName, out var snapshot)
             ? snapshot
             : CreateSnapshot(InitialState, timestamp: null);
     }
 
     public void ResetScenario(string scenarioName, DateTimeOffset timestamp)
     {
-        currentStates[scenarioName] = CreateSnapshot(InitialState, timestamp);
+        _currentStates[scenarioName] = CreateSnapshot(InitialState, timestamp);
     }
 
     public void ResetScenarios(IEnumerable<string> scenarioNames, DateTimeOffset timestamp)
     {
         var scenarioNameSet = new HashSet<string>(scenarioNames, StringComparer.Ordinal);
 
-        currentStates.Clear();
+        _currentStates.Clear();
 
         foreach (var scenarioName in scenarioNameSet)
         {
-            currentStates[scenarioName] = CreateSnapshot(InitialState, timestamp);
+            _currentStates[scenarioName] = CreateSnapshot(InitialState, timestamp);
         }
     }
 
     public void Clear()
     {
-        currentStates.Clear();
+        _currentStates.Clear();
     }
 
     private static ScenarioStateSnapshot CreateSnapshot(string state, DateTimeOffset? timestamp)

--- a/src/SemanticStub.Api/Services/Semantic/SemanticEmbeddingClient.cs
+++ b/src/SemanticStub.Api/Services/Semantic/SemanticEmbeddingClient.cs
@@ -11,8 +11,8 @@ namespace SemanticStub.Api.Services;
 internal sealed class SemanticEmbeddingClient : ISemanticEmbeddingClient
 {
     private const string HttpClientName = "SemanticEmbedding";
-    private readonly IHttpClientFactory httpClientFactory;
-    private readonly SemanticMatchingSettings settings;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly SemanticMatchingSettings _settings;
 
     /// <summary>
     /// Creates a client over the configured embedding endpoint settings.
@@ -21,8 +21,8 @@ internal sealed class SemanticEmbeddingClient : ISemanticEmbeddingClient
     /// <param name="settings">The stub runtime settings that provide the semantic endpoint configuration.</param>
     public SemanticEmbeddingClient(IHttpClientFactory httpClientFactory, IOptions<StubSettings> settings)
     {
-        this.httpClientFactory = httpClientFactory;
-        this.settings = settings.Value.SemanticMatching;
+        _httpClientFactory = httpClientFactory;
+        _settings = settings.Value.SemanticMatching;
     }
 
     /// <summary>
@@ -35,8 +35,8 @@ internal sealed class SemanticEmbeddingClient : ISemanticEmbeddingClient
     /// <exception cref="InvalidOperationException">Thrown when the response shape is invalid.</exception>
     public async Task<IReadOnlyList<float[]>> GetEmbeddingsAsync(IReadOnlyList<string> inputs)
     {
-        var httpClient = httpClientFactory.CreateClient(HttpClientName);
-        var endpoint = SemanticEmbeddingEndpoint.Normalize(settings.Endpoint!);
+        var httpClient = _httpClientFactory.CreateClient(HttpClientName);
+        var endpoint = SemanticEmbeddingEndpoint.Normalize(_settings.Endpoint!);
         var response = await httpClient.PostAsJsonAsync(endpoint, new EmbedRequest(inputs));
         response.EnsureSuccessStatusCode();
 

--- a/src/SemanticStub.Api/Services/Semantic/SemanticMatcherService.cs
+++ b/src/SemanticStub.Api/Services/Semantic/SemanticMatcherService.cs
@@ -11,18 +11,18 @@ namespace SemanticStub.Api.Services;
 /// </summary>
 public sealed class SemanticMatcherService : ISemanticMatcherService
 {
-    private readonly ISemanticEmbeddingClient embeddingClient;
-    private readonly StubSettings settings;
-    private readonly ILogger<SemanticMatcherService> logger;
+    private readonly ISemanticEmbeddingClient _embeddingClient;
+    private readonly StubSettings _settings;
+    private readonly ILogger<SemanticMatcherService> _logger;
 
     internal SemanticMatcherService(
         ISemanticEmbeddingClient embeddingClient,
         IOptions<StubSettings> settings,
         ILogger<SemanticMatcherService> logger)
     {
-        this.settings = settings.Value;
-        this.embeddingClient = embeddingClient;
-        this.logger = logger;
+        _settings = settings.Value;
+        _embeddingClient = embeddingClient;
+        _logger = logger;
     }
 
     /// <inheritdoc/>
@@ -36,12 +36,12 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
         Func<QueryMatchDefinition, bool>? candidateFilter = null,
         bool includeCandidateScores = false)
     {
-        var semanticSettings = settings.SemanticMatching;
+        var semanticSettings = _settings.SemanticMatching;
         var normalizedMethod = method.ToUpperInvariant();
 
         if (!IsEnabled(out var disabledReason))
         {
-            logger.LogDebug(
+            _logger.LogDebug(
                 "Semantic matching skipped for '{Path}' {Method}: {Reason}",
                 path,
                 normalizedMethod,
@@ -53,7 +53,7 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
 
         if (semanticCandidates.Count == 0)
         {
-            logger.LogDebug(
+            _logger.LogDebug(
                 "Semantic matching skipped for '{Path}' {Method}: no eligible candidates define x-semantic-match.",
                 path,
                 normalizedMethod);
@@ -64,7 +64,7 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
         {
             var endpoint = SemanticEmbeddingEndpoint.Normalize(semanticSettings.Endpoint!);
 
-            logger.LogInformation(
+            _logger.LogInformation(
                 "Semantic matching started for '{Path}' {Method}. Endpoint={Endpoint}, Threshold={Threshold}, TopScoreMargin={TopScoreMargin}, Candidates={CandidateCount}.",
                 path,
                 normalizedMethod,
@@ -92,7 +92,7 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
         }
         catch (HttpRequestException ex)
         {
-            logger.LogWarning(
+            _logger.LogWarning(
                 ex,
                 "Semantic matching failed for '{Path}' {Method}: the embedding endpoint request failed. Treating the request as a non-match.",
                 path,
@@ -101,7 +101,7 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
         }
         catch (TaskCanceledException ex)
         {
-            logger.LogWarning(
+            _logger.LogWarning(
                 ex,
                 "Semantic matching failed for '{Path}' {Method}: the embedding endpoint request timed out. Treating the request as a non-match.",
                 path,
@@ -110,7 +110,7 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
         }
         catch (Exception ex)
         {
-            logger.LogError(
+            _logger.LogError(
                 ex,
                 "Semantic matching encountered an unexpected error for '{Path}' {Method}. Treating the request as a non-match.",
                 path,
@@ -121,7 +121,7 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
 
     private bool IsEnabled(out string reason)
     {
-        var semanticSettings = settings.SemanticMatching;
+        var semanticSettings = _settings.SemanticMatching;
 
         if (!semanticSettings.Enabled)
         {
@@ -163,7 +163,7 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
         };
 
         allTexts.AddRange(semanticCandidates.Select(candidate => candidate.SemanticMatch!));
-        return await embeddingClient.GetEmbeddingsAsync(allTexts);
+        return await _embeddingClient.GetEmbeddingsAsync(allTexts);
     }
 
     private SemanticMatchExplanation ScoreAndLogExplanation(
@@ -183,7 +183,7 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
             includeCandidateScores,
             (candidate, score) =>
             {
-                logger.LogDebug(
+                _logger.LogDebug(
                     "Semantic candidate scored for '{Path}' {Method}. Candidate='{SemanticMatch}', Score={Score}, Threshold={Threshold}.",
                     path,
                     normalizedMethod,
@@ -196,7 +196,7 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
 
         if (explanation.SelectedCandidate is null && explanation.SelectedScore is null)
         {
-            logger.LogDebug(
+            _logger.LogDebug(
                 "Semantic matching did not select a candidate for '{Path}' {Method}. Best score stayed below the threshold.",
                 path,
                 normalizedMethod);
@@ -205,7 +205,7 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
 
         if (explanation.SelectedCandidate is null && explanation.SelectedScore is not null)
         {
-            logger.LogDebug(
+            _logger.LogDebug(
                 "Semantic matching did not select a candidate for '{Path}' {Method}. Top score margin {Margin} was below the required {RequiredMargin}.",
                 path,
                 normalizedMethod,
@@ -214,7 +214,7 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
             return explanation;
         }
 
-        logger.LogInformation(
+        _logger.LogInformation(
             "Semantic matching selected candidate for '{Path}' {Method}. Candidate='{SemanticMatch}', Score={Score}.",
             path,
             normalizedMethod,


### PR DESCRIPTION
## Summary
- Rename service-layer private instance fields to `_camelCase`
- Keep constants and static readonly members unchanged
- Keep matching, resolution, inspection, scenario, and semantic behavior unchanged

## Files Changed
- `src/SemanticStub.Api/Services/Inspection/*`
- `src/SemanticStub.Api/Services/Matching/*`
- `src/SemanticStub.Api/Services/Resolution/*`
- `src/SemanticStub.Api/Services/Scenario/*`
- `src/SemanticStub.Api/Services/Semantic/*`

## Tests
- `dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter "FullyQualifiedName~StubServiceTests|FullyQualifiedName~StubDispatchSelectorTests|FullyQualifiedName~MatcherServiceTests|FullyQualifiedName~ScenarioServiceTests|FullyQualifiedName~ScenarioStateStoreTests"`
- `dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --no-restore --filter "FullyQualifiedName~StubInspectionServiceTests|FullyQualifiedName~SemanticMatcherServiceTests|FullyQualifiedName~FormBodyMatcherTests|FullyQualifiedName~JsonBodyMatcherTests|FullyQualifiedName~RegexQueryMatcherTests|FullyQualifiedName~StubResponseBuilderTests"`
- `dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --no-restore`

## Notes
- Closes #208
- Part of #196 split rename work