### PR TITLE
refactor: mirror unit test folders by responsibility

### DIFF
--- a/tests/SemanticStub.Api.Tests/Unit/Controllers/StubControllerTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Controllers/StubControllerTests.cs
@@ -9,7 +9,7 @@ using SemanticStub.Api.Models;
 using SemanticStub.Api.Services;
 using Xunit;
 
-namespace SemanticStub.Api.Tests.Unit;
+namespace SemanticStub.Api.Tests.Unit.Controllers;
 
 public sealed class StubControllerTests
 {

--- a/tests/SemanticStub.Api.Tests/Unit/Controllers/StubRequestBodyReaderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Controllers/StubRequestBodyReaderTests.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using SemanticStub.Api.Controllers;
 using Xunit;
 
-namespace SemanticStub.Api.Tests.Unit;
+namespace SemanticStub.Api.Tests.Unit.Controllers;
 
 public sealed class StubRequestBodyReaderTests
 {

--- a/tests/SemanticStub.Api.Tests/Unit/Infrastructure/Yaml/StubDefinitionLoaderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Infrastructure/Yaml/StubDefinitionLoaderTests.cs
@@ -5,7 +5,7 @@ using SemanticStub.Api.Infrastructure.Yaml;
 using SemanticStub.Api.Models;
 using Xunit;
 
-namespace SemanticStub.Api.Tests.Unit;
+namespace SemanticStub.Api.Tests.Unit.Infrastructure.Yaml;
 
 public sealed class StubDefinitionLoaderTests
 {

--- a/tests/SemanticStub.Api.Tests/Unit/Infrastructure/Yaml/StubDefinitionNormalizerTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Infrastructure/Yaml/StubDefinitionNormalizerTests.cs
@@ -2,7 +2,7 @@ using SemanticStub.Api.Infrastructure.Yaml;
 using SemanticStub.Api.Models;
 using Xunit;
 
-namespace SemanticStub.Api.Tests.Unit;
+namespace SemanticStub.Api.Tests.Unit.Infrastructure.Yaml;
 
 public sealed class StubDefinitionNormalizerTests
 {

--- a/tests/SemanticStub.Api.Tests/Unit/Infrastructure/Yaml/StubDefinitionValidatorTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Infrastructure/Yaml/StubDefinitionValidatorTests.cs
@@ -2,7 +2,7 @@ using SemanticStub.Api.Infrastructure.Yaml;
 using SemanticStub.Api.Models;
 using Xunit;
 
-namespace SemanticStub.Api.Tests.Unit;
+namespace SemanticStub.Api.Tests.Unit.Infrastructure.Yaml;
 
 public sealed class StubDefinitionValidatorTests
 {

--- a/tests/SemanticStub.Api.Tests/Unit/Infrastructure/Yaml/StubScenarioNameCollectorTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Infrastructure/Yaml/StubScenarioNameCollectorTests.cs
@@ -2,7 +2,7 @@ using SemanticStub.Api.Infrastructure.Yaml;
 using SemanticStub.Api.Models;
 using Xunit;
 
-namespace SemanticStub.Api.Tests.Unit;
+namespace SemanticStub.Api.Tests.Unit.Infrastructure.Yaml;
 
 public sealed class StubScenarioNameCollectorTests
 {

--- a/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionProjectionBuilderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionProjectionBuilderTests.cs
@@ -4,7 +4,7 @@ using SemanticStub.Api.Models;
 using SemanticStub.Api.Services;
 using Xunit;
 
-namespace SemanticStub.Api.Tests.Unit;
+namespace SemanticStub.Api.Tests.Unit.Inspection;
 
 public sealed class StubInspectionProjectionBuilderTests
 {

--- a/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionServiceTests.cs
@@ -8,7 +8,7 @@ using SemanticStub.Api.Models;
 using SemanticStub.Api.Services;
 using Xunit;
 
-namespace SemanticStub.Api.Tests.Unit;
+namespace SemanticStub.Api.Tests.Unit.Inspection;
 
 public sealed class StubInspectionServiceTests
 {

--- a/tests/SemanticStub.Api.Tests/Unit/Models/StubResponseTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Models/StubResponseTests.cs
@@ -1,7 +1,7 @@
 using SemanticStub.Api.Models;
 using Xunit;
 
-namespace SemanticStub.Api.Tests.Unit;
+namespace SemanticStub.Api.Tests.Unit.Models;
 
 public sealed class StubResponseTests
 {

--- a/tests/SemanticStub.Api.Tests/Unit/Resolution/StubDispatchSelectorTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Resolution/StubDispatchSelectorTests.cs
@@ -4,7 +4,7 @@ using SemanticStub.Api.Models;
 using SemanticStub.Api.Services;
 using Xunit;
 
-namespace SemanticStub.Api.Tests.Unit;
+namespace SemanticStub.Api.Tests.Unit.Resolution;
 
 public sealed class StubDispatchSelectorTests
 {

--- a/tests/SemanticStub.Api.Tests/Unit/Resolution/StubMatchExplanationBuilderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Resolution/StubMatchExplanationBuilderTests.cs
@@ -3,7 +3,7 @@ using SemanticStub.Api.Models;
 using SemanticStub.Api.Services;
 using Xunit;
 
-namespace SemanticStub.Api.Tests.Unit;
+namespace SemanticStub.Api.Tests.Unit.Resolution;
 
 public sealed class StubMatchExplanationBuilderTests
 {

--- a/tests/SemanticStub.Api.Tests/Unit/Resolution/StubOperationResolverTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Resolution/StubOperationResolverTests.cs
@@ -3,7 +3,7 @@ using SemanticStub.Api.Models;
 using SemanticStub.Api.Services;
 using Xunit;
 
-namespace SemanticStub.Api.Tests.Unit;
+namespace SemanticStub.Api.Tests.Unit.Resolution;
 
 public sealed class StubOperationResolverTests
 {

--- a/tests/SemanticStub.Api.Tests/Unit/Resolution/StubResponseBuilderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Resolution/StubResponseBuilderTests.cs
@@ -2,7 +2,7 @@ using SemanticStub.Api.Models;
 using SemanticStub.Api.Services;
 using Xunit;
 
-namespace SemanticStub.Api.Tests.Unit;
+namespace SemanticStub.Api.Tests.Unit.Resolution;
 
 public sealed class StubResponseBuilderTests
 {

--- a/tests/SemanticStub.Api.Tests/Unit/Resolution/StubResponseHeaderBuilderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Resolution/StubResponseHeaderBuilderTests.cs
@@ -3,7 +3,7 @@ using SemanticStub.Api.Models;
 using SemanticStub.Api.Services;
 using Xunit;
 
-namespace SemanticStub.Api.Tests.Unit;
+namespace SemanticStub.Api.Tests.Unit.Resolution;
 
 public sealed class StubResponseHeaderBuilderTests
 {

--- a/tests/SemanticStub.Api.Tests/Unit/Resolution/StubRouteResolverTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Resolution/StubRouteResolverTests.cs
@@ -3,7 +3,7 @@ using SemanticStub.Api.Models;
 using SemanticStub.Api.Services;
 using Xunit;
 
-namespace SemanticStub.Api.Tests.Unit;
+namespace SemanticStub.Api.Tests.Unit.Resolution;
 
 public sealed class StubRouteResolverTests
 {

--- a/tests/SemanticStub.Api.Tests/Unit/Resolution/StubServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Resolution/StubServiceTests.cs
@@ -7,7 +7,7 @@ using SemanticStub.Api.Models;
 using SemanticStub.Api.Services;
 using Xunit;
 
-namespace SemanticStub.Api.Tests.Unit;
+namespace SemanticStub.Api.Tests.Unit.Resolution;
 
 public sealed class StubServiceTests
 {

--- a/tests/SemanticStub.Api.Tests/Unit/Semantic/SemanticMatcherServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Semantic/SemanticMatcherServiceTests.cs
@@ -11,7 +11,7 @@ using SemanticStub.Api.Models;
 using SemanticStub.Api.Services;
 using Xunit;
 
-namespace SemanticStub.Api.Tests.Unit;
+namespace SemanticStub.Api.Tests.Unit.Semantic;
 
 public sealed class SemanticMatcherServiceTests
 {


### PR DESCRIPTION
## Summary
- Move unit tests into responsibility-focused subfolders under tests/SemanticStub.Api.Tests/Unit
- Update test namespaces to match the new folder structure

## Files Changed
- Unit/Controllers
- Unit/Infrastructure/Yaml
- Unit/Inspection
- Unit/Models
- Unit/Resolution
- Unit/Semantic

## Tests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj

## Notes
- Test methods and assertions were not renamed or changed.
- Closes #201