### PR TITLE
refactor: align layer namespaces

### DIFF
--- a/src/SemanticStub.Api/Extensions/StubServiceCollectionExtensions.cs
+++ b/src/SemanticStub.Api/Extensions/StubServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using SemanticStub.Api.Infrastructure.Yaml;
+using SemanticStub.Application.Infrastructure.Yaml;
+using SemanticStub.Application.Services;
+using SemanticStub.Infrastructure.Yaml;
 using SemanticStub.Api.Services;
 
 namespace SemanticStub.Api.Extensions;

--- a/src/SemanticStub.Api/Program.cs
+++ b/src/SemanticStub.Api/Program.cs
@@ -3,7 +3,8 @@ using Microsoft.AspNetCore.HttpLogging;
 using Microsoft.AspNetCore.RequestDecompression;
 using Microsoft.AspNetCore.ResponseCompression;
 using SemanticStub.Api.Extensions;
-using SemanticStub.Api.Infrastructure.Yaml;
+using SemanticStub.Application.Infrastructure.Yaml;
+using SemanticStub.Infrastructure.Yaml;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/src/SemanticStub.Api/Services/Inspection/StubInspectionDocumentProjector.cs
+++ b/src/SemanticStub.Api/Services/Inspection/StubInspectionDocumentProjector.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using SemanticStub.Api.Inspection;
 using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 
 namespace SemanticStub.Api.Services;
 

--- a/src/SemanticStub.Api/Services/Inspection/StubInspectionProjectionBuilder.cs
+++ b/src/SemanticStub.Api/Services/Inspection/StubInspectionProjectionBuilder.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.Primitives;
 using SemanticStub.Api.Inspection;
 using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
+using SemanticStub.Application.Services;
 
 namespace SemanticStub.Api.Services;
 

--- a/src/SemanticStub.Api/Services/Inspection/StubInspectionScenarioCoordinator.cs
+++ b/src/SemanticStub.Api/Services/Inspection/StubInspectionScenarioCoordinator.cs
@@ -1,5 +1,7 @@
 using SemanticStub.Api.Inspection;
-using SemanticStub.Api.Infrastructure.Yaml;
+using SemanticStub.Application.Infrastructure.Yaml;
+using SemanticStub.Application.Services;
+using SemanticStub.Infrastructure.Yaml;
 
 namespace SemanticStub.Api.Services;
 

--- a/src/SemanticStub.Api/Services/Inspection/StubInspectionService.cs
+++ b/src/SemanticStub.Api/Services/Inspection/StubInspectionService.cs
@@ -1,7 +1,9 @@
 using Microsoft.Extensions.Options;
 using SemanticStub.Api.Inspection;
-using SemanticStub.Api.Infrastructure.Yaml;
+using SemanticStub.Application.Infrastructure.Yaml;
+using SemanticStub.Infrastructure.Yaml;
 using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 
 namespace SemanticStub.Api.Services;
 

--- a/src/SemanticStub.Api/Services/Matching/StubDefaultResponseSelector.cs
+++ b/src/SemanticStub.Api/Services/Matching/StubDefaultResponseSelector.cs
@@ -1,4 +1,6 @@
 using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
+using SemanticStub.Application.Services;
 
 namespace SemanticStub.Api.Services;
 

--- a/src/SemanticStub.Api/Services/Resolution/StubDispatchSelector.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubDispatchSelector.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
+using SemanticStub.Application.Services;
 
 namespace SemanticStub.Api.Services;
 

--- a/src/SemanticStub.Api/Services/Resolution/StubOperationResolver.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubOperationResolver.cs
@@ -1,4 +1,5 @@
 using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 
 namespace SemanticStub.Api.Services;
 

--- a/src/SemanticStub.Api/Services/Resolution/StubResponseBuilder.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubResponseBuilder.cs
@@ -1,5 +1,6 @@
 using SemanticStub.Api.Models;
-using SemanticStub.Api.Utilities;
+using SemanticStub.Application.Models;
+using SemanticStub.Application.Utilities;
 
 namespace SemanticStub.Api.Services;
 

--- a/src/SemanticStub.Api/Services/Resolution/StubResponseHeaderBuilder.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubResponseHeaderBuilder.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Primitives;
 using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 using System.Collections;
 using System.Globalization;
 

--- a/src/SemanticStub.Api/Services/Resolution/StubRouteResolver.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubRouteResolver.cs
@@ -1,4 +1,5 @@
 using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 
 namespace SemanticStub.Api.Services;
 

--- a/src/SemanticStub.Api/Services/Resolution/StubService.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubService.cs
@@ -1,6 +1,9 @@
-using SemanticStub.Api.Infrastructure.Yaml;
+using SemanticStub.Application.Infrastructure.Yaml;
+using SemanticStub.Infrastructure.Yaml;
 using SemanticStub.Api.Inspection;
 using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
+using SemanticStub.Application.Services;
 using Microsoft.Extensions.Primitives;
 
 namespace SemanticStub.Api.Services;

--- a/src/SemanticStub.Api/Services/Semantic/ISemanticMatcherService.cs
+++ b/src/SemanticStub.Api/Services/Semantic/ISemanticMatcherService.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Primitives;
 using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 
 namespace SemanticStub.Api.Services;
 

--- a/src/SemanticStub.Api/Services/Semantic/SemanticCandidateScorer.cs
+++ b/src/SemanticStub.Api/Services/Semantic/SemanticCandidateScorer.cs
@@ -1,4 +1,5 @@
 using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 
 namespace SemanticStub.Api.Services;
 

--- a/src/SemanticStub.Api/Services/Semantic/SemanticEmbeddingClient.cs
+++ b/src/SemanticStub.Api/Services/Semantic/SemanticEmbeddingClient.cs
@@ -1,7 +1,8 @@
 using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.Extensions.Options;
-using SemanticStub.Api.Infrastructure.Yaml;
+using SemanticStub.Application.Infrastructure.Yaml;
+using SemanticStub.Infrastructure.Yaml;
 
 namespace SemanticStub.Api.Services;
 

--- a/src/SemanticStub.Api/Services/Semantic/SemanticMatchExplanation.cs
+++ b/src/SemanticStub.Api/Services/Semantic/SemanticMatchExplanation.cs
@@ -1,4 +1,5 @@
 using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 
 namespace SemanticStub.Api.Services;
 

--- a/src/SemanticStub.Api/Services/Semantic/SemanticMatcherService.cs
+++ b/src/SemanticStub.Api/Services/Semantic/SemanticMatcherService.cs
@@ -1,8 +1,10 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
-using SemanticStub.Api.Infrastructure.Yaml;
+using SemanticStub.Application.Infrastructure.Yaml;
+using SemanticStub.Infrastructure.Yaml;
 using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 
 namespace SemanticStub.Api.Services;
 

--- a/src/SemanticStub.Api/appsettings.json
+++ b/src/SemanticStub.Api/appsettings.json
@@ -7,7 +7,7 @@
     "LogLevel": {
       "Default": "Warning",
       "Microsoft.AspNetCore.HttpLogging": "Information",
-      "SemanticStub.Api.Infrastructure.Yaml": "Information"
+      "SemanticStub.Infrastructure.Yaml": "Information"
     }
   },
   "StubSettings": {

--- a/src/SemanticStub.Application/Infrastructure/Yaml/IStubDefinitionLoader.cs
+++ b/src/SemanticStub.Application/Infrastructure/Yaml/IStubDefinitionLoader.cs
@@ -1,6 +1,6 @@
-using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 
-namespace SemanticStub.Api.Infrastructure.Yaml;
+namespace SemanticStub.Application.Infrastructure.Yaml;
 
 /// <summary>
 /// Loads validated OpenAPI-based stub definitions and file-backed response payloads from disk without exposing discovery, validation, or normalization internals to callers.

--- a/src/SemanticStub.Application/Models/HeaderDefinition.cs
+++ b/src/SemanticStub.Application/Models/HeaderDefinition.cs
@@ -1,4 +1,4 @@
-namespace SemanticStub.Api.Models;
+namespace SemanticStub.Application.Models;
 
 /// <summary>
 /// Describes an OpenAPI response header exposed by a stub response.

--- a/src/SemanticStub.Application/Models/HeaderSchemaDefinition.cs
+++ b/src/SemanticStub.Application/Models/HeaderSchemaDefinition.cs
@@ -1,4 +1,4 @@
-namespace SemanticStub.Api.Models;
+namespace SemanticStub.Application.Models;
 
 public sealed class HeaderSchemaDefinition
 {

--- a/src/SemanticStub.Application/Models/MatchOperatorDefinition.cs
+++ b/src/SemanticStub.Application/Models/MatchOperatorDefinition.cs
@@ -1,6 +1,6 @@
 using System.Collections;
 
-namespace SemanticStub.Api.Models;
+namespace SemanticStub.Application.Models;
 
 internal static class MatchOperatorDefinition
 {

--- a/src/SemanticStub.Application/Models/MediaTypeDefinition.cs
+++ b/src/SemanticStub.Application/Models/MediaTypeDefinition.cs
@@ -1,4 +1,4 @@
-namespace SemanticStub.Api.Models;
+namespace SemanticStub.Application.Models;
 
 public sealed class MediaTypeDefinition
 {

--- a/src/SemanticStub.Application/Models/OperationDefinition.cs
+++ b/src/SemanticStub.Application/Models/OperationDefinition.cs
@@ -1,6 +1,6 @@
 using YamlDotNet.Serialization;
 
-namespace SemanticStub.Api.Models;
+namespace SemanticStub.Application.Models;
 
 /// <summary>
 /// Describes an OpenAPI operation and its stub-specific match definitions.

--- a/src/SemanticStub.Application/Models/ParameterDefinition.cs
+++ b/src/SemanticStub.Application/Models/ParameterDefinition.cs
@@ -1,4 +1,4 @@
-namespace SemanticStub.Api.Models;
+namespace SemanticStub.Application.Models;
 
 public sealed class ParameterDefinition
 {

--- a/src/SemanticStub.Application/Models/ParameterSchemaDefinition.cs
+++ b/src/SemanticStub.Application/Models/ParameterSchemaDefinition.cs
@@ -1,4 +1,4 @@
-namespace SemanticStub.Api.Models;
+namespace SemanticStub.Application.Models;
 
 public sealed class ParameterSchemaDefinition
 {

--- a/src/SemanticStub.Application/Models/PathItemDefinition.cs
+++ b/src/SemanticStub.Application/Models/PathItemDefinition.cs
@@ -1,4 +1,4 @@
-namespace SemanticStub.Api.Models;
+namespace SemanticStub.Application.Models;
 
 public sealed class PathItemDefinition
 {

--- a/src/SemanticStub.Application/Models/QueryMatchDefinition.cs
+++ b/src/SemanticStub.Application/Models/QueryMatchDefinition.cs
@@ -1,6 +1,6 @@
 using YamlDotNet.Serialization;
 
-namespace SemanticStub.Api.Models;
+namespace SemanticStub.Application.Models;
 
 /// <summary>
 /// Describes the request conditions and response selected by a stub match entry.

--- a/src/SemanticStub.Application/Models/QueryMatchResponseDefinition.cs
+++ b/src/SemanticStub.Application/Models/QueryMatchResponseDefinition.cs
@@ -1,6 +1,6 @@
 using YamlDotNet.Serialization;
 
-namespace SemanticStub.Api.Models;
+namespace SemanticStub.Application.Models;
 
 public sealed class QueryMatchResponseDefinition
 {

--- a/src/SemanticStub.Application/Models/ResponseDefinition.cs
+++ b/src/SemanticStub.Application/Models/ResponseDefinition.cs
@@ -1,6 +1,6 @@
 using YamlDotNet.Serialization;
 
-namespace SemanticStub.Api.Models;
+namespace SemanticStub.Application.Models;
 
 public sealed class ResponseDefinition
 {

--- a/src/SemanticStub.Application/Models/ScenarioDefinition.cs
+++ b/src/SemanticStub.Application/Models/ScenarioDefinition.cs
@@ -1,6 +1,6 @@
 using YamlDotNet.Serialization;
 
-namespace SemanticStub.Api.Models;
+namespace SemanticStub.Application.Models;
 
 /// <summary>
 /// Describes the scenario state required for a response to be eligible and the optional next state to persist after that response is selected.

--- a/src/SemanticStub.Application/Models/StubDocument.cs
+++ b/src/SemanticStub.Application/Models/StubDocument.cs
@@ -1,6 +1,6 @@
 using YamlDotNet.Serialization;
 
-namespace SemanticStub.Api.Models;
+namespace SemanticStub.Application.Models;
 
 /// <summary>
 /// Represents the OpenAPI document used as the YAML source of truth for stub definitions.

--- a/src/SemanticStub.Application/Services/Matching/FormBodyMatcher.cs
+++ b/src/SemanticStub.Application/Services/Matching/FormBodyMatcher.cs
@@ -3,9 +3,9 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
-using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 
-namespace SemanticStub.Api.Services;
+namespace SemanticStub.Application.Services;
 
 internal sealed class FormBodyMatcher
 {

--- a/src/SemanticStub.Application/Services/Matching/JsonBodyMatcher.cs
+++ b/src/SemanticStub.Application/Services/Matching/JsonBodyMatcher.cs
@@ -1,8 +1,8 @@
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
-using SemanticStub.Api.Utilities;
+using SemanticStub.Application.Utilities;
 
-namespace SemanticStub.Api.Services;
+namespace SemanticStub.Application.Services;
 
 /// <summary>
 /// Parses request bodies and compares structured JSON body expectations without changing matcher orchestration behavior.

--- a/src/SemanticStub.Application/Services/Matching/MatcherService.cs
+++ b/src/SemanticStub.Application/Services/Matching/MatcherService.cs
@@ -1,8 +1,8 @@
 using System.Text.Json;
 using Microsoft.Extensions.Primitives;
-using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 
-namespace SemanticStub.Api.Services;
+namespace SemanticStub.Application.Services;
 
 /// <summary>
 /// Evaluates <c>x-match</c> candidates and returns the most specific successful match without mutating request or stub state.

--- a/src/SemanticStub.Application/Services/Matching/QueryMatchCandidateEvaluation.cs
+++ b/src/SemanticStub.Application/Services/Matching/QueryMatchCandidateEvaluation.cs
@@ -1,6 +1,6 @@
-using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 
-namespace SemanticStub.Api.Services;
+namespace SemanticStub.Application.Services;
 
 /// <summary>
 /// Describes how one <c>x-match</c> candidate evaluated against request data.

--- a/src/SemanticStub.Application/Services/Matching/QueryMatchSpecificityComparer.cs
+++ b/src/SemanticStub.Application/Services/Matching/QueryMatchSpecificityComparer.cs
@@ -1,7 +1,7 @@
 using System.Collections;
-using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 
-namespace SemanticStub.Api.Services;
+namespace SemanticStub.Application.Services;
 
 internal sealed class QueryMatchSpecificityComparer : IComparer<QueryMatchDefinition>
 {

--- a/src/SemanticStub.Application/Services/Matching/QueryParameterTypeMapBuilder.cs
+++ b/src/SemanticStub.Application/Services/Matching/QueryParameterTypeMapBuilder.cs
@@ -1,6 +1,6 @@
-using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 
-namespace SemanticStub.Api.Services;
+namespace SemanticStub.Application.Services;
 
 internal static class QueryParameterTypeMapBuilder
 {

--- a/src/SemanticStub.Application/Services/Matching/QueryValueMatcher.cs
+++ b/src/SemanticStub.Application/Services/Matching/QueryValueMatcher.cs
@@ -1,9 +1,9 @@
 using System.Collections;
 using System.Globalization;
 using Microsoft.Extensions.Primitives;
-using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 
-namespace SemanticStub.Api.Services;
+namespace SemanticStub.Application.Services;
 
 /// <summary>
 /// Evaluates exact query value matches, including typed comparisons for declared query parameter schemas.

--- a/src/SemanticStub.Application/Services/Matching/RegexQueryMatcher.cs
+++ b/src/SemanticStub.Application/Services/Matching/RegexQueryMatcher.cs
@@ -2,9 +2,9 @@ using System.Collections;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
-using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 
-namespace SemanticStub.Api.Services;
+namespace SemanticStub.Application.Services;
 
 /// <summary>
 /// Evaluates regex match constraints without changing matcher orchestration behavior.

--- a/src/SemanticStub.Application/Services/Scenario/ScenarioService.cs
+++ b/src/SemanticStub.Application/Services/Scenario/ScenarioService.cs
@@ -1,6 +1,6 @@
-using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 
-namespace SemanticStub.Api.Services;
+namespace SemanticStub.Application.Services;
 
 /// <summary>
 /// Stores scenario state transitions in memory so YAML-defined stateful flows can advance deterministically across requests.

--- a/src/SemanticStub.Application/Services/Scenario/ScenarioStateStore.cs
+++ b/src/SemanticStub.Application/Services/Scenario/ScenarioStateStore.cs
@@ -1,7 +1,7 @@
-using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 using System.Collections.Concurrent;
 
-namespace SemanticStub.Api.Services;
+namespace SemanticStub.Application.Services;
 
 /// <summary>
 /// Stores in-memory scenario state snapshots and applies the runtime transition rules used by <see cref="ScenarioService"/>.

--- a/src/SemanticStub.Application/Utilities/StubExampleSerializer.cs
+++ b/src/SemanticStub.Application/Utilities/StubExampleSerializer.cs
@@ -1,6 +1,6 @@
 using System.Text.Json;
 
-namespace SemanticStub.Api.Utilities;
+namespace SemanticStub.Application.Utilities;
 
 /// <summary>
 /// Normalizes YAML-deserialized example values into JSON-friendly shapes so matching and response generation can compare values consistently.

--- a/src/SemanticStub.Infrastructure/Infrastructure/Yaml/SemanticMatchingSettings.cs
+++ b/src/SemanticStub.Infrastructure/Infrastructure/Yaml/SemanticMatchingSettings.cs
@@ -1,4 +1,4 @@
-namespace SemanticStub.Api.Infrastructure.Yaml;
+namespace SemanticStub.Infrastructure.Yaml;
 
 /// <summary>
 /// Configures the optional semantic request matching fallback.

--- a/src/SemanticStub.Infrastructure/Infrastructure/Yaml/StubDefinitionLoader.cs
+++ b/src/SemanticStub.Infrastructure/Infrastructure/Yaml/StubDefinitionLoader.cs
@@ -1,10 +1,11 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Options;
-using SemanticStub.Api.Models;
+using SemanticStub.Application.Infrastructure.Yaml;
+using SemanticStub.Application.Models;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
-namespace SemanticStub.Api.Infrastructure.Yaml;
+namespace SemanticStub.Infrastructure.Yaml;
 
 /// <summary>
 /// Loads OpenAPI-based stub definitions from disk, validates repository-specific constraints, and normalizes file-backed references before the runtime uses the document.

--- a/src/SemanticStub.Infrastructure/Infrastructure/Yaml/StubDefinitionNormalizer.cs
+++ b/src/SemanticStub.Infrastructure/Infrastructure/Yaml/StubDefinitionNormalizer.cs
@@ -1,7 +1,7 @@
-using SemanticStub.Api.Models;
-using SemanticStub.Api.Utilities;
+using SemanticStub.Application.Models;
+using SemanticStub.Application.Utilities;
 
-namespace SemanticStub.Api.Infrastructure.Yaml;
+namespace SemanticStub.Infrastructure.Yaml;
 
 internal sealed class StubDefinitionNormalizer
 {

--- a/src/SemanticStub.Infrastructure/Infrastructure/Yaml/StubDefinitionPathResolver.cs
+++ b/src/SemanticStub.Infrastructure/Infrastructure/Yaml/StubDefinitionPathResolver.cs
@@ -1,4 +1,4 @@
-namespace SemanticStub.Api.Infrastructure.Yaml;
+namespace SemanticStub.Infrastructure.Yaml;
 
 internal static class StubDefinitionPathResolver
 {

--- a/src/SemanticStub.Infrastructure/Infrastructure/Yaml/StubDefinitionState.cs
+++ b/src/SemanticStub.Infrastructure/Infrastructure/Yaml/StubDefinitionState.cs
@@ -1,8 +1,9 @@
 using Microsoft.Extensions.Logging;
-using SemanticStub.Api.Models;
-using SemanticStub.Api.Services;
+using SemanticStub.Application.Infrastructure.Yaml;
+using SemanticStub.Application.Models;
+using SemanticStub.Application.Services;
 
-namespace SemanticStub.Api.Infrastructure.Yaml;
+namespace SemanticStub.Infrastructure.Yaml;
 
 /// <summary>
 /// Holds the current process-wide YAML definition snapshot and swaps it atomically during reloads.

--- a/src/SemanticStub.Infrastructure/Infrastructure/Yaml/StubDefinitionValidator.cs
+++ b/src/SemanticStub.Infrastructure/Infrastructure/Yaml/StubDefinitionValidator.cs
@@ -1,8 +1,8 @@
-using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 using System.Collections;
 using System.Text.RegularExpressions;
 
-namespace SemanticStub.Api.Infrastructure.Yaml;
+namespace SemanticStub.Infrastructure.Yaml;
 
 internal sealed class StubDefinitionValidator
 {

--- a/src/SemanticStub.Infrastructure/Infrastructure/Yaml/StubDefinitionWatcher.cs
+++ b/src/SemanticStub.Infrastructure/Infrastructure/Yaml/StubDefinitionWatcher.cs
@@ -1,7 +1,8 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using SemanticStub.Application.Infrastructure.Yaml;
 
-namespace SemanticStub.Api.Infrastructure.Yaml;
+namespace SemanticStub.Infrastructure.Yaml;
 
 internal sealed class StubDefinitionWatcher : IHostedService, IDisposable
 {

--- a/src/SemanticStub.Infrastructure/Infrastructure/Yaml/StubScenarioNameCollector.cs
+++ b/src/SemanticStub.Infrastructure/Infrastructure/Yaml/StubScenarioNameCollector.cs
@@ -1,6 +1,6 @@
-using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 
-namespace SemanticStub.Api.Infrastructure.Yaml;
+namespace SemanticStub.Infrastructure.Yaml;
 
 internal static class StubScenarioNameCollector
 {

--- a/src/SemanticStub.Infrastructure/Infrastructure/Yaml/StubSettings.cs
+++ b/src/SemanticStub.Infrastructure/Infrastructure/Yaml/StubSettings.cs
@@ -1,4 +1,4 @@
-namespace SemanticStub.Api.Infrastructure.Yaml;
+namespace SemanticStub.Infrastructure.Yaml;
 
 /// <summary>
 /// Configures the YAML stub definition source and optional matching features.

--- a/tests/SemanticStub.Api.Tests/Integration/HttpLoggingTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/HttpLoggingTests.cs
@@ -78,7 +78,7 @@ public sealed class HttpLoggingTests
 
         var configuration = factory.Services.GetRequiredService<IConfiguration>();
 
-        Assert.Equal("Information", configuration["Logging:LogLevel:SemanticStub.Api.Infrastructure.Yaml"]);
+        Assert.Equal("Information", configuration["Logging:LogLevel:SemanticStub.Infrastructure.Yaml"]);
     }
 
     [Fact]

--- a/tests/SemanticStub.Api.Tests/Integration/StubServiceCollectionExtensionsTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/StubServiceCollectionExtensionsTests.cs
@@ -4,7 +4,9 @@ using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using SemanticStub.Api.Extensions;
-using SemanticStub.Api.Infrastructure.Yaml;
+using SemanticStub.Application.Infrastructure.Yaml;
+using SemanticStub.Application.Services;
+using SemanticStub.Infrastructure.Yaml;
 using SemanticStub.Api.Services;
 using Xunit;
 

--- a/tests/SemanticStub.Api.Tests/Unit/Infrastructure/Yaml/StubDefinitionLoaderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Infrastructure/Yaml/StubDefinitionLoaderTests.cs
@@ -1,8 +1,10 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
-using SemanticStub.Api.Infrastructure.Yaml;
+using SemanticStub.Application.Infrastructure.Yaml;
+using SemanticStub.Infrastructure.Yaml;
 using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 using Xunit;
 
 namespace SemanticStub.Api.Tests.Unit.Infrastructure.Yaml;

--- a/tests/SemanticStub.Api.Tests/Unit/Infrastructure/Yaml/StubDefinitionNormalizerTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Infrastructure/Yaml/StubDefinitionNormalizerTests.cs
@@ -1,5 +1,7 @@
-using SemanticStub.Api.Infrastructure.Yaml;
+using SemanticStub.Application.Infrastructure.Yaml;
+using SemanticStub.Infrastructure.Yaml;
 using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 using Xunit;
 
 namespace SemanticStub.Api.Tests.Unit.Infrastructure.Yaml;

--- a/tests/SemanticStub.Api.Tests/Unit/Infrastructure/Yaml/StubDefinitionValidatorTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Infrastructure/Yaml/StubDefinitionValidatorTests.cs
@@ -1,5 +1,7 @@
-using SemanticStub.Api.Infrastructure.Yaml;
+using SemanticStub.Application.Infrastructure.Yaml;
+using SemanticStub.Infrastructure.Yaml;
 using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 using Xunit;
 
 namespace SemanticStub.Api.Tests.Unit.Infrastructure.Yaml;

--- a/tests/SemanticStub.Api.Tests/Unit/Infrastructure/Yaml/StubScenarioNameCollectorTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Infrastructure/Yaml/StubScenarioNameCollectorTests.cs
@@ -1,5 +1,7 @@
-using SemanticStub.Api.Infrastructure.Yaml;
+using SemanticStub.Application.Infrastructure.Yaml;
+using SemanticStub.Infrastructure.Yaml;
 using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 using Xunit;
 
 namespace SemanticStub.Api.Tests.Unit.Infrastructure.Yaml;

--- a/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionProjectionBuilderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionProjectionBuilderTests.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.Primitives;
 using SemanticStub.Api.Inspection;
 using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
+using SemanticStub.Application.Services;
 using SemanticStub.Api.Services;
 using Xunit;
 

--- a/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionServiceTests.cs
@@ -3,8 +3,11 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using SemanticStub.Api.Inspection;
-using SemanticStub.Api.Infrastructure.Yaml;
+using SemanticStub.Application.Infrastructure.Yaml;
+using SemanticStub.Infrastructure.Yaml;
 using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
+using SemanticStub.Application.Services;
 using SemanticStub.Api.Services;
 using Xunit;
 

--- a/tests/SemanticStub.Api.Tests/Unit/Resolution/StubDispatchSelectorTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Resolution/StubDispatchSelectorTests.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
+using SemanticStub.Application.Services;
 using SemanticStub.Api.Services;
 using Xunit;
 

--- a/tests/SemanticStub.Api.Tests/Unit/Resolution/StubOperationResolverTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Resolution/StubOperationResolverTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 using SemanticStub.Api.Services;
 using Xunit;
 

--- a/tests/SemanticStub.Api.Tests/Unit/Resolution/StubResponseBuilderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Resolution/StubResponseBuilderTests.cs
@@ -1,4 +1,5 @@
 using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 using SemanticStub.Api.Services;
 using Xunit;
 

--- a/tests/SemanticStub.Api.Tests/Unit/Resolution/StubResponseHeaderBuilderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Resolution/StubResponseHeaderBuilderTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Primitives;
 using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 using SemanticStub.Api.Services;
 using Xunit;
 

--- a/tests/SemanticStub.Api.Tests/Unit/Resolution/StubRouteResolverTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Resolution/StubRouteResolverTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 using SemanticStub.Api.Services;
 using Xunit;
 

--- a/tests/SemanticStub.Api.Tests/Unit/Resolution/StubServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Resolution/StubServiceTests.cs
@@ -2,8 +2,11 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Primitives;
 using SemanticStub.Api.Inspection;
-using SemanticStub.Api.Infrastructure.Yaml;
+using SemanticStub.Application.Infrastructure.Yaml;
+using SemanticStub.Infrastructure.Yaml;
 using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
+using SemanticStub.Application.Services;
 using SemanticStub.Api.Services;
 using Xunit;
 

--- a/tests/SemanticStub.Api.Tests/Unit/Semantic/SemanticMatcherServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Semantic/SemanticMatcherServiceTests.cs
@@ -6,8 +6,10 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
-using SemanticStub.Api.Infrastructure.Yaml;
+using SemanticStub.Application.Infrastructure.Yaml;
+using SemanticStub.Infrastructure.Yaml;
 using SemanticStub.Api.Models;
+using SemanticStub.Application.Models;
 using SemanticStub.Api.Services;
 using Xunit;
 

--- a/tests/SemanticStub.Application.Tests/Unit/FormBodyMatcherTests.cs
+++ b/tests/SemanticStub.Application.Tests/Unit/FormBodyMatcherTests.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
-using SemanticStub.Api.Services;
+using SemanticStub.Application.Services;
 using Xunit;
 
 namespace SemanticStub.Application.Tests.Unit;

--- a/tests/SemanticStub.Application.Tests/Unit/JsonBodyMatcherTests.cs
+++ b/tests/SemanticStub.Application.Tests/Unit/JsonBodyMatcherTests.cs
@@ -1,4 +1,4 @@
-using SemanticStub.Api.Services;
+using SemanticStub.Application.Services;
 using Xunit;
 
 namespace SemanticStub.Application.Tests.Unit;

--- a/tests/SemanticStub.Application.Tests/Unit/MatcherServiceTests.cs
+++ b/tests/SemanticStub.Application.Tests/Unit/MatcherServiceTests.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.Primitives;
-using SemanticStub.Api.Models;
-using SemanticStub.Api.Services;
+using SemanticStub.Application.Models;
+using SemanticStub.Application.Services;
 using System.Diagnostics;
 using Xunit;
 

--- a/tests/SemanticStub.Application.Tests/Unit/QueryMatchSpecificityComparerTests.cs
+++ b/tests/SemanticStub.Application.Tests/Unit/QueryMatchSpecificityComparerTests.cs
@@ -1,5 +1,5 @@
-using SemanticStub.Api.Models;
-using SemanticStub.Api.Services;
+using SemanticStub.Application.Models;
+using SemanticStub.Application.Services;
 using Xunit;
 
 namespace SemanticStub.Application.Tests.Unit;

--- a/tests/SemanticStub.Application.Tests/Unit/QueryParameterTypeMapBuilderTests.cs
+++ b/tests/SemanticStub.Application.Tests/Unit/QueryParameterTypeMapBuilderTests.cs
@@ -1,5 +1,5 @@
-using SemanticStub.Api.Models;
-using SemanticStub.Api.Services;
+using SemanticStub.Application.Models;
+using SemanticStub.Application.Services;
 using Xunit;
 
 namespace SemanticStub.Application.Tests.Unit;

--- a/tests/SemanticStub.Application.Tests/Unit/QueryValueMatcherTests.cs
+++ b/tests/SemanticStub.Application.Tests/Unit/QueryValueMatcherTests.cs
@@ -1,5 +1,5 @@
 using Microsoft.Extensions.Primitives;
-using SemanticStub.Api.Services;
+using SemanticStub.Application.Services;
 using Xunit;
 
 namespace SemanticStub.Application.Tests.Unit;

--- a/tests/SemanticStub.Application.Tests/Unit/RegexQueryMatcherTests.cs
+++ b/tests/SemanticStub.Application.Tests/Unit/RegexQueryMatcherTests.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
-using SemanticStub.Api.Services;
+using SemanticStub.Application.Services;
 using Xunit;
 
 namespace SemanticStub.Application.Tests.Unit;

--- a/tests/SemanticStub.Application.Tests/Unit/ScenarioServiceTests.cs
+++ b/tests/SemanticStub.Application.Tests/Unit/ScenarioServiceTests.cs
@@ -1,5 +1,5 @@
-using SemanticStub.Api.Services;
-using SemanticStub.Api.Models;
+using SemanticStub.Application.Services;
+using SemanticStub.Application.Models;
 using System.Threading;
 using Xunit;
 

--- a/tests/SemanticStub.Application.Tests/Unit/ScenarioStateStoreTests.cs
+++ b/tests/SemanticStub.Application.Tests/Unit/ScenarioStateStoreTests.cs
@@ -1,5 +1,5 @@
-using SemanticStub.Api.Models;
-using SemanticStub.Api.Services;
+using SemanticStub.Application.Models;
+using SemanticStub.Application.Services;
 using Xunit;
 
 namespace SemanticStub.Application.Tests.Unit;


### PR DESCRIPTION
## Summary
- Rename Application-owned namespaces to `SemanticStub.Application.*`
- Rename Infrastructure YAML namespaces to `SemanticStub.Infrastructure.Yaml`
- Update API imports, tests, and logging category configuration to the new namespaces

## Files Changed
- `src/SemanticStub.Application/**`
- `src/SemanticStub.Infrastructure/**`
- API imports/configuration and related tests

## Tests
- `dotnet test SemanticStub.sln`

## Notes
- No file moves, YAML schema changes, or runtime behavior changes intended.

Closes #237