### PR TITLE
refactor: clarify layer internals boundaries

### DIFF
--- a/src/SemanticStub.Api/Extensions/StubServiceCollectionExtensions.cs
+++ b/src/SemanticStub.Api/Extensions/StubServiceCollectionExtensions.cs
@@ -1,7 +1,9 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using SemanticStub.Application.Extensions;
 using SemanticStub.Application.Infrastructure.Yaml;
 using SemanticStub.Application.Services;
+using SemanticStub.Infrastructure.Extensions;
 using SemanticStub.Infrastructure.Yaml;
 using SemanticStub.Api.Services;
 
@@ -22,11 +24,9 @@ public static class StubServiceCollectionExtensions
         // Keep resolution registration in this chain because inspection resolves IStubService lazily.
         return services
             .AddSemanticMatchingServices()
+            .AddApplicationServices()
             .AddYamlInfrastructureServices()
             .AddInspectionServices()
-            .AddHostedReloadServices()
-            .AddMatchingServices()
-            .AddScenarioServices()
             .AddResolutionServices();
     }
 
@@ -46,15 +46,6 @@ public static class StubServiceCollectionExtensions
         return services;
     }
 
-    private static IServiceCollection AddYamlInfrastructureServices(this IServiceCollection services)
-    {
-        services.AddSingleton<IStubDefinitionLoader, StubDefinitionLoader>();
-        // The loaded YAML definition is process-wide runtime state and is replaced atomically on reload.
-        services.AddSingleton<StubDefinitionState>();
-
-        return services;
-    }
-
     private static IServiceCollection AddInspectionServices(this IServiceCollection services)
     {
         // Runtime inspection metrics and recent request history are process-wide by design.
@@ -67,39 +58,6 @@ public static class StubServiceCollectionExtensions
             serviceProvider.GetRequiredService<IStubService>(),
             serviceProvider.GetRequiredService<StubInspectionRuntimeStore>(),
             serviceProvider.GetRequiredService<StubInspectionScenarioCoordinator>()));
-
-        return services;
-    }
-
-    private static IServiceCollection AddHostedReloadServices(this IServiceCollection services)
-    {
-        services.AddHostedService<StubDefinitionWatcher>();
-
-        return services;
-    }
-
-    private static IServiceCollection AddMatchingServices(this IServiceCollection services)
-    {
-        services.AddSingleton(serviceProvider => new JsonBodyMatcher(
-            serviceProvider.GetRequiredService<ILogger<JsonBodyMatcher>>()));
-        services.AddSingleton(serviceProvider => new FormBodyMatcher(
-            serviceProvider.GetRequiredService<ILogger<FormBodyMatcher>>()));
-        services.AddSingleton<QueryValueMatcher>();
-        services.AddSingleton(serviceProvider => new RegexQueryMatcher(
-            serviceProvider.GetRequiredService<ILogger<RegexQueryMatcher>>()));
-        services.AddSingleton<MatcherService>(serviceProvider => new MatcherService(
-            serviceProvider.GetRequiredService<JsonBodyMatcher>(),
-            serviceProvider.GetRequiredService<FormBodyMatcher>(),
-            serviceProvider.GetRequiredService<QueryValueMatcher>(),
-            serviceProvider.GetRequiredService<RegexQueryMatcher>()));
-
-        return services;
-    }
-
-    private static IServiceCollection AddScenarioServices(this IServiceCollection services)
-    {
-        // YAML scenario progress is shared across requests for the current process.
-        services.AddSingleton<ScenarioService>();
 
         return services;
     }

--- a/src/SemanticStub.Application/Extensions/ApplicationServiceCollectionExtensions.cs
+++ b/src/SemanticStub.Application/Extensions/ApplicationServiceCollectionExtensions.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using SemanticStub.Application.Services;
+
+namespace SemanticStub.Application.Extensions;
+
+/// <summary>
+/// Registers application-layer services for matching and scenario state management.
+/// </summary>
+public static class ApplicationServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds the application services required by the stub runtime.
+    /// </summary>
+    /// <param name="services">The service collection to extend.</param>
+    /// <returns>The same service collection for chaining.</returns>
+    public static IServiceCollection AddApplicationServices(this IServiceCollection services)
+    {
+        services.AddSingleton(serviceProvider => new JsonBodyMatcher(
+            serviceProvider.GetRequiredService<ILogger<JsonBodyMatcher>>()));
+        services.AddSingleton(serviceProvider => new FormBodyMatcher(
+            serviceProvider.GetRequiredService<ILogger<FormBodyMatcher>>()));
+        services.AddSingleton<QueryValueMatcher>();
+        services.AddSingleton(serviceProvider => new RegexQueryMatcher(
+            serviceProvider.GetRequiredService<ILogger<RegexQueryMatcher>>()));
+        services.AddSingleton<MatcherService>(serviceProvider => new MatcherService(
+            serviceProvider.GetRequiredService<JsonBodyMatcher>(),
+            serviceProvider.GetRequiredService<FormBodyMatcher>(),
+            serviceProvider.GetRequiredService<QueryValueMatcher>(),
+            serviceProvider.GetRequiredService<RegexQueryMatcher>()));
+
+        // YAML scenario progress is shared across requests for the current process.
+        services.AddSingleton<ScenarioService>();
+
+        return services;
+    }
+}

--- a/src/SemanticStub.Application/Models/MatchOperatorDefinition.cs
+++ b/src/SemanticStub.Application/Models/MatchOperatorDefinition.cs
@@ -2,15 +2,34 @@ using System.Collections;
 
 namespace SemanticStub.Application.Models;
 
-internal static class MatchOperatorDefinition
+/// <summary>
+/// Defines supported structured match operators used by YAML validation and request matching.
+/// </summary>
+public static class MatchOperatorDefinition
 {
+    /// <summary>
+    /// The operator key for exact value comparisons.
+    /// </summary>
     public const string EqualsOperator = "equals";
+
+    /// <summary>
+    /// The operator key for regular expression comparisons.
+    /// </summary>
     public const string RegexOperator = "regex";
 
+    /// <summary>
+    /// Returns whether the supplied value is a map containing at least one supported match operator.
+    /// </summary>
+    /// <param name="value">The YAML value to inspect.</param>
     public static bool IsOperatorMap(object? value)
         => TryGetMap(value, out var map) &&
            (map.ContainsKey(EqualsOperator) || map.ContainsKey(RegexOperator));
 
+    /// <summary>
+    /// Attempts to extract the exact comparison value from a structured operator map or raw value.
+    /// </summary>
+    /// <param name="value">The YAML value to inspect.</param>
+    /// <param name="equals">The extracted exact comparison value.</param>
     public static bool TryGetEquals(object? value, out object? equals)
     {
         if (TryGetMap(value, out var map) && map.TryGetValue(EqualsOperator, out equals))
@@ -28,6 +47,11 @@ internal static class MatchOperatorDefinition
         return true;
     }
 
+    /// <summary>
+    /// Attempts to extract the regular expression comparison value from a structured operator map.
+    /// </summary>
+    /// <param name="value">The YAML value to inspect.</param>
+    /// <param name="regex">The extracted regular expression comparison value.</param>
     public static bool TryGetRegex(object? value, out object? regex)
     {
         if (TryGetMap(value, out var map) && map.TryGetValue(RegexOperator, out regex))
@@ -39,6 +63,10 @@ internal static class MatchOperatorDefinition
         return false;
     }
 
+    /// <summary>
+    /// Returns all keys from a structured operator map, including unsupported keys for validation diagnostics.
+    /// </summary>
+    /// <param name="value">The YAML value to inspect.</param>
     public static IReadOnlyCollection<string> GetKeys(object? value)
     {
         if (!TryGetMap(value, out var map))

--- a/src/SemanticStub.Application/Properties/AssemblyInfo.cs
+++ b/src/SemanticStub.Application/Properties/AssemblyInfo.cs
@@ -1,6 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("SemanticStub.Application.Tests")]
-[assembly: InternalsVisibleTo("SemanticStub.Api")]
 [assembly: InternalsVisibleTo("SemanticStub.Api.Tests")]
-[assembly: InternalsVisibleTo("SemanticStub.Infrastructure")]

--- a/src/SemanticStub.Application/Services/Scenario/ScenarioService.cs
+++ b/src/SemanticStub.Application/Services/Scenario/ScenarioService.cs
@@ -93,17 +93,31 @@ public sealed class ScenarioService
         ExecuteLockedWithTimestamp(timestamp => ResetScenariosWithinLock(scenarioNames, timestamp));
     }
 
-    internal ScenarioStateSnapshot GetSnapshotWithinLock(string scenarioName)
+    /// <summary>
+    /// Returns a scenario snapshot while the caller already holds the scenario lock.
+    /// </summary>
+    /// <param name="scenarioName">The scenario name defined in YAML.</param>
+    public ScenarioStateSnapshot GetSnapshotWithinLock(string scenarioName)
     {
         return _stateStore.GetSnapshot(scenarioName);
     }
 
-    internal void ResetScenarioWithinLock(string scenarioName, DateTimeOffset timestamp)
+    /// <summary>
+    /// Resets the supplied scenario while the caller already holds the scenario lock.
+    /// </summary>
+    /// <param name="scenarioName">The scenario name defined in YAML.</param>
+    /// <param name="timestamp">The timestamp to assign to the reset state.</param>
+    public void ResetScenarioWithinLock(string scenarioName, DateTimeOffset timestamp)
     {
         _stateStore.ResetScenario(scenarioName, timestamp);
     }
 
-    internal void ResetScenariosWithinLock(IEnumerable<string> scenarioNames, DateTimeOffset timestamp)
+    /// <summary>
+    /// Resets the supplied scenarios while the caller already holds the scenario lock.
+    /// </summary>
+    /// <param name="scenarioNames">The scenario names defined in YAML.</param>
+    /// <param name="timestamp">The timestamp to assign to each reset state.</param>
+    public void ResetScenariosWithinLock(IEnumerable<string> scenarioNames, DateTimeOffset timestamp)
     {
         _stateStore.ResetScenarios(scenarioNames, timestamp);
     }

--- a/src/SemanticStub.Infrastructure/Extensions/YamlInfrastructureServiceCollectionExtensions.cs
+++ b/src/SemanticStub.Infrastructure/Extensions/YamlInfrastructureServiceCollectionExtensions.cs
@@ -1,0 +1,26 @@
+using Microsoft.Extensions.DependencyInjection;
+using SemanticStub.Application.Infrastructure.Yaml;
+using SemanticStub.Infrastructure.Yaml;
+
+namespace SemanticStub.Infrastructure.Extensions;
+
+/// <summary>
+/// Registers infrastructure services for YAML definition loading and reload monitoring.
+/// </summary>
+public static class YamlInfrastructureServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds YAML infrastructure services required by the stub runtime.
+    /// </summary>
+    /// <param name="services">The service collection to extend.</param>
+    /// <returns>The same service collection for chaining.</returns>
+    public static IServiceCollection AddYamlInfrastructureServices(this IServiceCollection services)
+    {
+        services.AddSingleton<IStubDefinitionLoader, StubDefinitionLoader>();
+        // The loaded YAML definition is process-wide runtime state and is replaced atomically on reload.
+        services.AddSingleton<StubDefinitionState>();
+        services.AddHostedService<StubDefinitionWatcher>();
+
+        return services;
+    }
+}

--- a/src/SemanticStub.Infrastructure/Infrastructure/Yaml/StubDefinitionState.cs
+++ b/src/SemanticStub.Infrastructure/Infrastructure/Yaml/StubDefinitionState.cs
@@ -8,7 +8,7 @@ namespace SemanticStub.Infrastructure.Yaml;
 /// <summary>
 /// Holds the current process-wide YAML definition snapshot and swaps it atomically during reloads.
 /// </summary>
-internal sealed class StubDefinitionState
+public sealed class StubDefinitionState
 {
     private readonly IStubDefinitionLoader _loader;
     private readonly ScenarioService _scenarioService;
@@ -16,6 +16,12 @@ internal sealed class StubDefinitionState
     private readonly object _syncRoot = new();
     private StubDocument _currentDocument;
 
+    /// <summary>
+    /// Initializes the process-wide definition state from the default YAML definition.
+    /// </summary>
+    /// <param name="loader">The YAML definition loader used for initial load, reload, and response file content.</param>
+    /// <param name="scenarioService">The scenario state service reset when definitions are reloaded.</param>
+    /// <param name="logger">The logger used for reload diagnostics.</param>
     public StubDefinitionState(IStubDefinitionLoader loader, ScenarioService scenarioService, ILogger<StubDefinitionState> logger)
     {
         _loader = loader;
@@ -24,16 +30,27 @@ internal sealed class StubDefinitionState
         _currentDocument = loader.LoadDefaultDefinition();
     }
 
+    /// <summary>
+    /// Returns the currently active stub document snapshot.
+    /// </summary>
     public StubDocument GetCurrentDocument()
     {
         return Volatile.Read(ref _currentDocument);
     }
 
+    /// <summary>
+    /// Loads response file content relative to the configured YAML definition root.
+    /// </summary>
+    /// <param name="fileName">The response file name referenced from YAML.</param>
     public string LoadResponseFileContent(string fileName)
     {
         return _loader.LoadResponseFileContent(fileName);
     }
 
+    /// <summary>
+    /// Attempts to reload YAML definitions and keeps the previous snapshot if reload fails.
+    /// </summary>
+    /// <returns><see langword="true"/> when reload succeeds; otherwise, <see langword="false"/>.</returns>
     public bool TryReload()
     {
         lock (_syncRoot)

--- a/src/SemanticStub.Infrastructure/Properties/AssemblyInfo.cs
+++ b/src/SemanticStub.Infrastructure/Properties/AssemblyInfo.cs
@@ -1,4 +1,3 @@
 using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("SemanticStub.Api")]
 [assembly: InternalsVisibleTo("SemanticStub.Api.Tests")]


### PR DESCRIPTION
## Summary
- Move Application and Infrastructure DI registrations into layer-specific public extensions.
- Remove production InternalsVisibleTo entries while keeping test-only friend assemblies.
- Make the cross-layer contracts used by Infrastructure/API explicit with public APIs and XML docs.

## Files Changed
- Application DI registration, match operator definition, scenario service boundary, and AssemblyInfo.
- Infrastructure YAML DI registration, definition state boundary, and AssemblyInfo.
- API service registration now composes layer extensions instead of direct internal registrations.

## Tests
- dotnet build SemanticStub.sln
- dotnet test SemanticStub.sln --no-build
- dotnet format SemanticStub.sln --verify-no-changes --no-restore
- git diff --check

## Notes
Closes #241