### PR TITLE
fix: disable request and response body logging by default

### DIFF
--- a/src/SemanticStub.Api/Program.cs
+++ b/src/SemanticStub.Api/Program.cs
@@ -43,9 +43,7 @@ static void ConfigureHttpLoggingDefaults(HttpLoggingOptions options)
 {
     options.LoggingFields =
         HttpLoggingFields.RequestPropertiesAndHeaders |
-        HttpLoggingFields.ResponsePropertiesAndHeaders |
-        HttpLoggingFields.RequestBody |
-        HttpLoggingFields.ResponseBody;
+        HttpLoggingFields.ResponsePropertiesAndHeaders;
 }
 
 static void ConfigureHttpLoggingMediaTypes(HttpLoggingOptions options)

--- a/src/SemanticStub.Api/appsettings.Development.json
+++ b/src/SemanticStub.Api/appsettings.Development.json
@@ -1,5 +1,6 @@
 {
   "HttpLogging": {
+    "LoggingFields": "RequestPropertiesAndHeaders, ResponsePropertiesAndHeaders, RequestBody, ResponseBody",
     "RequestBodyLogLimit": 4096,
     "ResponseBodyLogLimit": 4096
   },

--- a/src/SemanticStub.Api/appsettings.json
+++ b/src/SemanticStub.Api/appsettings.json
@@ -1,8 +1,4 @@
 {
-  "HttpLogging": {
-    "RequestBodyLogLimit": 1024,
-    "ResponseBodyLogLimit": 1024
-  },
   "Logging": {
     "LogLevel": {
       "Default": "Warning",

--- a/tests/SemanticStub.Api.Tests/Integration/HttpLoggingTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/HttpLoggingTests.cs
@@ -11,20 +11,30 @@ namespace SemanticStub.Api.Tests.Integration;
 
 public sealed class HttpLoggingTests
 {
-    [Theory]
-    [InlineData("Development", 4096)]
-    [InlineData("Production", 1024)]
-    public void CreateClient_ConfiguresBodyLogLimitsPerEnvironment(string environmentName, int expectedLimit)
+    [Fact]
+    public void CreateClient_DefaultLogging_DoesNotIncludeBodyFields()
     {
-        using var factory = new HttpLoggingFactory(environmentName);
+        using var factory = new HttpLoggingFactory("Production");
         using var client = factory.CreateClient();
 
         var options = factory.Services.GetRequiredService<IOptions<HttpLoggingOptions>>().Value;
 
-        Assert.Equal(expectedLimit, options.RequestBodyLogLimit);
-        Assert.Equal(expectedLimit, options.ResponseBodyLogLimit);
+        Assert.False(options.LoggingFields.HasFlag(HttpLoggingFields.RequestBody));
+        Assert.False(options.LoggingFields.HasFlag(HttpLoggingFields.ResponseBody));
+    }
+
+    [Fact]
+    public void CreateClient_DevelopmentLogging_IncludesBodyFieldsWithLimits()
+    {
+        using var factory = new HttpLoggingFactory("Development");
+        using var client = factory.CreateClient();
+
+        var options = factory.Services.GetRequiredService<IOptions<HttpLoggingOptions>>().Value;
+
         Assert.True(options.LoggingFields.HasFlag(HttpLoggingFields.RequestBody));
         Assert.True(options.LoggingFields.HasFlag(HttpLoggingFields.ResponseBody));
+        Assert.Equal(4096, options.RequestBodyLogLimit);
+        Assert.Equal(4096, options.ResponseBodyLogLimit);
     }
 
     [Fact]
@@ -124,6 +134,12 @@ public sealed class HttpLoggingTests
             if (!string.IsNullOrEmpty(contentRootPath))
             {
                 builder.UseContentRoot(contentRootPath);
+                builder.ConfigureAppConfiguration((_, cfg) =>
+                {
+                    var baseDir = AppContext.BaseDirectory;
+                    cfg.AddJsonFile(Path.Combine(baseDir, "appsettings.json"), optional: true);
+                    cfg.AddJsonFile(Path.Combine(baseDir, $"appsettings.{environmentName}.json"), optional: true);
+                });
             }
 
             if (loggerProvider is null)


### PR DESCRIPTION
## Summary
- Remove `RequestBody` and `ResponseBody` from the default `HttpLoggingFields` in `Program.cs`
- Remove body log limits from `appsettings.json` (no longer applicable as default)
- Add `LoggingFields` opt-in to `appsettings.Development.json` to preserve diagnostic logging in development
- Update `HttpLoggingTests` to verify Production excludes body fields and Development includes them via config

## Files Changed
- `src/SemanticStub.Api/Program.cs` — remove body flags from `ConfigureHttpLoggingDefaults`
- `src/SemanticStub.Api/appsettings.json` — remove `HttpLogging` section
- `src/SemanticStub.Api/appsettings.Development.json` — add `LoggingFields` opt-in with body logging
- `tests/SemanticStub.Api.Tests/Integration/HttpLoggingTests.cs` — replace theory test with two focused facts; fix appsettings loading for workspace-based tests

## Tests
All 396 tests pass (`dotnet test`).

## Notes
Body logging is now opt-in via environment-specific configuration. The existing `builder.Configuration.GetSection("HttpLogging").Bind(options)` mechanism handles the override without new abstractions.

Closes #232