### PR TITLE
feat: validate StubSettings at startup

### DIFF
--- a/src/SemanticStub.Api/Program.cs
+++ b/src/SemanticStub.Api/Program.cs
@@ -24,7 +24,23 @@ builder.Services.Configure<GzipCompressionProviderOptions>(options =>
 {
     options.Level = CompressionLevel.Fastest;
 });
-builder.Services.Configure<StubSettings>(builder.Configuration.GetSection("StubSettings"));
+builder.Services.AddOptions<StubSettings>()
+    .BindConfiguration("StubSettings")
+    .Validate(
+        s => !s.SemanticMatching.Enabled
+             || (!string.IsNullOrWhiteSpace(s.SemanticMatching.Endpoint)
+                 && Uri.TryCreate(s.SemanticMatching.Endpoint, UriKind.Absolute, out _)),
+        "SemanticMatching.Endpoint must be a non-empty absolute URI when semantic matching is enabled.")
+    .Validate(
+        s => s.SemanticMatching.TimeoutSeconds > 0,
+        "SemanticMatching.TimeoutSeconds must be positive.")
+    .Validate(
+        s => s.SemanticMatching.Threshold is >= -1.0 and <= 1.0,
+        "SemanticMatching.Threshold must be within the cosine similarity range [-1.0, 1.0].")
+    .Validate(
+        s => s.SemanticMatching.TopScoreMargin >= 0,
+        "SemanticMatching.TopScoreMargin must be non-negative.")
+    .ValidateOnStart();
 builder.Services.AddStubServices();
 
 var app = builder.Build();

--- a/src/SemanticStub.Api/Program.cs
+++ b/src/SemanticStub.Api/Program.cs
@@ -29,8 +29,9 @@ builder.Services.AddOptions<StubSettings>()
     .Validate(
         s => !s.SemanticMatching.Enabled
              || (!string.IsNullOrWhiteSpace(s.SemanticMatching.Endpoint)
-                 && Uri.TryCreate(s.SemanticMatching.Endpoint, UriKind.Absolute, out _)),
-        "SemanticMatching.Endpoint must be a non-empty absolute URI when semantic matching is enabled.")
+                 && Uri.TryCreate(s.SemanticMatching.Endpoint, UriKind.Absolute, out var uri)
+                 && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)),
+        "SemanticMatching.Endpoint must be a non-empty absolute HTTP or HTTPS URI when semantic matching is enabled.")
     .Validate(
         s => s.SemanticMatching.TimeoutSeconds > 0,
         "SemanticMatching.TimeoutSeconds must be positive.")

--- a/tests/SemanticStub.Api.Tests/Integration/StartupValidationTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/StartupValidationTests.cs
@@ -1,11 +1,97 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
 using Xunit;
 
 namespace SemanticStub.Api.Tests.Integration;
 
 public sealed class StartupValidationTests
 {
+    [Fact]
+    public void CreateClient_ThrowsWhenSemanticMatchingEnabledWithEmptyEndpoint()
+    {
+        using var factory = new SettingsFactory([
+            KeyValuePair.Create<string, string?>("StubSettings:SemanticMatching:Enabled", "true"),
+            KeyValuePair.Create<string, string?>("StubSettings:SemanticMatching:Endpoint", ""),
+        ]);
+
+        var exception = Record.Exception(() => factory.CreateClient());
+
+        Assert.NotNull(exception);
+        Assert.Contains("non-empty absolute URI", exception.ToString());
+    }
+
+    [Fact]
+    public void CreateClient_ThrowsWhenSemanticMatchingEnabledWithRelativeEndpoint()
+    {
+        using var factory = new SettingsFactory([
+            KeyValuePair.Create<string, string?>("StubSettings:SemanticMatching:Enabled", "true"),
+            KeyValuePair.Create<string, string?>("StubSettings:SemanticMatching:Endpoint", "relative/path"),
+        ]);
+
+        var exception = Record.Exception(() => factory.CreateClient());
+
+        Assert.NotNull(exception);
+        Assert.Contains("non-empty absolute URI", exception.ToString());
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-1")]
+    public void CreateClient_ThrowsWhenTimeoutSecondsIsNotPositive(string value)
+    {
+        using var factory = new SettingsFactory([
+            KeyValuePair.Create<string, string?>("StubSettings:SemanticMatching:TimeoutSeconds", value),
+        ]);
+
+        var exception = Record.Exception(() => factory.CreateClient());
+
+        Assert.NotNull(exception);
+        Assert.Contains("must be positive", exception.ToString());
+    }
+
+    [Fact]
+    public void CreateClient_ThrowsWhenThresholdIsOutOfRange()
+    {
+        using var factory = new SettingsFactory([
+            KeyValuePair.Create<string, string?>("StubSettings:SemanticMatching:Threshold", "1.5"),
+        ]);
+
+        var exception = Record.Exception(() => factory.CreateClient());
+
+        Assert.NotNull(exception);
+        Assert.Contains("cosine similarity range", exception.ToString());
+    }
+
+    [Fact]
+    public void CreateClient_ThrowsWhenTopScoreMarginIsNegative()
+    {
+        using var factory = new SettingsFactory([
+            KeyValuePair.Create<string, string?>("StubSettings:SemanticMatching:TopScoreMargin", "-0.1"),
+        ]);
+
+        var exception = Record.Exception(() => factory.CreateClient());
+
+        Assert.NotNull(exception);
+        Assert.Contains("non-negative", exception.ToString());
+    }
+
+    [Fact]
+    public void CreateClient_SucceedsWhenSemanticMatchingEnabledWithValidAbsoluteEndpoint()
+    {
+        using var factory = new SettingsFactory([
+            KeyValuePair.Create<string, string?>("StubSettings:SemanticMatching:Enabled", "true"),
+            KeyValuePair.Create<string, string?>("StubSettings:SemanticMatching:Endpoint", "http://localhost:8080"),
+            KeyValuePair.Create<string, string?>("StubSettings:SemanticMatching:TimeoutSeconds", "30"),
+            KeyValuePair.Create<string, string?>("StubSettings:SemanticMatching:Threshold", "0.85"),
+            KeyValuePair.Create<string, string?>("StubSettings:SemanticMatching:TopScoreMargin", "0"),
+        ]);
+
+        var exception = Record.Exception(() => factory.CreateClient());
+
+        Assert.Null(exception);
+    }
+
     [Fact]
     public void CreateClient_ThrowsWhenStubDefinitionIsInvalidAtStartup()
     {
@@ -28,6 +114,15 @@ public sealed class StartupValidationTests
         var exception = Assert.Throws<InvalidOperationException>(() => factory.CreateClient());
 
         Assert.Contains("The 'openapi' field is required.", exception.ToString());
+    }
+
+    private sealed class SettingsFactory(IEnumerable<KeyValuePair<string, string?>> config)
+        : WebApplicationFactory<Program>
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.ConfigureAppConfiguration(c => c.AddInMemoryCollection(config));
+        }
     }
 
     private sealed class InvalidStubFactory(string contentRootPath) : WebApplicationFactory<Program>

--- a/tests/SemanticStub.Api.Tests/Integration/StartupValidationTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/StartupValidationTests.cs
@@ -18,7 +18,7 @@ public sealed class StartupValidationTests
         var exception = Record.Exception(() => factory.CreateClient());
 
         Assert.NotNull(exception);
-        Assert.Contains("non-empty absolute URI", exception.ToString());
+        Assert.Contains("non-empty absolute HTTP or HTTPS URI", exception.ToString());
     }
 
     [Fact]
@@ -32,7 +32,21 @@ public sealed class StartupValidationTests
         var exception = Record.Exception(() => factory.CreateClient());
 
         Assert.NotNull(exception);
-        Assert.Contains("non-empty absolute URI", exception.ToString());
+        Assert.Contains("non-empty absolute HTTP or HTTPS URI", exception.ToString());
+    }
+
+    [Fact]
+    public void CreateClient_ThrowsWhenSemanticMatchingEnabledWithUnsupportedScheme()
+    {
+        using var factory = new SettingsFactory([
+            KeyValuePair.Create<string, string?>("StubSettings:SemanticMatching:Enabled", "true"),
+            KeyValuePair.Create<string, string?>("StubSettings:SemanticMatching:Endpoint", "ftp://host/embed"),
+        ]);
+
+        var exception = Record.Exception(() => factory.CreateClient());
+
+        Assert.NotNull(exception);
+        Assert.Contains("non-empty absolute HTTP or HTTPS URI", exception.ToString());
     }
 
     [Theory]


### PR DESCRIPTION
## Summary
- Replace `services.Configure<StubSettings>()` with `AddOptions<StubSettings>().BindConfiguration().Validate().ValidateOnStart()` to enforce fail-fast validation at startup
- Validates that semantic matching requires a non-empty absolute URI endpoint when enabled, `TimeoutSeconds` is positive, `Threshold` is within `[-1.0, 1.0]`, and `TopScoreMargin` is non-negative
- Closes #230

## Files Changed
- `src/SemanticStub.Api/Program.cs` — switched to `AddOptions` with 4 chained `Validate()` calls and `ValidateOnStart()`
- `tests/SemanticStub.Api.Tests/Integration/StartupValidationTests.cs` — added 7 new test cases and a shared `SettingsFactory` inner class

## Tests
All 403 tests pass. New tests cover:
- Empty endpoint with semantic matching enabled → throws
- Relative endpoint with semantic matching enabled → throws
- `TimeoutSeconds=0` and `-1` → throws
- `Threshold=1.5` (out of cosine similarity range) → throws
- `TopScoreMargin=-0.1` → throws
- All valid values with semantic matching enabled → succeeds

## Notes
- `AddOptions<T>().BindConfiguration()` is fully equivalent to `Configure<T>()` for consumers using `IOptions<StubSettings>`; no other files need to change
- `appsettings.Development.json` sets `Endpoint=http://localhost:8081`, so the empty-endpoint test explicitly overrides the `Endpoint` key to `""` via in-memory config