### PR TITLE
fix: narrow catch-all to expected exceptions in SemanticMatcherService

### DIFF
--- a/src/SemanticStub.Application/Services/Semantic/SemanticMatcherService.cs
+++ b/src/SemanticStub.Application/Services/Semantic/SemanticMatcherService.cs
@@ -107,11 +107,11 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
                 normalizedMethod);
             return CreateFailedExplanation(semanticSettings);
         }
-        catch (Exception ex)
+        catch (InvalidOperationException ex)
         {
-            _logger.LogError(
+            _logger.LogWarning(
                 ex,
-                "Semantic matching encountered an unexpected error for '{Path}' {Method}. Treating the request as a non-match.",
+                "Semantic matching failed for '{Path}' {Method}: the embedding endpoint returned an unexpected response. Treating the request as a non-match.",
                 path,
                 normalizedMethod);
             return CreateFailedExplanation(semanticSettings);

--- a/src/SemanticStub.Infrastructure/Semantic/SemanticEmbeddingClient.cs
+++ b/src/SemanticStub.Infrastructure/Semantic/SemanticEmbeddingClient.cs
@@ -41,15 +41,26 @@ internal sealed class SemanticEmbeddingClient : ISemanticEmbeddingClient
         var response = await httpClient.PostAsJsonAsync(endpoint, new EmbedRequest(inputs));
         response.EnsureSuccessStatusCode();
 
-        using var responseStream = await response.Content.ReadAsStreamAsync();
-        using var document = await JsonDocument.ParseAsync(responseStream);
-
-        if (TryReadEmbeddings(document.RootElement, inputs.Count, out var embeddings))
+        try
         {
-            return embeddings;
-        }
+            using var responseStream = await response.Content.ReadAsStreamAsync();
+            using var document = await JsonDocument.ParseAsync(responseStream);
 
-        throw new InvalidOperationException("The embedding endpoint returned an unexpected response shape.");
+            if (TryReadEmbeddings(document.RootElement, inputs.Count, out var embeddings))
+            {
+                return embeddings;
+            }
+
+            throw new InvalidOperationException("The embedding endpoint returned an unexpected response shape.");
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException("The embedding endpoint returned an invalid JSON response.", ex);
+        }
+        catch (FormatException ex)
+        {
+            throw new InvalidOperationException("The embedding endpoint returned an invalid numeric value.", ex);
+        }
     }
 
     private static bool TryReadEmbeddings(JsonElement root, int expectedCount, out IReadOnlyList<float[]> embeddings)

--- a/tests/SemanticStub.Api.Tests/Unit/Semantic/SemanticMatcherServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Semantic/SemanticMatcherServiceTests.cs
@@ -126,6 +126,39 @@ public sealed class SemanticMatcherServiceTests
     }
 
     [Fact]
+    public async Task ExplainMatchAsync_ReturnsAttemptedNonMatchWhenEmbeddingResponseIsInvalidJson()
+    {
+        var service = CreateService(
+            new StubSettings
+            {
+                SemanticMatching = new SemanticMatchingSettings
+                {
+                    Enabled = true,
+                    Endpoint = "http://tei",
+                    Threshold = 0.8d,
+                    TopScoreMargin = 0.03d
+                }
+            },
+            (_, _) => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("not-valid-json", Encoding.UTF8, "application/json")
+            });
+
+        var explanation = await service.ExplainMatchAsync(
+            "POST",
+            "/search",
+            new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            "admin search",
+            [CreateCandidate("find admin users")]);
+
+        Assert.True(explanation.Attempted);
+        Assert.Null(explanation.SelectedCandidate);
+        Assert.Equal(0.8d, explanation.Threshold);
+        Assert.Equal(0.03d, explanation.RequiredMargin);
+    }
+
+    [Fact]
     public async Task ExplainMatchAsync_PropagatesUnexpectedExceptions()
     {
         var service = CreateService(

--- a/tests/SemanticStub.Api.Tests/Unit/Semantic/SemanticMatcherServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Semantic/SemanticMatcherServiceTests.cs
@@ -126,6 +126,29 @@ public sealed class SemanticMatcherServiceTests
     }
 
     [Fact]
+    public async Task ExplainMatchAsync_PropagatesUnexpectedExceptions()
+    {
+        var service = CreateService(
+            new StubSettings
+            {
+                SemanticMatching = new SemanticMatchingSettings
+                {
+                    Enabled = true,
+                    Endpoint = "http://tei"
+                }
+            },
+            (_, _) => throw new ArgumentNullException("Unexpected bug"));
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => service.ExplainMatchAsync(
+            "POST",
+            "/search",
+            new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            "admin search",
+            [CreateCandidate("find admin users")]));
+    }
+
+    [Fact]
     public async Task ExplainMatchAsync_ReturnsNullSelectedCandidateWhenBestScoreIsBelowThreshold()
     {
         var service = CreateService(


### PR DESCRIPTION
## Summary

- Replace `catch (Exception)` with `catch (InvalidOperationException)` in `SemanticMatcherService.ExplainMatchAsync` so unexpected exceptions propagate to the centralized handler instead of being silently swallowed as non-matches
- `HttpRequestException` and `TaskCanceledException` handling is unchanged
- Log level for the invalid-response-shape case changed from `Error` to `Warning` (it is an expected external dependency failure, not a bug)
- Wrap `JsonException` and `FormatException` inside `SemanticEmbeddingClient` as `InvalidOperationException` to keep the documented contract consistent — malformed JSON or out-of-range float values from the endpoint now correctly result in a non-match instead of a 500

## Files Changed

- `src/SemanticStub.Application/Services/Semantic/SemanticMatcherService.cs` — narrowed catch block
- `src/SemanticStub.Infrastructure/Semantic/SemanticEmbeddingClient.cs` — wrap `JsonException`/`FormatException` as `InvalidOperationException`
- `tests/SemanticStub.Api.Tests/Unit/Semantic/SemanticMatcherServiceTests.cs` — added `ExplainMatchAsync_PropagatesUnexpectedExceptions` and `ExplainMatchAsync_ReturnsAttemptedNonMatchWhenEmbeddingResponseIsInvalidJson`

## Tests

All 19 tests pass (17 existing + 2 new regression tests).

## Notes

Closes #231