### PR TITLE
feat: propagate CancellationToken through request dispatch and semantic HTTP calls

### DIFF
--- a/src/SemanticStub.Api/Controllers/StubController.cs
+++ b/src/SemanticStub.Api/Controllers/StubController.cs
@@ -102,7 +102,7 @@ public sealed class StubController : ControllerBase
         var query = Request.Query.ToDictionary(entry => entry.Key, entry => entry.Value, StringComparer.Ordinal);
         var headers = Request.Headers.ToDictionary(entry => entry.Key, entry => entry.Value.ToString(), StringComparer.OrdinalIgnoreCase);
         var requestBody = await StubRequestBodyReader.ReadAsync(Request, _logger);
-        return await _stubService.DispatchAsync(method, requestPath, query, headers, requestBody);
+        return await _stubService.DispatchAsync(method, requestPath, query, headers, requestBody, HttpContext.RequestAborted);
     }
 
     private async Task<IActionResult> CreateActionResultAsync(StubDispatchResult dispatch, string requestPath, Action<int> setStatusCode)

--- a/src/SemanticStub.Api/Controllers/StubInspectionController.cs
+++ b/src/SemanticStub.Api/Controllers/StubInspectionController.cs
@@ -63,14 +63,14 @@ public sealed class StubInspectionController : ControllerBase
     [HttpPost("test-match")]
     public async Task<IActionResult> TestMatch([FromBody] MatchRequestInfo request)
     {
-        return Ok(await _inspectionService.TestMatchAsync(request));
+        return Ok(await _inspectionService.TestMatchAsync(request, HttpContext.RequestAborted));
     }
 
     /// <summary>Explains how the runtime evaluated a virtual request without executing a response.</summary>
     [HttpPost("explain")]
     public async Task<IActionResult> ExplainMatch([FromBody] MatchRequestInfo request)
     {
-        return Ok(await _inspectionService.ExplainMatchAsync(request));
+        return Ok(await _inspectionService.ExplainMatchAsync(request, HttpContext.RequestAborted));
     }
 
     /// <summary>Returns the explanation captured for the most recent real request.</summary>

--- a/src/SemanticStub.Api/Services/Inspection/IStubInspectionService.cs
+++ b/src/SemanticStub.Api/Services/Inspection/IStubInspectionService.cs
@@ -43,13 +43,15 @@ public interface IStubInspectionService
     /// Simulates how the runtime would match the supplied virtual request without executing a response or mutating scenario state.
     /// </summary>
     /// <param name="request">The virtual request to evaluate.</param>
-    Task<MatchSimulationInfo> TestMatchAsync(MatchRequestInfo request);
+    /// <param name="cancellationToken">A token that cancels the evaluation when the caller is no longer interested in the result.</param>
+    Task<MatchSimulationInfo> TestMatchAsync(MatchRequestInfo request, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Explains how the runtime evaluated the supplied virtual request without executing a response or mutating scenario state.
     /// </summary>
     /// <param name="request">The virtual request to evaluate.</param>
-    Task<MatchExplanationInfo> ExplainMatchAsync(MatchRequestInfo request);
+    /// <param name="cancellationToken">A token that cancels the evaluation when the caller is no longer interested in the result.</param>
+    Task<MatchExplanationInfo> ExplainMatchAsync(MatchRequestInfo request, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns the explanation captured for the most recent real request, when one has been recorded.

--- a/src/SemanticStub.Api/Services/Inspection/StubInspectionService.cs
+++ b/src/SemanticStub.Api/Services/Inspection/StubInspectionService.cs
@@ -81,16 +81,16 @@ internal sealed class StubInspectionService : IStubInspectionService
     }
 
     /// <inheritdoc/>
-    public async Task<MatchSimulationInfo> TestMatchAsync(MatchRequestInfo request)
+    public async Task<MatchSimulationInfo> TestMatchAsync(MatchRequestInfo request, CancellationToken cancellationToken = default)
     {
-        var explanation = await _stubService.ExplainMatchAsync(request);
+        var explanation = await _stubService.ExplainMatchAsync(request, cancellationToken);
         return explanation.Result;
     }
 
     /// <inheritdoc/>
-    public Task<MatchExplanationInfo> ExplainMatchAsync(MatchRequestInfo request)
+    public Task<MatchExplanationInfo> ExplainMatchAsync(MatchRequestInfo request, CancellationToken cancellationToken = default)
     {
-        return _stubService.ExplainMatchAsync(request);
+        return _stubService.ExplainMatchAsync(request, cancellationToken);
     }
 
     /// <inheritdoc/>

--- a/src/SemanticStub.Api/Services/Resolution/IStubService.cs
+++ b/src/SemanticStub.Api/Services/Resolution/IStubService.cs
@@ -24,18 +24,21 @@ public interface IStubService
     /// <param name="query">The query-string values to evaluate.</param>
     /// <param name="headers">The request headers to evaluate.</param>
     /// <param name="body">The request body used for JSON body matching.</param>
+    /// <param name="cancellationToken">A token that cancels dispatch when the caller is no longer interested in the result.</param>
     /// <returns>The dispatch result, including the assembled response and explanation captured from the same evaluation.</returns>
     Task<StubDispatchResult> DispatchAsync(
         string method,
         string path,
         IReadOnlyDictionary<string, StringValues> query,
         IReadOnlyDictionary<string, string> headers,
-        string? body);
+        string? body,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Explains how the runtime would evaluate the supplied virtual request without executing a response or mutating scenario state.
     /// </summary>
     /// <param name="request">The virtual request to evaluate.</param>
+    /// <param name="cancellationToken">A token that cancels the evaluation when the caller is no longer interested in the result.</param>
     /// <returns>The explanation produced by the shared matching pipeline.</returns>
-    Task<MatchExplanationInfo> ExplainMatchAsync(MatchRequestInfo request);
+    Task<MatchExplanationInfo> ExplainMatchAsync(MatchRequestInfo request, CancellationToken cancellationToken = default);
 }

--- a/src/SemanticStub.Api/Services/Resolution/StubDispatchSelector.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubDispatchSelector.cs
@@ -41,7 +41,8 @@ internal sealed class StubDispatchSelector
         IReadOnlyDictionary<string, string> headers,
         string? body,
         bool mutateScenarioState,
-        bool includeSemanticCandidates)
+        bool includeSemanticCandidates,
+        CancellationToken cancellationToken = default)
     {
         var selectedDeterministicCandidate = _matcherService.FindBestMatch(
             pathItem.Parameters,
@@ -103,7 +104,8 @@ internal sealed class StubDispatchSelector
                 body,
                 operation.Matches,
                 candidate => _scenarioService.IsMatch(candidate.Response.Scenario),
-                includeCandidateScores: includeSemanticCandidates);
+                includeCandidateScores: includeSemanticCandidates,
+                cancellationToken: cancellationToken);
 
         if (semanticExplanation.SelectedCandidate is not null)
         {

--- a/src/SemanticStub.Api/Services/Resolution/StubService.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubService.cs
@@ -75,7 +75,8 @@ public sealed class StubService : IStubService
         string path,
         IReadOnlyDictionary<string, StringValues> query,
         IReadOnlyDictionary<string, string> headers,
-        string? body)
+        string? body,
+        CancellationToken cancellationToken = default)
     {
         return await EvaluateAsync(
             method,
@@ -85,11 +86,12 @@ public sealed class StubService : IStubService
             body,
             mutateScenarioState: true,
             includeCandidates: true,
-            includeSemanticCandidates: false);
+            includeSemanticCandidates: false,
+            cancellationToken);
     }
 
     /// <inheritdoc/>
-    public async Task<MatchExplanationInfo> ExplainMatchAsync(MatchRequestInfo request)
+    public async Task<MatchExplanationInfo> ExplainMatchAsync(MatchRequestInfo request, CancellationToken cancellationToken = default)
     {
         var dispatch = await EvaluateAsync(
             CreateExplainMethod(request),
@@ -99,7 +101,8 @@ public sealed class StubService : IStubService
             NormalizeBody(request.Body),
             mutateScenarioState: false,
             includeCandidates: request.IncludeCandidates,
-            includeSemanticCandidates: request.IncludeSemanticCandidates);
+            includeSemanticCandidates: request.IncludeSemanticCandidates,
+            cancellationToken);
 
         return dispatch.Explanation;
     }
@@ -112,7 +115,8 @@ public sealed class StubService : IStubService
         string? body,
         bool mutateScenarioState,
         bool includeCandidates,
-        bool includeSemanticCandidates)
+        bool includeSemanticCandidates,
+        CancellationToken cancellationToken)
     {
         var document = _documentAccessor();
 
@@ -130,10 +134,10 @@ public sealed class StubService : IStubService
         if (OperationUsesScenario(operation))
         {
             return await _scenarioService.ExecuteLockedAsync(
-                () => DispatchCoreAsync(method, path, pathPattern, pathItem, operation, query, headers, body, mutateScenarioState, includeCandidates, includeSemanticCandidates));
+                () => DispatchCoreAsync(method, path, pathPattern, pathItem, operation, query, headers, body, mutateScenarioState, includeCandidates, includeSemanticCandidates, cancellationToken));
         }
 
-        return await DispatchCoreAsync(method, path, pathPattern, pathItem, operation, query, headers, body, mutateScenarioState, includeCandidates, includeSemanticCandidates);
+        return await DispatchCoreAsync(method, path, pathPattern, pathItem, operation, query, headers, body, mutateScenarioState, includeCandidates, includeSemanticCandidates, cancellationToken);
     }
 
     private static bool OperationUsesScenario(OperationDefinition operation)
@@ -153,7 +157,8 @@ public sealed class StubService : IStubService
         string? body,
         bool mutateScenarioState,
         bool includeCandidates,
-        bool includeSemanticCandidates)
+        bool includeSemanticCandidates,
+        CancellationToken cancellationToken)
     {
         var routeId = GetRouteId(method, pathPattern, operation);
         var request = _inspectionProjectionBuilder.CreateInspectionRequest(method, path, query, headers, body, includeCandidates, includeSemanticCandidates);
@@ -170,7 +175,8 @@ public sealed class StubService : IStubService
             headers,
             body,
             mutateScenarioState,
-            includeSemanticCandidates);
+            includeSemanticCandidates,
+            cancellationToken);
 
         SemanticMatchInfo? semanticEvaluationInfo = null;
         if (selection.SemanticExplanation.Attempted)

--- a/src/SemanticStub.Application/Services/Semantic/ISemanticEmbeddingClient.cs
+++ b/src/SemanticStub.Application/Services/Semantic/ISemanticEmbeddingClient.cs
@@ -9,6 +9,7 @@ public interface ISemanticEmbeddingClient
     /// Gets embeddings for the supplied inputs.
     /// </summary>
     /// <param name="inputs">The request and candidate texts to embed.</param>
+    /// <param name="cancellationToken">A token that cancels the embedding request when the caller is no longer interested in the result.</param>
     /// <returns>The returned embedding vectors in request order.</returns>
-    Task<IReadOnlyList<float[]>> GetEmbeddingsAsync(IReadOnlyList<string> inputs);
+    Task<IReadOnlyList<float[]>> GetEmbeddingsAsync(IReadOnlyList<string> inputs, CancellationToken cancellationToken = default);
 }

--- a/src/SemanticStub.Application/Services/Semantic/ISemanticMatcherService.cs
+++ b/src/SemanticStub.Application/Services/Semantic/ISemanticMatcherService.cs
@@ -19,6 +19,7 @@ public interface ISemanticMatcherService
     /// <param name="candidates">The semantic candidates attached to the resolved operation.</param>
     /// <param name="candidateFilter">An optional filter that excludes ineligible candidates before scoring.</param>
     /// <param name="includeCandidateScores">Whether per-candidate scores should be returned.</param>
+    /// <param name="cancellationToken">A token that cancels the embedding request when the caller is no longer interested in the result.</param>
     /// <returns>The semantic evaluation details, including scores and the selected candidate when one was accepted.</returns>
     Task<SemanticMatchExplanation> ExplainMatchAsync(
         string method,
@@ -28,5 +29,6 @@ public interface ISemanticMatcherService
         string? body,
         IReadOnlyCollection<QueryMatchDefinition> candidates,
         Func<QueryMatchDefinition, bool>? candidateFilter = null,
-        bool includeCandidateScores = false);
+        bool includeCandidateScores = false,
+        CancellationToken cancellationToken = default);
 }

--- a/src/SemanticStub.Application/Services/Semantic/SemanticMatcherService.cs
+++ b/src/SemanticStub.Application/Services/Semantic/SemanticMatcherService.cs
@@ -33,7 +33,8 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
         string? body,
         IReadOnlyCollection<QueryMatchDefinition> candidates,
         Func<QueryMatchDefinition, bool>? candidateFilter = null,
-        bool includeCandidateScores = false)
+        bool includeCandidateScores = false,
+        CancellationToken cancellationToken = default)
     {
         var semanticSettings = _settings.SemanticMatching;
         var normalizedMethod = method.ToUpperInvariant();
@@ -78,7 +79,8 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
                 query,
                 headers,
                 body,
-                semanticCandidates);
+                semanticCandidates,
+                cancellationToken);
 
             return ScoreAndLogExplanation(
                 path,
@@ -100,6 +102,7 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
         }
         catch (TaskCanceledException ex)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             _logger.LogWarning(
                 ex,
                 "Semantic matching failed for '{Path}' {Method}: the embedding endpoint request timed out. Treating the request as a non-match.",
@@ -154,7 +157,8 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
         IReadOnlyDictionary<string, StringValues> query,
         IReadOnlyDictionary<string, string> headers,
         string? body,
-        IReadOnlyList<QueryMatchDefinition> semanticCandidates)
+        IReadOnlyList<QueryMatchDefinition> semanticCandidates,
+        CancellationToken cancellationToken)
     {
         var allTexts = new List<string>(semanticCandidates.Count + 1)
         {
@@ -162,7 +166,7 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
         };
 
         allTexts.AddRange(semanticCandidates.Select(candidate => candidate.SemanticMatch!));
-        return await _embeddingClient.GetEmbeddingsAsync(allTexts);
+        return await _embeddingClient.GetEmbeddingsAsync(allTexts, cancellationToken);
     }
 
     private SemanticMatchExplanation ScoreAndLogExplanation(

--- a/src/SemanticStub.Infrastructure/Semantic/SemanticEmbeddingClient.cs
+++ b/src/SemanticStub.Infrastructure/Semantic/SemanticEmbeddingClient.cs
@@ -34,17 +34,17 @@ internal sealed class SemanticEmbeddingClient : ISemanticEmbeddingClient
     /// <exception cref="HttpRequestException">Thrown when the embedding endpoint request fails.</exception>
     /// <exception cref="TaskCanceledException">Thrown when the embedding endpoint request times out.</exception>
     /// <exception cref="InvalidOperationException">Thrown when the response shape is invalid.</exception>
-    public async Task<IReadOnlyList<float[]>> GetEmbeddingsAsync(IReadOnlyList<string> inputs)
+    public async Task<IReadOnlyList<float[]>> GetEmbeddingsAsync(IReadOnlyList<string> inputs, CancellationToken cancellationToken = default)
     {
         var httpClient = _httpClientFactory.CreateClient(HttpClientName);
         var endpoint = SemanticEmbeddingEndpoint.Normalize(_settings.Endpoint!);
-        var response = await httpClient.PostAsJsonAsync(endpoint, new EmbedRequest(inputs));
+        var response = await httpClient.PostAsJsonAsync(endpoint, new EmbedRequest(inputs), cancellationToken);
         response.EnsureSuccessStatusCode();
 
         try
         {
-            using var responseStream = await response.Content.ReadAsStreamAsync();
-            using var document = await JsonDocument.ParseAsync(responseStream);
+            using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            using var document = await JsonDocument.ParseAsync(responseStream, cancellationToken: cancellationToken);
 
             if (TryReadEmbeddings(document.RootElement, inputs.Count, out var embeddings))
             {

--- a/tests/SemanticStub.Api.Tests/Unit/Controllers/StubControllerTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Controllers/StubControllerTests.cs
@@ -334,6 +334,19 @@ public sealed class StubControllerTests
         Assert.Equal("/users", inspectionService.LastRecordedExplanation!.Result.PathPattern);
     }
 
+    [Fact]
+    public async Task Get_PassesRequestAbortedToken_ToStubService()
+    {
+        var stubService = new RecordingStubService(StubMatchResult.Matched, new StubResponse { StatusCode = 200 });
+        var controller = CreateController(stubService);
+        using var cancellationSource = new CancellationTokenSource();
+        controller.HttpContext.RequestAborted = cancellationSource.Token;
+
+        await controller.Get("users");
+
+        Assert.Equal(cancellationSource.Token, stubService.CancellationToken);
+    }
+
     private static readonly RecordingInspectionService controllerInspectionService = new();
 
     private static StubController CreateController(IStubService stubService, IStubInspectionService? inspectionService = null)
@@ -456,6 +469,8 @@ public sealed class StubControllerTests
 
         public string? Body { get; private set; }
 
+        public CancellationToken CancellationToken { get; private set; }
+
         public IReadOnlyList<string> AllowedMethods { get; }
 
         public IReadOnlyList<string> GetAllowedMethods(string path)
@@ -468,13 +483,15 @@ public sealed class StubControllerTests
             string path,
             IReadOnlyDictionary<string, StringValues> query,
             IReadOnlyDictionary<string, string> headers,
-            string? body)
+            string? body,
+            CancellationToken cancellationToken = default)
         {
             Method = method;
             Path = path;
             Query = query;
             Headers = headers;
             Body = body;
+            CancellationToken = cancellationToken;
 
             return Task.FromResult(new StubDispatchResult
             {
@@ -511,7 +528,7 @@ public sealed class StubControllerTests
             });
         }
 
-        public Task<MatchExplanationInfo> ExplainMatchAsync(MatchRequestInfo request)
+        public Task<MatchExplanationInfo> ExplainMatchAsync(MatchRequestInfo request, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(new MatchExplanationInfo
             {

--- a/tests/SemanticStub.Api.Tests/Unit/Controllers/StubControllerTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Controllers/StubControllerTests.cs
@@ -401,9 +401,9 @@ public sealed class StubControllerTests
 
         public IReadOnlyList<RecentRequestInfo> GetRecentRequests(int limit) => throw new NotSupportedException();
 
-        public Task<MatchSimulationInfo> TestMatchAsync(MatchRequestInfo request) => throw new NotSupportedException();
+        public Task<MatchSimulationInfo> TestMatchAsync(MatchRequestInfo request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
 
-        public Task<MatchExplanationInfo> ExplainMatchAsync(MatchRequestInfo request) => throw new NotSupportedException();
+        public Task<MatchExplanationInfo> ExplainMatchAsync(MatchRequestInfo request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
 
         public MatchExplanationInfo? GetLastMatchExplanation() => throw new NotSupportedException();
 

--- a/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionServiceTests.cs
@@ -151,7 +151,8 @@ public sealed class StubInspectionServiceTests
             string? body,
             IReadOnlyCollection<QueryMatchDefinition> candidates,
             Func<QueryMatchDefinition, bool>? candidateFilter = null,
-            bool includeCandidateScores = false)
+            bool includeCandidateScores = false,
+            CancellationToken cancellationToken = default)
         {
             return Task.FromResult(new SemanticMatchExplanation());
         }
@@ -167,7 +168,8 @@ public sealed class StubInspectionServiceTests
             string? body,
             IReadOnlyCollection<QueryMatchDefinition> candidates,
             Func<QueryMatchDefinition, bool>? candidateFilter = null,
-            bool includeCandidateScores = false)
+            bool includeCandidateScores = false,
+            CancellationToken cancellationToken = default)
         {
             return Task.FromResult(explanation);
         }

--- a/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionServiceTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 using SemanticStub.Api.Inspection;
 using SemanticStub.Application.Infrastructure.Yaml;
 using SemanticStub.Infrastructure.Yaml;
@@ -1849,6 +1850,75 @@ public sealed class StubInspectionServiceTests
         Assert.True(explanation!.Result.Matched);
         Assert.Equal("fallback", explanation.Result.MatchMode);
         Assert.Equal("listUsers", explanation.Result.RouteId);
+    }
+
+    [Fact]
+    public async Task TestMatchAsync_PassesCancellationToken_ToStubService()
+    {
+        var spy = new RecordingExplainStubService();
+        var service = CreateInspectionServiceWithStubService(spy);
+        using var cancellationSource = new CancellationTokenSource();
+
+        await service.TestMatchAsync(new MatchRequestInfo { Method = "GET", Path = "/users" }, cancellationSource.Token);
+
+        Assert.Equal(cancellationSource.Token, spy.ReceivedCancellationToken);
+    }
+
+    [Fact]
+    public async Task ExplainMatchAsync_PassesCancellationToken_ToStubService()
+    {
+        var spy = new RecordingExplainStubService();
+        var service = CreateInspectionServiceWithStubService(spy);
+        using var cancellationSource = new CancellationTokenSource();
+
+        await service.ExplainMatchAsync(new MatchRequestInfo { Method = "GET", Path = "/users" }, cancellationSource.Token);
+
+        Assert.Equal(cancellationSource.Token, spy.ReceivedCancellationToken);
+    }
+
+    private static StubInspectionService CreateInspectionServiceWithStubService(IStubService stubService)
+    {
+        var document = new StubDocument
+        {
+            Paths = new Dictionary<string, PathItemDefinition>(StringComparer.Ordinal)
+            {
+                ["/users"] = new() { Get = new OperationDefinition() }
+            }
+        };
+        var loader = new TestStubDefinitionLoader(document);
+        var scenarioService = new ScenarioService();
+        var state = new StubDefinitionState(loader, scenarioService, NullLogger<StubDefinitionState>.Instance);
+        return new StubInspectionService(
+            state,
+            loader,
+            Options.Create(new StubSettings()),
+            stubService,
+            new StubInspectionRuntimeStore(),
+            new StubInspectionScenarioCoordinator(state, scenarioService));
+    }
+
+    private sealed class RecordingExplainStubService : IStubService
+    {
+        public CancellationToken ReceivedCancellationToken { get; private set; }
+
+        public IReadOnlyList<string> GetAllowedMethods(string path) => Array.Empty<string>();
+
+        public Task<StubDispatchResult> DispatchAsync(
+            string method,
+            string path,
+            IReadOnlyDictionary<string, StringValues> query,
+            IReadOnlyDictionary<string, string> headers,
+            string? body,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<MatchExplanationInfo> ExplainMatchAsync(MatchRequestInfo request, CancellationToken cancellationToken = default)
+        {
+            ReceivedCancellationToken = cancellationToken;
+            return Task.FromResult(new MatchExplanationInfo
+            {
+                Result = new MatchSimulationInfo { MatchResult = "PathNotFound" }
+            });
+        }
     }
 
     [Fact]

--- a/tests/SemanticStub.Api.Tests/Unit/Resolution/StubDispatchSelectorTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Resolution/StubDispatchSelectorTests.cs
@@ -247,8 +247,40 @@ public sealed class StubDispatchSelectorTests
         Assert.Equal("confirmed", scenarioService.GetSnapshot("checkout-flow").State);
     }
 
+    [Fact]
+    public async Task SelectAsync_PassesCancellationToken_ToSemanticMatcherService()
+    {
+        var scenarioService = new ScenarioService();
+        var responseBuilder = new StubResponseBuilder(_ => throw new InvalidOperationException("No file loading expected."));
+        var spy = new StubSemanticMatcherService(new SemanticMatchExplanation());
+        var selector = new StubDispatchSelector(
+            CreateMatcherService(),
+            spy,
+            responseBuilder,
+            new StubDefaultResponseSelector(responseBuilder, scenarioService),
+            scenarioService,
+            logger: null);
+        using var cancellationSource = new CancellationTokenSource();
+
+        await selector.SelectAsync(
+            HttpMethods.Get,
+            "/users",
+            new PathItemDefinition(),
+            new OperationDefinition(),
+            new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            null,
+            mutateScenarioState: false,
+            includeSemanticCandidates: false,
+            cancellationSource.Token);
+
+        Assert.Equal(cancellationSource.Token, spy.ReceivedCancellationToken);
+    }
+
     private sealed class StubSemanticMatcherService(SemanticMatchExplanation explanation) : ISemanticMatcherService
     {
+        public CancellationToken ReceivedCancellationToken { get; private set; }
+
         public Task<SemanticMatchExplanation> ExplainMatchAsync(
             string method,
             string path,
@@ -257,8 +289,10 @@ public sealed class StubDispatchSelectorTests
             string? body,
             IReadOnlyCollection<QueryMatchDefinition> candidates,
             Func<QueryMatchDefinition, bool>? candidateFilter = null,
-            bool includeCandidateScores = false)
+            bool includeCandidateScores = false,
+            CancellationToken cancellationToken = default)
         {
+            ReceivedCancellationToken = cancellationToken;
             return Task.FromResult(explanation);
         }
     }

--- a/tests/SemanticStub.Api.Tests/Unit/Resolution/StubServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Resolution/StubServiceTests.cs
@@ -1979,7 +1979,8 @@ public sealed class StubServiceTests
             string? body,
             IReadOnlyCollection<QueryMatchDefinition> candidates,
             Func<QueryMatchDefinition, bool>? candidateFilter = null,
-            bool includeCandidateScores = false)
+            bool includeCandidateScores = false,
+            CancellationToken cancellationToken = default)
         {
             CallCount++;
 

--- a/tests/SemanticStub.Api.Tests/Unit/Semantic/SemanticMatcherServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Semantic/SemanticMatcherServiceTests.cs
@@ -517,6 +517,68 @@ public sealed class SemanticMatcherServiceTests
         Assert.Null(explanation.SelectedCandidate);
     }
 
+    [Fact]
+    public async Task ExplainMatchAsync_PropagatesCancellationToken_ToEmbeddingClient()
+    {
+        CancellationToken receivedToken = default;
+        using var cancellationSource = new CancellationTokenSource();
+
+        var service = CreateService(
+            new StubSettings
+            {
+                SemanticMatching = new SemanticMatchingSettings
+                {
+                    Enabled = true,
+                    Endpoint = "http://tei"
+                }
+            },
+            (_, ct) =>
+            {
+                receivedToken = ct;
+                return CreateEmbeddingResponse("[[1.0,0.0],[0.9,0.1]]");
+            });
+
+        await service.ExplainMatchAsync(
+            "POST",
+            "/search",
+            new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            "admin search",
+            [CreateCandidate("find admin users")],
+            cancellationToken: cancellationSource.Token);
+
+        // HttpClient links the caller's token internally, so the received token is a linked token rather
+        // than the original. Verify that a cancellable token (not CancellationToken.None) was forwarded.
+        Assert.True(receivedToken.CanBeCanceled);
+    }
+
+    [Fact]
+    public async Task ExplainMatchAsync_ThrowsOperationCanceledException_WhenTokenCancelledDuringEmbeddingCall()
+    {
+        using var cancellationSource = new CancellationTokenSource();
+        await cancellationSource.CancelAsync();
+
+        var service = CreateService(
+            new StubSettings
+            {
+                SemanticMatching = new SemanticMatchingSettings
+                {
+                    Enabled = true,
+                    Endpoint = "http://tei"
+                }
+            },
+            (_, _) => CreateEmbeddingResponse("[[1.0,0.0],[0.9,0.1]]"));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => service.ExplainMatchAsync(
+            "POST",
+            "/search",
+            new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            "admin search",
+            [CreateCandidate("find admin users")],
+            cancellationToken: cancellationSource.Token));
+    }
+
     private static QueryMatchDefinition CreateCandidate(string semanticMatch)
     {
         return new QueryMatchDefinition


### PR DESCRIPTION
## Summary

- Thread `CancellationToken` through the full dispatch chain: `StubController` → `IStubService` → `StubDispatchSelector` → `ISemanticMatcherService` → `ISemanticEmbeddingClient`
- Pass `HttpContext.RequestAborted` from the controller so aborted client requests cancel the semantic embedding call
- Apply the token to `PostAsJsonAsync`, `ReadAsStreamAsync`, and `JsonDocument.ParseAsync` in `SemanticEmbeddingClient`
- Add `cancellationToken.ThrowIfCancellationRequested()` in the `TaskCanceledException` catch block of `SemanticMatcherService` so request-aborted cancellations propagate rather than silently becoming non-matches

## Files Changed

- `src/SemanticStub.Api/Controllers/StubController.cs` — pass `HttpContext.RequestAborted` to `DispatchAsync`
- `src/SemanticStub.Api/Services/Resolution/IStubService.cs` — add CT to `DispatchAsync` and `ExplainMatchAsync`
- `src/SemanticStub.Api/Services/Resolution/StubService.cs` — thread CT through `EvaluateAsync` and `DispatchCoreAsync`
- `src/SemanticStub.Api/Services/Resolution/StubDispatchSelector.cs` — add CT to `SelectAsync`, pass to semantic service
- `src/SemanticStub.Application/Services/Semantic/ISemanticMatcherService.cs` — add CT to `ExplainMatchAsync`
- `src/SemanticStub.Application/Services/Semantic/SemanticMatcherService.cs` — thread CT, add `ThrowIfCancellationRequested` in catch block
- `src/SemanticStub.Application/Services/Semantic/ISemanticEmbeddingClient.cs` — add CT to `GetEmbeddingsAsync`
- `src/SemanticStub.Infrastructure/Semantic/SemanticEmbeddingClient.cs` — pass CT to all async I/O calls

## Tests

- Added `Get_PassesRequestAbortedToken_ToStubService` in `StubControllerTests`
- Added `SelectAsync_PassesCancellationToken_ToSemanticMatcherService` in `StubDispatchSelectorTests`
- Added `ExplainMatchAsync_PropagatesCancellationToken_ToEmbeddingClient` in `SemanticMatcherServiceTests`
- Added `ExplainMatchAsync_ThrowsOperationCanceledException_WhenTokenCancelledDuringEmbeddingCall` in `SemanticMatcherServiceTests`
- Updated all `ISemanticMatcherService` and `IStubService` spy/stub implementations in existing tests
- All 342 tests pass

## Notes

All new parameters use `CancellationToken cancellationToken = default` to preserve backward compatibility. The `CancellationToken` is placed as the last parameter per .NET conventions.

Closes #229