### PR TITLE
fix: move startup validation into hosted service

### DIFF
--- a/src/SemanticStub.Api/Program.cs
+++ b/src/SemanticStub.Api/Program.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.RequestDecompression;
 using Microsoft.AspNetCore.ResponseCompression;
 using SemanticStub.Api.Extensions;
 using SemanticStub.Application.Infrastructure.Yaml;
-using SemanticStub.Infrastructure.Yaml;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -45,9 +44,6 @@ builder.Services.AddOptions<StubSettings>()
 builder.Services.AddStubServices();
 
 var app = builder.Build();
-
-// Fail fast during startup when stub definitions are invalid instead of deferring configuration errors until the first request.
-app.Services.GetRequiredService<StubDefinitionState>();
 
 app.UseRequestDecompression();
 app.UseResponseCompression();

--- a/src/SemanticStub.Infrastructure/Extensions/YamlInfrastructureServiceCollectionExtensions.cs
+++ b/src/SemanticStub.Infrastructure/Extensions/YamlInfrastructureServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ public static class YamlInfrastructureServiceCollectionExtensions
         services.AddSingleton<IStubDefinitionLoader, StubDefinitionLoader>();
         // The loaded YAML definition is process-wide runtime state and is replaced atomically on reload.
         services.AddSingleton<StubDefinitionState>();
+        services.AddHostedService<StubDefinitionStartupValidator>();
         services.AddHostedService<StubDefinitionWatcher>();
 
         return services;

--- a/src/SemanticStub.Infrastructure/Infrastructure/Yaml/StubDefinitionStartupValidator.cs
+++ b/src/SemanticStub.Infrastructure/Infrastructure/Yaml/StubDefinitionStartupValidator.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Hosting;
+
+namespace SemanticStub.Infrastructure.Yaml;
+
+internal sealed class StubDefinitionStartupValidator : IHostedService
+{
+    private readonly StubDefinitionState _state;
+
+    public StubDefinitionStartupValidator(StubDefinitionState state)
+    {
+        _state = state;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _state.GetCurrentDocument();
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/tests/SemanticStub.Api.Tests/Integration/StubServiceCollectionExtensionsTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/StubServiceCollectionExtensionsTests.cs
@@ -33,6 +33,9 @@ public sealed class StubServiceCollectionExtensionsTests
         Assert.NotNull(serviceProvider.GetRequiredService<IStubInspectionService>());
         Assert.NotNull(serviceProvider.GetRequiredService<IStubDefinitionLoader>());
         Assert.NotEmpty(serviceProvider.GetServices<IHostedService>());
+        Assert.Contains(services, descriptor =>
+            descriptor.ServiceType == typeof(IHostedService) &&
+            descriptor.ImplementationType?.Name == "StubDefinitionStartupValidator");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add an explicit hosted startup validator for YAML definitions.
- Register the validator from the Infrastructure YAML service registration.
- Remove manual StubDefinitionState resolution from Program.cs.

## Files Changed
- src/SemanticStub.Api/Program.cs
- src/SemanticStub.Infrastructure/Extensions/YamlInfrastructureServiceCollectionExtensions.cs
- src/SemanticStub.Infrastructure/Infrastructure/Yaml/StubDefinitionStartupValidator.cs
- tests/SemanticStub.Api.Tests/Integration/StubServiceCollectionExtensionsTests.cs

## Tests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter FullyQualifiedName~StubServiceCollectionExtensionsTests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter FullyQualifiedName~StartupValidationTests
- dotnet test SemanticStub.sln

## Notes
- Preserves fail-fast startup behavior for invalid YAML without resolving services manually in Program.cs.

Closes #236