### PR TITLE
refactor: reduce DI factory registrations

### DIFF
--- a/src/SemanticStub.Api/Extensions/StubServiceCollectionExtensions.cs
+++ b/src/SemanticStub.Api/Extensions/StubServiceCollectionExtensions.cs
@@ -40,10 +40,8 @@ public static class StubServiceCollectionExtensions
             client.Timeout = TimeSpan.FromSeconds(settings.SemanticMatching.TimeoutSeconds);
         });
         services.AddSingleton<ISemanticEmbeddingClient, SemanticEmbeddingClient>();
-        services.AddSingleton<ISemanticMatcherService>(serviceProvider => new SemanticMatcherService(
-            serviceProvider.GetRequiredService<ISemanticEmbeddingClient>(),
-            serviceProvider.GetRequiredService<IOptions<StubSettings>>().Value,
-            serviceProvider.GetRequiredService<ILogger<SemanticMatcherService>>()));
+        services.AddSingleton(serviceProvider => serviceProvider.GetRequiredService<IOptions<StubSettings>>().Value);
+        services.AddSingleton<ISemanticMatcherService, SemanticMatcherService>();
 
         return services;
     }
@@ -53,13 +51,7 @@ public static class StubServiceCollectionExtensions
         // Runtime inspection metrics and recent request history are process-wide by design.
         services.AddSingleton<StubInspectionRuntimeStore>();
         services.AddSingleton<StubInspectionScenarioCoordinator>();
-        services.AddSingleton<IStubInspectionService>(serviceProvider => new StubInspectionService(
-            serviceProvider.GetRequiredService<StubDefinitionState>(),
-            serviceProvider.GetRequiredService<IStubDefinitionLoader>(),
-            serviceProvider.GetRequiredService<IOptions<StubSettings>>(),
-            serviceProvider.GetRequiredService<IStubService>(),
-            serviceProvider.GetRequiredService<StubInspectionRuntimeStore>(),
-            serviceProvider.GetRequiredService<StubInspectionScenarioCoordinator>()));
+        services.AddSingleton<IStubInspectionService, StubInspectionService>();
 
         return services;
     }
@@ -68,20 +60,10 @@ public static class StubServiceCollectionExtensions
     {
         services.AddSingleton<Func<string, string>>(serviceProvider =>
             serviceProvider.GetRequiredService<StubDefinitionState>().LoadResponseFileContent);
-        services.AddSingleton<StubResponseBuilder>(serviceProvider => new StubResponseBuilder(
-            serviceProvider.GetRequiredService<Func<string, string>>()));
-        services.AddSingleton<StubDefaultResponseSelector>(serviceProvider => new StubDefaultResponseSelector(
-            serviceProvider.GetRequiredService<StubResponseBuilder>(),
-            serviceProvider.GetRequiredService<ScenarioService>()));
-        services.AddSingleton<StubDispatchSelector>(serviceProvider => new StubDispatchSelector(
-            serviceProvider.GetRequiredService<MatcherService>(),
-            serviceProvider.GetRequiredService<ISemanticMatcherService>(),
-            serviceProvider.GetRequiredService<StubResponseBuilder>(),
-            serviceProvider.GetRequiredService<StubDefaultResponseSelector>(),
-            serviceProvider.GetRequiredService<ScenarioService>(),
-            serviceProvider.GetRequiredService<ILogger<StubDispatchSelector>>()));
-        services.AddSingleton<StubInspectionProjectionBuilder>(serviceProvider => new StubInspectionProjectionBuilder(
-            serviceProvider.GetRequiredService<ScenarioService>()));
+        services.AddSingleton<StubResponseBuilder>();
+        services.AddSingleton<StubDefaultResponseSelector>();
+        services.AddSingleton<StubDispatchSelector>();
+        services.AddSingleton<StubInspectionProjectionBuilder>();
         services.AddSingleton<IStubService>(serviceProvider => new StubService(
             serviceProvider.GetRequiredService<StubDefinitionState>(),
             serviceProvider.GetRequiredService<MatcherService>(),

--- a/src/SemanticStub.Api/Services/Inspection/StubInspectionService.cs
+++ b/src/SemanticStub.Api/Services/Inspection/StubInspectionService.cs
@@ -16,7 +16,7 @@ internal sealed class StubInspectionService : IStubInspectionService
     private readonly StubInspectionRuntimeStore _runtimeStore;
     private readonly StubInspectionScenarioCoordinator _scenarioCoordinator;
 
-    internal StubInspectionService(
+    public StubInspectionService(
         StubDefinitionState state,
         IStubDefinitionLoader loader,
         IOptions<StubSettings> settings,

--- a/src/SemanticStub.Api/Services/Resolution/StubDispatchSelector.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubDispatchSelector.cs
@@ -14,7 +14,7 @@ internal sealed class StubDispatchSelector
     private readonly ISemanticMatcherService? _semanticMatcherService;
     private readonly StubResponseBuilder _responseBuilder;
     private readonly ScenarioService _scenarioService;
-    private readonly ILogger? _logger;
+    private readonly ILogger<StubDispatchSelector>? _logger;
 
     public StubDispatchSelector(
         MatcherService matcherService,
@@ -22,7 +22,7 @@ internal sealed class StubDispatchSelector
         StubResponseBuilder responseBuilder,
         StubDefaultResponseSelector defaultResponseSelector,
         ScenarioService scenarioService,
-        ILogger? logger)
+        ILogger<StubDispatchSelector>? logger)
     {
         _matcherService = matcherService;
         _semanticMatcherService = semanticMatcherService;

--- a/src/SemanticStub.Application/Extensions/ApplicationServiceCollectionExtensions.cs
+++ b/src/SemanticStub.Application/Extensions/ApplicationServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using SemanticStub.Application.Services;
 
 namespace SemanticStub.Application.Extensions;
@@ -16,14 +15,11 @@ public static class ApplicationServiceCollectionExtensions
     /// <returns>The same service collection for chaining.</returns>
     public static IServiceCollection AddApplicationServices(this IServiceCollection services)
     {
-        services.AddSingleton(serviceProvider => new JsonBodyMatcher(
-            serviceProvider.GetRequiredService<ILogger<JsonBodyMatcher>>()));
-        services.AddSingleton(serviceProvider => new FormBodyMatcher(
-            serviceProvider.GetRequiredService<ILogger<FormBodyMatcher>>()));
+        services.AddSingleton<JsonBodyMatcher>();
+        services.AddSingleton<FormBodyMatcher>();
         services.AddSingleton<QueryValueMatcher>();
-        services.AddSingleton(serviceProvider => new RegexQueryMatcher(
-            serviceProvider.GetRequiredService<ILogger<RegexQueryMatcher>>()));
-        services.AddSingleton<MatcherService>(serviceProvider => new MatcherService(
+        services.AddSingleton<RegexQueryMatcher>();
+        services.AddSingleton(serviceProvider => new MatcherService(
             serviceProvider.GetRequiredService<JsonBodyMatcher>(),
             serviceProvider.GetRequiredService<FormBodyMatcher>(),
             serviceProvider.GetRequiredService<QueryValueMatcher>(),

--- a/src/SemanticStub.Application/Services/Matching/FormBodyMatcher.cs
+++ b/src/SemanticStub.Application/Services/Matching/FormBodyMatcher.cs
@@ -13,7 +13,7 @@ internal sealed class FormBodyMatcher
     private static readonly TimeSpan RegexMatchTimeout = TimeSpan.FromMilliseconds(100);
     private readonly ILogger<FormBodyMatcher>? _logger;
 
-    internal FormBodyMatcher(ILogger<FormBodyMatcher>? logger = null)
+    public FormBodyMatcher(ILogger<FormBodyMatcher>? logger = null)
     {
         _logger = logger;
     }

--- a/src/SemanticStub.Application/Services/Matching/JsonBodyMatcher.cs
+++ b/src/SemanticStub.Application/Services/Matching/JsonBodyMatcher.cs
@@ -14,7 +14,7 @@ internal sealed class JsonBodyMatcher
     /// <summary>
     /// Creates a body matcher with optional warning logging for invalid stub body definitions.
     /// </summary>
-    internal JsonBodyMatcher(ILogger<JsonBodyMatcher>? logger = null)
+    public JsonBodyMatcher(ILogger<JsonBodyMatcher>? logger = null)
     {
         _logger = logger;
     }

--- a/src/SemanticStub.Application/Services/Matching/RegexQueryMatcher.cs
+++ b/src/SemanticStub.Application/Services/Matching/RegexQueryMatcher.cs
@@ -17,7 +17,7 @@ internal sealed class RegexQueryMatcher
     /// <summary>
     /// Creates a regex query matcher with optional warning logging for invalid or slow regex patterns.
     /// </summary>
-    internal RegexQueryMatcher(ILogger<RegexQueryMatcher>? logger = null)
+    public RegexQueryMatcher(ILogger<RegexQueryMatcher>? logger = null)
     {
         _logger = logger;
     }

--- a/tests/SemanticStub.Api.Tests/Integration/StubServiceCollectionExtensionsTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/StubServiceCollectionExtensionsTests.cs
@@ -68,6 +68,28 @@ public sealed class StubServiceCollectionExtensionsTests
             serviceProvider.GetRequiredService<StubInspectionRuntimeStore>());
     }
 
+    [Fact]
+    public void AddStubServices_UsesDirectRegistrationForStraightforwardServices()
+    {
+        using var workspace = StubWorkspace.Create();
+        var services = CreateServiceCollection(workspace);
+
+        services.AddStubServices();
+
+        AssertDirectRegistration<JsonBodyMatcher>(services);
+        AssertDirectRegistration<FormBodyMatcher>(services);
+        AssertDirectRegistration<QueryValueMatcher>(services);
+        AssertDirectRegistration<RegexQueryMatcher>(services);
+        AssertConstructorFactory<MatcherService>(services);
+        AssertDirectRegistration<ISemanticMatcherService, SemanticMatcherService>(services);
+        AssertDirectRegistration<IStubInspectionService, StubInspectionService>(services);
+        AssertDirectRegistration<StubResponseBuilder>(services);
+        AssertDirectRegistration<StubDefaultResponseSelector>(services);
+        AssertDirectRegistration<StubDispatchSelector>(services);
+        AssertDirectRegistration<StubInspectionProjectionBuilder>(services);
+        AssertConstructorFactory<IStubService>(services);
+    }
+
     private static ServiceCollection CreateServiceCollection(StubWorkspace workspace)
     {
         var services = new ServiceCollection();
@@ -92,6 +114,30 @@ public sealed class StubServiceCollectionExtensionsTests
         var descriptor = Assert.Single(services, descriptor => descriptor.ServiceType == typeof(TService));
 
         Assert.Equal(expectedLifetime, descriptor.Lifetime);
+    }
+
+    private static void AssertDirectRegistration<TService>(IServiceCollection services)
+    {
+        var descriptor = Assert.Single(services, descriptor => descriptor.ServiceType == typeof(TService));
+
+        Assert.Null(descriptor.ImplementationFactory);
+        Assert.Equal(typeof(TService), descriptor.ImplementationType);
+    }
+
+    private static void AssertDirectRegistration<TService, TImplementation>(IServiceCollection services)
+    {
+        var descriptor = Assert.Single(services, descriptor => descriptor.ServiceType == typeof(TService));
+
+        Assert.Null(descriptor.ImplementationFactory);
+        Assert.Equal(typeof(TImplementation), descriptor.ImplementationType);
+    }
+
+    private static void AssertConstructorFactory<TService>(IServiceCollection services)
+    {
+        var descriptor = Assert.Single(services, descriptor => descriptor.ServiceType == typeof(TService));
+
+        Assert.NotNull(descriptor.ImplementationFactory);
+        Assert.Null(descriptor.ImplementationType);
     }
 
     private sealed class StubWorkspace(string rootPath, string samplesPath) : IDisposable

--- a/tests/SemanticStub.Api.Tests/Unit/Semantic/SemanticMatcherServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Semantic/SemanticMatcherServiceTests.cs
@@ -610,10 +610,8 @@ public sealed class SemanticMatcherServiceTests
         services.AddLogging();
         services.AddSingleton<IHttpClientFactory>(_ => new TestHttpClientFactory(new HttpClient(new DelegatingTestHandler(handler))));
         services.AddSingleton<ISemanticEmbeddingClient, SemanticEmbeddingClient>();
-        services.AddSingleton<ISemanticMatcherService>(serviceProvider => new SemanticMatcherService(
-            serviceProvider.GetRequiredService<ISemanticEmbeddingClient>(),
-            serviceProvider.GetRequiredService<IOptions<StubSettings>>().Value,
-            serviceProvider.GetRequiredService<ILogger<SemanticMatcherService>>()));
+        services.AddSingleton(serviceProvider => serviceProvider.GetRequiredService<IOptions<StubSettings>>().Value);
+        services.AddSingleton<ISemanticMatcherService, SemanticMatcherService>();
 
         return (SemanticMatcherService)services.BuildServiceProvider().GetRequiredService<ISemanticMatcherService>();
     }


### PR DESCRIPTION
## Summary
- Replace straightforward service-provider factory registrations with direct DI registrations in API and Application composition
- Keep constructor factories only where preserving internal collaborators or delegate construction requires them
- Add regression coverage for direct registration choices in the production composition graph

## Files Changed
- src/SemanticStub.Api/Extensions/StubServiceCollectionExtensions.cs
- src/SemanticStub.Application/Extensions/ApplicationServiceCollectionExtensions.cs
- matching/inspection/resolution constructor visibility adjustments
- DI composition tests

## Tests
- dotnet test SemanticStub.sln
- dotnet format SemanticStub.sln --verify-no-changes

## Notes
- Closes #235