### PR TITLE
fix: return inspection not found problem details

### DIFF
--- a/src/SemanticStub.Api/Controllers/StubInspectionController.cs
+++ b/src/SemanticStub.Api/Controllers/StubInspectionController.cs
@@ -36,7 +36,9 @@ public sealed class StubInspectionController : ControllerBase
     public IActionResult GetRoute(string routeId)
     {
         var route = _inspectionService.GetRoute(routeId);
-        return route is null ? NotFound() : Ok(route);
+        return route is null
+            ? NotFoundProblem("Route not found", $"Inspection route '{routeId}' was not found.")
+            : Ok(route);
     }
 
     /// <summary>Returns the current runtime state for all configured scenarios.</summary>
@@ -78,7 +80,9 @@ public sealed class StubInspectionController : ControllerBase
     public IActionResult ExplainLastMatch()
     {
         var explanation = _inspectionService.GetLastMatchExplanation();
-        return explanation is null ? NotFound() : Ok(explanation);
+        return explanation is null
+            ? NotFoundProblem("Last match explanation not found", "No real request match explanation has been captured yet.")
+            : Ok(explanation);
     }
 
     /// <summary>Resets all configured scenarios back to their initial state.</summary>
@@ -95,6 +99,14 @@ public sealed class StubInspectionController : ControllerBase
     {
         return _inspectionService.ResetScenarioState(name)
             ? NoContent()
-            : NotFound();
+            : NotFoundProblem("Scenario not found", $"Scenario '{name}' was not found.");
+    }
+
+    private ObjectResult NotFoundProblem(string title, string detail)
+    {
+        return Problem(
+            statusCode: StatusCodes.Status404NotFound,
+            title: title,
+            detail: detail);
     }
 }

--- a/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SemanticStub.Api.Inspection;
 using Xunit;
@@ -139,6 +140,7 @@ public sealed class StubInspectionEndpointTests : IClassFixture<WebApplicationFa
         var response = await client.GetAsync("/_semanticstub/runtime/routes/does-not-exist");
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        await AssertNotFoundProblemDetails(response, "Route not found");
     }
 
     [Fact]
@@ -299,6 +301,7 @@ public sealed class StubInspectionEndpointTests : IClassFixture<WebApplicationFa
         var response = await client.PostAsync("/_semanticstub/runtime/scenarios/does-not-exist/reset", content: null);
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        await AssertNotFoundProblemDetails(response, "Scenario not found");
     }
 
     [Fact]
@@ -383,5 +386,30 @@ public sealed class StubInspectionEndpointTests : IClassFixture<WebApplicationFa
         Assert.NotNull(payload);
         Assert.Equal("Matched", payload!.Result.MatchResult);
         Assert.Equal("listUsers", payload.Result.RouteId);
+    }
+
+    [Fact]
+    public async Task ExplainLastMatch_ReturnsNotFoundProblemDetails_WhenNoRealRequestExplanationExists()
+    {
+        await using var factory = new WebApplicationFactory<Program>();
+        using var freshClient = factory.CreateClient();
+
+        var response = await freshClient.GetAsync("/_semanticstub/runtime/explain/last");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        await AssertNotFoundProblemDetails(response, "Last match explanation not found");
+    }
+
+    private static async Task AssertNotFoundProblemDetails(HttpResponseMessage response, string expectedTitle)
+    {
+        Assert.Equal("application/problem+json", response.Content.Headers.ContentType?.MediaType);
+
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.NotNull(problem);
+        Assert.Equal(StatusCodes.Status404NotFound, problem!.Status);
+        Assert.Equal(expectedTitle, problem.Title);
+        Assert.False(string.IsNullOrWhiteSpace(problem.Detail));
     }
 }


### PR DESCRIPTION
## Summary
- Return explicit ProblemDetails for expected runtime inspection 404 cases.
- Cover missing route, missing last explanation, and missing scenario reset target responses.

## Files Changed
- src/SemanticStub.Api/Controllers/StubInspectionController.cs
- tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs

## Tests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter StubInspectionEndpointTests
- dotnet test SemanticStub.sln

## Notes
- Preserves existing 404 status codes.
- Closes #233