### PR TITLE
feat: add inspection reset route aliases

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -254,13 +254,13 @@ SemanticStub は、runtime inspection endpoint を予約プレフィックス
 - `GET /_semanticstub/runtime/routes/{routeId}` は、1 件の active route の effective runtime detail を返します。
 - `GET /_semanticstub/runtime/scenarios` は、現在の scenario state snapshot を返します。
 - `GET /_semanticstub/runtime/metrics` は、現在のプロセスで処理した実リクエストの集計 metrics を返します。
-- `POST /_semanticstub/runtime/metrics/reset` は、現在のプロセスの集計 metrics と recent request history を reset します。
+- `POST /_semanticstub/runtime/metrics/resets` は、現在のプロセスの集計 metrics と recent request history を reset します。互換性維持のため `POST /_semanticstub/runtime/metrics/reset` も引き続き利用できます。
 - `GET /_semanticstub/runtime/requests?limit=20` は、現在のプロセスで処理した実リクエストの recent request history を返します。
 - `POST /_semanticstub/runtime/test-match` は、実レスポンスを実行せず scenario state も変更せずに virtual request を評価します。
 - `POST /_semanticstub/runtime/explain` は、virtual request の structured match detail を返します。該当する場合は deterministic / semantic evaluation も含みます。
 - `GET /_semanticstub/runtime/explain/last` は、現在のプロセスで最後に実リクエストから記録された explanation を返します。
-- `POST /_semanticstub/runtime/scenarios/reset` は、設定済みの全 scenario を初期状態に戻します。
-- `POST /_semanticstub/runtime/scenarios/{name}/reset` は、設定済みの 1 scenario を初期状態に戻します。
+- `POST /_semanticstub/runtime/scenarios/resets` は、設定済みの全 scenario を初期状態に戻します。互換性維持のため `POST /_semanticstub/runtime/scenarios/reset` も引き続き利用できます。
+- `POST /_semanticstub/runtime/scenarios/{name}/resets` は、設定済みの 1 scenario を初期状態に戻します。互換性維持のため `POST /_semanticstub/runtime/scenarios/{name}/reset` も引き続き利用できます。
 - `/_semanticstub/runtime/*` 配下の YAML stub 定義は inspection endpoint 用に予約されており、通常の stub route としては到達できません。
 
 補足:
@@ -270,11 +270,11 @@ SemanticStub は、runtime inspection endpoint を予約プレフィックス
 - `/_semanticstub/runtime/routes/{routeId}` は、1 件の route について top-level response と正規化済み conditional match metadata を含む detail view を返します。
 - `/_semanticstub/runtime/scenarios` は、既知の scenario ごとに現在の state と active かどうかを返します。
 - `/_semanticstub/runtime/metrics` は process-local で、total request count、matched / unmatched count、fallback / semantic count、average latency、status code summary、top routes を返します。
-- `/_semanticstub/runtime/metrics/reset` は process-local な aggregate metrics と recent request history を消去します。configuration reload、scenario state の変更、`/_semanticstub/runtime/explain/last` の消去は行いません。
+- `/_semanticstub/runtime/metrics/resets` と `/_semanticstub/runtime/metrics/reset` は process-local な aggregate metrics と recent request history を消去します。configuration reload、scenario state の変更、`/_semanticstub/runtime/explain/last` の消去は行いません。
 - `/_semanticstub/runtime/requests` は process-local で、最大 100 件の recent request history を新しい順で返します。各 item には timestamp、method、path、利用可能な場合の route id、status code、elapsed time、match mode、および unmatched request の failure reason が含まれます。`limit` query parameter のデフォルトは `20` です。
 - `/_semanticstub/runtime/test-match` と `/_semanticstub/runtime/explain` は、method、path、省略可能な query / header / body、および省略可能な candidate detail flag を持つ virtual request payload を受け取ります。
 - `/_semanticstub/runtime/explain/last` は process-local で、実リクエストが stub response に match した後だけ更新されます。
-- `/_semanticstub/runtime/scenarios/reset` と `/_semanticstub/runtime/scenarios/{name}/reset` は、現在のプロセスの in-memory scenario state だけを変更します。
+- `/_semanticstub/runtime/scenarios/resets`、`/_semanticstub/runtime/scenarios/reset`、`/_semanticstub/runtime/scenarios/{name}/resets`、`/_semanticstub/runtime/scenarios/{name}/reset` は、現在のプロセスの in-memory scenario state だけを変更します。
 - これらの endpoint は、raw YAML、内部 domain object、完全な response payload body は公開しません。
 
 `POST /_semanticstub/runtime/test-match` と

--- a/README.md
+++ b/README.md
@@ -294,13 +294,13 @@ SemanticStub exposes runtime inspection endpoints under the reserved prefix
 - `GET /_semanticstub/runtime/routes/{routeId}` returns the effective runtime details for one active route.
 - `GET /_semanticstub/runtime/scenarios` returns the current scenario state snapshot.
 - `GET /_semanticstub/runtime/metrics` returns aggregate runtime metrics for real requests handled by the current process.
-- `POST /_semanticstub/runtime/metrics/reset` resets aggregate runtime metrics and recent request history for the current process.
+- `POST /_semanticstub/runtime/metrics/resets` resets aggregate runtime metrics and recent request history for the current process. `POST /_semanticstub/runtime/metrics/reset` remains supported for compatibility.
 - `GET /_semanticstub/runtime/requests?limit=20` returns a bounded recent request history for real requests handled by the current process.
 - `POST /_semanticstub/runtime/test-match` evaluates a virtual request without executing a real response or mutating scenario state.
 - `POST /_semanticstub/runtime/explain` returns structured match details for a virtual request, including deterministic and semantic evaluation when applicable.
 - `GET /_semanticstub/runtime/explain/last` returns the latest explanation captured from a real matched request in the current process.
-- `POST /_semanticstub/runtime/scenarios/reset` resets all configured scenarios back to their initial state.
-- `POST /_semanticstub/runtime/scenarios/{name}/reset` resets one configured scenario back to its initial state.
+- `POST /_semanticstub/runtime/scenarios/resets` resets all configured scenarios back to their initial state. `POST /_semanticstub/runtime/scenarios/reset` remains supported for compatibility.
+- `POST /_semanticstub/runtime/scenarios/{name}/resets` resets one configured scenario back to its initial state. `POST /_semanticstub/runtime/scenarios/{name}/reset` remains supported for compatibility.
 - YAML stub definitions under `/_semanticstub/runtime/*` are reserved for these inspection endpoints and are not reachable as normal stub routes.
 
 Inspection notes:
@@ -310,11 +310,11 @@ Inspection notes:
 - `/_semanticstub/runtime/routes/{routeId}` expands a single route into a stable detail view with top-level responses and normalized conditional match metadata.
 - `/_semanticstub/runtime/scenarios` returns one item per known scenario with its current state and whether it is active.
 - `/_semanticstub/runtime/metrics` is process-local and currently returns total request count, matched and unmatched counts, fallback and semantic counts, average latency, status-code summaries, and top routes.
-- `/_semanticstub/runtime/metrics/reset` clears process-local aggregate metrics and recent request history without reloading configuration, changing scenario state, or clearing `/_semanticstub/runtime/explain/last`.
+- `/_semanticstub/runtime/metrics/resets` and `/_semanticstub/runtime/metrics/reset` clear process-local aggregate metrics and recent request history without reloading configuration, changing scenario state, or clearing `/_semanticstub/runtime/explain/last`.
 - `/_semanticstub/runtime/requests` is process-local and currently returns up to 100 recent real requests in newest-first order. Each item includes timestamp, method, path, resolved route id when available, status code, elapsed time, match mode, and failure reason for unmatched requests. The `limit` query parameter defaults to `20`.
 - `/_semanticstub/runtime/test-match` and `/_semanticstub/runtime/explain` accept a virtual request payload with method, path, optional query/header/body values, and optional candidate-detail flags.
 - `/_semanticstub/runtime/explain/last` is process-local and only updates after a real request produces a matched stub response.
-- `/_semanticstub/runtime/scenarios/reset` and `/_semanticstub/runtime/scenarios/{name}/reset` mutate only in-memory scenario state for the current process.
+- `/_semanticstub/runtime/scenarios/resets`, `/_semanticstub/runtime/scenarios/reset`, `/_semanticstub/runtime/scenarios/{name}/resets`, and `/_semanticstub/runtime/scenarios/{name}/reset` mutate only in-memory scenario state for the current process.
 - These endpoints do not expose raw YAML, internal domain objects, or full response payload bodies.
 
 Example request body for `POST /_semanticstub/runtime/test-match` and

--- a/src/SemanticStub.Api/Controllers/StubInspectionController.cs
+++ b/src/SemanticStub.Api/Controllers/StubInspectionController.cs
@@ -51,6 +51,7 @@ public sealed class StubInspectionController : ControllerBase
 
     /// <summary>Resets aggregate runtime metrics and recent request history for the current process.</summary>
     [HttpPost("metrics/reset")]
+    [HttpPost("metrics/resets")]
     public IActionResult ResetMetrics()
     {
         _inspectionService.ResetRuntimeMetrics();
@@ -87,6 +88,7 @@ public sealed class StubInspectionController : ControllerBase
 
     /// <summary>Resets all configured scenarios back to their initial state.</summary>
     [HttpPost("scenarios/reset")]
+    [HttpPost("scenarios/resets")]
     public IActionResult ResetScenarios()
     {
         _inspectionService.ResetScenarioStates();
@@ -95,6 +97,7 @@ public sealed class StubInspectionController : ControllerBase
 
     /// <summary>Resets a configured scenario back to its initial state.</summary>
     [HttpPost("scenarios/{name}/reset")]
+    [HttpPost("scenarios/{name}/resets")]
     public IActionResult ResetScenario(string name)
     {
         return _inspectionService.ResetScenarioState(name)

--- a/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
@@ -219,12 +219,49 @@ public sealed class StubInspectionEndpointTests : IClassFixture<WebApplicationFa
     }
 
     [Fact]
+    public async Task ResetMetricsAlias_ReturnsNoContent()
+    {
+        var response = await client.PostAsync("/_semanticstub/runtime/metrics/resets", content: null);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
     public async Task ResetMetrics_ClearsMetricsAndRecentRequests()
     {
         var routedResponse = await client.GetAsync("/users?role=admin");
         routedResponse.EnsureSuccessStatusCode();
 
         var resetResponse = await client.PostAsync("/_semanticstub/runtime/metrics/reset", content: null);
+        Assert.Equal(HttpStatusCode.NoContent, resetResponse.StatusCode);
+
+        var metricsResponse = await client.GetAsync("/_semanticstub/runtime/metrics");
+        metricsResponse.EnsureSuccessStatusCode();
+        var metrics = await metricsResponse.Content.ReadFromJsonAsync<RuntimeMetricsSummaryInfo>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        var requestsResponse = await client.GetAsync("/_semanticstub/runtime/requests");
+        requestsResponse.EnsureSuccessStatusCode();
+        var requests = await requestsResponse.Content.ReadFromJsonAsync<RecentRequestInfo[]>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.NotNull(metrics);
+        Assert.Equal(0, metrics!.TotalRequestCount);
+        Assert.Equal(0, metrics.MatchedRequestCount);
+        Assert.Equal(0, metrics.UnmatchedRequestCount);
+        Assert.Empty(metrics.StatusCodes);
+        Assert.Empty(metrics.TopRoutes);
+        Assert.NotNull(requests);
+        Assert.Empty(requests!);
+    }
+
+    [Fact]
+    public async Task ResetMetricsAlias_ClearsMetricsAndRecentRequests()
+    {
+        var routedResponse = await client.GetAsync("/users?role=admin");
+        routedResponse.EnsureSuccessStatusCode();
+
+        var resetResponse = await client.PostAsync("/_semanticstub/runtime/metrics/resets", content: null);
         Assert.Equal(HttpStatusCode.NoContent, resetResponse.StatusCode);
 
         var metricsResponse = await client.GetAsync("/_semanticstub/runtime/metrics");
@@ -296,9 +333,34 @@ public sealed class StubInspectionEndpointTests : IClassFixture<WebApplicationFa
     }
 
     [Fact]
+    public async Task ResetScenariosAlias_ReturnsNoContent()
+    {
+        var response = await client.PostAsync("/_semanticstub/runtime/scenarios/resets", content: null);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ResetScenarioAlias_ReturnsNoContent_WhenScenarioExists()
+    {
+        var response = await client.PostAsync("/_semanticstub/runtime/scenarios/checkout-flow/resets", content: null);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
     public async Task ResetScenario_ReturnsNotFound_WhenScenarioDoesNotExist()
     {
         var response = await client.PostAsync("/_semanticstub/runtime/scenarios/does-not-exist/reset", content: null);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        await AssertNotFoundProblemDetails(response, "Scenario not found");
+    }
+
+    [Fact]
+    public async Task ResetScenarioAlias_ReturnsNotFound_WhenScenarioDoesNotExist()
+    {
+        var response = await client.PostAsync("/_semanticstub/runtime/scenarios/does-not-exist/resets", content: null);
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         await AssertNotFoundProblemDetails(response, "Scenario not found");


### PR DESCRIPTION
## Summary
- Add noun-style reset aliases for runtime inspection metrics and scenarios
- Keep existing operation-style reset routes working for compatibility
- Document both alias and compatibility routes in English and Japanese READMEs

## Files Changed
- src/SemanticStub.Api/Controllers/StubInspectionController.cs
- tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
- README.md
- README.ja.md

## Tests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter StubInspectionEndpointTests
- dotnet test

## Notes
Closes #234