### PR TITLE
fix: respect cancellation while waiting for scenario lock

### DIFF
--- a/src/SemanticStub.Api/Services/Resolution/StubService.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubService.cs
@@ -134,7 +134,8 @@ public sealed class StubService : IStubService
         if (OperationUsesScenario(operation))
         {
             return await _scenarioService.ExecuteLockedAsync(
-                () => DispatchCoreAsync(method, path, pathPattern, pathItem, operation, query, headers, body, mutateScenarioState, includeCandidates, includeSemanticCandidates, cancellationToken));
+                () => DispatchCoreAsync(method, path, pathPattern, pathItem, operation, query, headers, body, mutateScenarioState, includeCandidates, includeSemanticCandidates, cancellationToken),
+                cancellationToken);
         }
 
         return await DispatchCoreAsync(method, path, pathPattern, pathItem, operation, query, headers, body, mutateScenarioState, includeCandidates, includeSemanticCandidates, cancellationToken);

--- a/src/SemanticStub.Application/Services/Scenario/ScenarioService.cs
+++ b/src/SemanticStub.Application/Services/Scenario/ScenarioService.cs
@@ -158,7 +158,17 @@ public sealed class ScenarioService
     /// <param name="action">The scenario-aware async operation to run atomically.</param>
     public async Task<T> ExecuteLockedAsync<T>(Func<Task<T>> action)
     {
-        await _semaphore.WaitAsync();
+        return await ExecuteLockedAsync(action, CancellationToken.None);
+    }
+
+    /// <summary>
+    /// Executes scenario-sensitive selection and transition logic under one asynchronous lock so state checks and advances stay atomic across concurrent async requests.
+    /// </summary>
+    /// <param name="action">The scenario-aware async operation to run atomically.</param>
+    /// <param name="cancellationToken">The token that cancels waiting for the scenario lock.</param>
+    public async Task<T> ExecuteLockedAsync<T>(Func<Task<T>> action, CancellationToken cancellationToken)
+    {
+        await _semaphore.WaitAsync(cancellationToken);
         try
         {
             return await action();

--- a/tests/SemanticStub.Application.Tests/Unit/ScenarioServiceTests.cs
+++ b/tests/SemanticStub.Application.Tests/Unit/ScenarioServiceTests.cs
@@ -32,6 +32,40 @@ public sealed class ScenarioServiceTests
     }
 
     [Fact]
+    public async Task ExecuteLockedAsync_ThrowsOperationCanceledException_WhenCancellationIsRequestedWhileWaiting()
+    {
+        var service = new ScenarioService();
+        var lockEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseLock = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cts = new CancellationTokenSource();
+
+        var heldLock = service.ExecuteLockedAsync(async () =>
+        {
+            lockEntered.SetResult();
+            await releaseLock.Task;
+            return 0;
+        });
+
+        await lockEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var waitingForLock = service.ExecuteLockedAsync(
+            () => Task.FromResult(0),
+            cts.Token);
+
+        cts.Cancel();
+
+        try
+        {
+            await Assert.ThrowsAsync<OperationCanceledException>(() => waitingForLock);
+        }
+        finally
+        {
+            releaseLock.SetResult();
+            await heldLock;
+        }
+    }
+
+    [Fact]
     public void Reset_ClearsAdvancedScenarioState()
     {
         var service = new ScenarioService();


### PR DESCRIPTION
## Summary
- Add cancellation-aware scenario async lock acquisition.
- Pass request cancellation into scenario dispatch lock waits.
- Add a regression test for cancellation while waiting on the scenario lock.

## Files Changed
- src/SemanticStub.Application/Services/Scenario/ScenarioService.cs
- src/SemanticStub.Api/Services/Resolution/StubService.cs
- tests/SemanticStub.Application.Tests/Unit/ScenarioServiceTests.cs

## Tests
- dotnet test tests/SemanticStub.Application.Tests/SemanticStub.Application.Tests.csproj --filter FullyQualifiedName~ScenarioServiceTests.ExecuteLockedAsync_ThrowsOperationCanceledException_WhenCancellationIsRequestedWhileWaiting
- dotnet test

## Notes
Closes #239