### PR TITLE
test: add coverage collection support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.0" />

--- a/README.ja.md
+++ b/README.ja.md
@@ -438,6 +438,25 @@ Claude Skill を使うと、MCP ツールを効率よく利用できます。
 dotnet test
 ```
 
+Cobertura 形式でカバレッジを計測する場合:
+
+```sh
+dotnet test --collect:"XPlat Code Coverage"
+```
+
+結果を固定ディレクトリに出力する場合:
+
+```sh
+dotnet test --collect:"XPlat Code Coverage" --results-directory ./TestResults
+```
+
+必要に応じて ReportGenerator で Cobertura 出力から HTML レポートを生成できます:
+
+```sh
+dotnet tool install --global dotnet-reportgenerator-globaltool
+reportgenerator -reports:"TestResults/**/coverage.cobertura.xml" -targetdir:"TestResults/CoverageReport" -reporttypes:Html
+```
+
 ## 補足
 
 リポジトリ固有のガイダンスは `AGENTS.md` を参照してください。

--- a/README.md
+++ b/README.md
@@ -477,6 +477,25 @@ A Claude skill is available for efficient use of the MCP tools.
 dotnet test
 ```
 
+Collect coverage in Cobertura format:
+
+```sh
+dotnet test --collect:"XPlat Code Coverage"
+```
+
+Write coverage results to a fixed directory:
+
+```sh
+dotnet test --collect:"XPlat Code Coverage" --results-directory ./TestResults
+```
+
+Optionally generate an HTML report from the Cobertura output with ReportGenerator:
+
+```sh
+dotnet tool install --global dotnet-reportgenerator-globaltool
+reportgenerator -reports:"TestResults/**/coverage.cobertura.xml" -targetdir:"TestResults/CoverageReport" -reporttypes:Html
+```
+
 ## Notes
 See `AGENTS.md` for repository guidance.
 

--- a/tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj
+++ b/tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj
@@ -9,6 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/tests/SemanticStub.Application.Tests/SemanticStub.Application.Tests.csproj
+++ b/tests/SemanticStub.Application.Tests/SemanticStub.Application.Tests.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">


### PR DESCRIPTION
## Summary
- add `coverlet.collector` to the test projects so `dotnet test` can emit Cobertura coverage reports
- document the coverage commands in the English and Japanese READMEs
- keep the default test flow unchanged while adding optional ReportGenerator usage

## Verification
- `dotnet test /Users/yohei/github/SemanticStub/SemanticStub.sln`
- `dotnet test /Users/yohei/github/SemanticStub/SemanticStub.sln --collect:"XPlat Code Coverage" --results-directory /Users/yohei/github/SemanticStub/TestResults`