### PR TITLE
[codex] docs: expand README overview in English and Japanese

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,32 @@
 
 Semantic-aware な API モックサーバーです。
 
+
 English: [README.md](README.md)
+
+## 概要
+
+SemanticStub は、ローカル開発、テスト、AI 支援ワークフロー向けの semantic-aware な API モックサーバーです。
+
+決定的な OpenAPI ベースのルーティングと、必要に応じたセマンティックマッチングを組み合わせることで、厳密なモック動作を定義しつつ、自然言語ベースのフォールバックシナリオにも対応できます。
+
+### 主な機能
+
+- OpenAPI 3.1 ベースの YAML stub 定義と、SemanticStub 固有の動作を記述する `x-*` 拡張。
+- query string、header、JSON body、form-urlencoded body に対する条件付きリクエストマッチング。
+- Text Embeddings Inference (TEI) エンドポイントを利用したオプションのセマンティックマッチング。
+- インメモリ state transition によるシナリオベースのレスポンスフロー。
+- route、scenario、metrics、recent requests、match explanation を確認できる runtime inspection endpoint。
+- ファイルベースレスポンス、レスポンス遅延、Docker を使ったローカル開発サポート。
+
+## ❤️ Sponsors
+
+SemanticStub がワークフローの役に立ったら、スポンサーをご検討ください 🙌
+
+ご支援によって、次の取り組みを継続できます。
+- SemanticStub の保守と改善
+- 関連する開発者向けツールの開発
+- AI 支援開発に関する調査と実験
 
 ## YAML 拡張
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,30 @@ Semantic-aware API mock server.
 
 日本語版: [README.ja.md](README.ja.md)
 
+## Overview
+
+SemanticStub is a semantic-aware API mock server for local development, testing, and AI-assisted workflows.
+
+It combines deterministic OpenAPI-based routing with optional semantic matching, so you can define precise mock behavior while also supporting natural-language fallback scenarios.
+
+### Key features
+
+- OpenAPI 3.1-based YAML stub definitions with `x-*` extensions for SemanticStub-specific behavior.
+- Conditional request matching for query strings, headers, JSON bodies, and form-urlencoded bodies.
+- Optional semantic matching powered by a Text Embeddings Inference (TEI) endpoint.
+- Scenario-based response flows with in-memory state transitions.
+- Runtime inspection endpoints for routes, scenarios, metrics, recent requests, and match explanations.
+- File-backed responses, response delays, and Docker-based local development support.
+
+## ❤️ Sponsors
+
+If SemanticStub helps your workflow, consider sponsoring 🙌
+
+Your support helps:
+- Maintain and improve SemanticStub
+- Build related developer tools
+- Continue AI-assisted development research
+
 ## YAML Extensions
 
 SemanticStub uses OpenAPI 3.1 for the base document structure and `x-*`


### PR DESCRIPTION
## Summary
- expand the English README with a clearer product overview and feature summary
- add matching overview and sponsor sections to the Japanese README
- make the bilingual entry points more informative for new users

## Why
The README previously opened with only a minimal description. These additions make the project purpose, core capabilities, and sponsorship context easier to understand in both languages.

## Validation
- reviewed the staged diff for `README.md` and `README.ja.md`
- no automated checks were run because this is a documentation-only change