### PR TITLE
[codex] feat: expose inspection delay metadata

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -330,6 +330,7 @@ SemanticStub は、runtime inspection endpoint を予約プレフィックス
   "responses": [
     {
       "responseId": "200",
+      "delayMilliseconds": 100,
       "usesScenario": false,
       "scenario": null
     }
@@ -347,6 +348,7 @@ SemanticStub は、runtime inspection endpoint を予約プレフィックス
       "hasBody": false,
       "usesSemanticMatching": false,
       "responseStatusCode": 200,
+      "delayMilliseconds": null,
       "usesScenario": false,
       "scenario": null
     }

--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ Excerpt from the response body for `GET /_semanticstub/runtime/routes/listUsers`
   "responses": [
     {
       "responseId": "200",
+      "delayMilliseconds": 100,
       "usesScenario": false,
       "scenario": null
     }
@@ -386,6 +387,7 @@ Excerpt from the response body for `GET /_semanticstub/runtime/routes/listUsers`
       "hasBody": false,
       "usesSemanticMatching": false,
       "responseStatusCode": 200,
+      "delayMilliseconds": null,
       "usesScenario": false,
       "scenario": null
     }

--- a/src/SemanticStub.Api/Inspection/StubRouteConditionInfo.cs
+++ b/src/SemanticStub.Api/Inspection/StubRouteConditionInfo.cs
@@ -32,6 +32,9 @@ public sealed class StubRouteConditionInfo
     /// <summary>Gets the response status code selected by the candidate.</summary>
     public int ResponseStatusCode { get; init; }
 
+    /// <summary>Gets the configured response delay in milliseconds when present.</summary>
+    public int? DelayMilliseconds { get; init; }
+
     /// <summary>Gets whether the candidate response participates in a scenario state machine.</summary>
     public bool UsesScenario { get; init; }
 

--- a/src/SemanticStub.Api/Inspection/StubRouteResponseInfo.cs
+++ b/src/SemanticStub.Api/Inspection/StubRouteResponseInfo.cs
@@ -8,6 +8,9 @@ public sealed class StubRouteResponseInfo
     /// <summary>Gets the stable response identifier from the OpenAPI <c>responses</c> map key.</summary>
     public required string ResponseId { get; init; }
 
+    /// <summary>Gets the configured response delay in milliseconds when present.</summary>
+    public int? DelayMilliseconds { get; init; }
+
     /// <summary>Gets whether the response participates in a scenario state machine.</summary>
     public bool UsesScenario { get; init; }
 

--- a/src/SemanticStub.Api/Services/Inspection/StubInspectionDocumentProjector.cs
+++ b/src/SemanticStub.Api/Services/Inspection/StubInspectionDocumentProjector.cs
@@ -116,6 +116,7 @@ internal static class StubInspectionDocumentProjector
             .Select(entry => new StubRouteResponseInfo
             {
                 ResponseId = entry.Key,
+                DelayMilliseconds = entry.Value.DelayMilliseconds,
                 UsesScenario = entry.Value.Scenario is not null,
                 Scenario = BuildScenario(entry.Value.Scenario),
             })
@@ -136,6 +137,7 @@ internal static class StubInspectionDocumentProjector
                 HasBody = match.Body is not null,
                 UsesSemanticMatching = match.SemanticMatch is not null,
                 ResponseStatusCode = match.Response.StatusCode,
+                DelayMilliseconds = match.Response.DelayMilliseconds,
                 UsesScenario = match.Response.Scenario is not null,
                 Scenario = BuildScenario(match.Response.Scenario),
             })

--- a/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionServiceTests.cs
@@ -783,6 +783,7 @@ public sealed class StubInspectionServiceTests
                                 Response = new QueryMatchResponseDefinition
                                 {
                                     StatusCode = 202,
+                                    DelayMilliseconds = 250,
                                     Scenario = new ScenarioDefinition
                                     {
                                         Name = "checkout",
@@ -805,6 +806,7 @@ public sealed class StubInspectionServiceTests
                             ["200"] = new()
                             {
                                 Description = "Default users",
+                                DelayMilliseconds = 150,
                             },
                             ["409"] = new()
                             {
@@ -838,12 +840,14 @@ public sealed class StubInspectionServiceTests
             response =>
             {
                 Assert.Equal("200", response.ResponseId);
+                Assert.Equal(150, response.DelayMilliseconds);
                 Assert.False(response.UsesScenario);
                 Assert.Null(response.Scenario);
             },
             response =>
             {
                 Assert.Equal("409", response.ResponseId);
+                Assert.Null(response.DelayMilliseconds);
                 Assert.True(response.UsesScenario);
                 Assert.NotNull(response.Scenario);
                 Assert.Equal("checkout", response.Scenario!.Name);
@@ -864,6 +868,7 @@ public sealed class StubInspectionServiceTests
                 Assert.True(candidate.HasBody);
                 Assert.False(candidate.UsesSemanticMatching);
                 Assert.Equal(202, candidate.ResponseStatusCode);
+                Assert.Equal(250, candidate.DelayMilliseconds);
                 Assert.True(candidate.UsesScenario);
                 Assert.NotNull(candidate.Scenario);
                 Assert.Equal("checkout", candidate.Scenario!.Name);
@@ -881,6 +886,7 @@ public sealed class StubInspectionServiceTests
                 Assert.False(candidate.HasBody);
                 Assert.True(candidate.UsesSemanticMatching);
                 Assert.Equal(200, candidate.ResponseStatusCode);
+                Assert.Null(candidate.DelayMilliseconds);
                 Assert.False(candidate.UsesScenario);
                 Assert.Null(candidate.Scenario);
             });


### PR DESCRIPTION
## Summary

- expose configured response delays in route inspection detail responses
- include both top-level response delays and x-match response delays
- document the new delay metadata in the English and Japanese READMEs

## Why

Some routes can feel slower because they intentionally configure `x-delay`, but the existing inspection detail view did not surface that setting. This change makes the configured delay visible without changing routing behavior or YAML compatibility.

## Validation

- `dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter FullyQualifiedName~SemanticStub.Api.Tests.Unit.Inspection`
