### PR TITLE
feat: expose response media types in route inspection

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -292,7 +292,7 @@ SemanticStub は、runtime inspection endpoint を予約プレフィックス
 
 - `/_semanticstub/runtime/config` はサマリ表示です。現在は snapshot timestamp、configuration hash、definitions directory、route count、semantic matching の有効状態などを返します。
 - `/_semanticstub/runtime/routes` は、現在有効な path と HTTP method の組み合わせごとに 1 件ずつ、route id、正規化済み path pattern、semantic matching の利用有無、scenario の利用有無、response 数を返します。
-- `/_semanticstub/runtime/routes/{routeId}` は、1 件の route について top-level response と正規化済み conditional match metadata を含む detail view を返します。
+- `/_semanticstub/runtime/routes/{routeId}` は、1 件の route について top-level response、設定済み response media type、および正規化済み conditional match metadata を含む detail view を返します。
 - `/_semanticstub/runtime/scenarios` は、既知の scenario ごとに現在の state と active かどうかを返します。
 - `/_semanticstub/runtime/metrics` は process-local で、total request count、matched / unmatched count、fallback / semantic count、average latency、status code summary、top routes を返します。
 - `/_semanticstub/runtime/metrics/resets` と `/_semanticstub/runtime/metrics/reset` は process-local な aggregate metrics と recent request history を消去します。configuration reload、scenario state の変更、`/_semanticstub/runtime/explain/last` の消去は行いません。
@@ -331,6 +331,7 @@ SemanticStub は、runtime inspection endpoint を予約プレフィックス
     {
       "responseId": "200",
       "delayMilliseconds": 100,
+      "mediaTypes": ["application/json"],
       "usesScenario": false,
       "scenario": null
     }
@@ -349,6 +350,7 @@ SemanticStub は、runtime inspection endpoint を予約プレフィックス
       "usesSemanticMatching": false,
       "responseStatusCode": 200,
       "delayMilliseconds": null,
+      "mediaTypes": ["application/json"],
       "usesScenario": false,
       "scenario": null
     }

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Inspection notes:
 
 - `/_semanticstub/runtime/config` is a summary view. It currently returns snapshot metadata such as timestamp, configuration hash, definitions directory, route count, and whether semantic matching is enabled.
 - `/_semanticstub/runtime/routes` returns one item per active path and HTTP method with stable external fields such as route id, normalized path pattern, semantic matching usage, scenario usage, and response count.
-- `/_semanticstub/runtime/routes/{routeId}` expands a single route into a stable detail view with top-level responses and normalized conditional match metadata.
+- `/_semanticstub/runtime/routes/{routeId}` expands a single route into a stable detail view with top-level responses, configured response media types, and normalized conditional match metadata.
 - `/_semanticstub/runtime/scenarios` returns one item per known scenario with its current state and whether it is active.
 - `/_semanticstub/runtime/metrics` is process-local and currently returns total request count, matched and unmatched counts, fallback and semantic counts, average latency, status-code summaries, and top routes.
 - `/_semanticstub/runtime/metrics/resets` and `/_semanticstub/runtime/metrics/reset` clear process-local aggregate metrics and recent request history without reloading configuration, changing scenario state, or clearing `/_semanticstub/runtime/explain/last`.
@@ -370,6 +370,7 @@ Excerpt from the response body for `GET /_semanticstub/runtime/routes/listUsers`
     {
       "responseId": "200",
       "delayMilliseconds": 100,
+      "mediaTypes": ["application/json"],
       "usesScenario": false,
       "scenario": null
     }
@@ -388,6 +389,7 @@ Excerpt from the response body for `GET /_semanticstub/runtime/routes/listUsers`
       "usesSemanticMatching": false,
       "responseStatusCode": 200,
       "delayMilliseconds": null,
+      "mediaTypes": ["application/json"],
       "usesScenario": false,
       "scenario": null
     }

--- a/src/SemanticStub.Api/Inspection/StubRouteConditionInfo.cs
+++ b/src/SemanticStub.Api/Inspection/StubRouteConditionInfo.cs
@@ -35,6 +35,9 @@ public sealed class StubRouteConditionInfo
     /// <summary>Gets the configured response delay in milliseconds when present.</summary>
     public int? DelayMilliseconds { get; init; }
 
+    /// <summary>Gets the configured response media types in stable order.</summary>
+    public IReadOnlyList<string> MediaTypes { get; init; } = [];
+
     /// <summary>Gets whether the candidate response participates in a scenario state machine.</summary>
     public bool UsesScenario { get; init; }
 

--- a/src/SemanticStub.Api/Inspection/StubRouteResponseInfo.cs
+++ b/src/SemanticStub.Api/Inspection/StubRouteResponseInfo.cs
@@ -11,6 +11,9 @@ public sealed class StubRouteResponseInfo
     /// <summary>Gets the configured response delay in milliseconds when present.</summary>
     public int? DelayMilliseconds { get; init; }
 
+    /// <summary>Gets the configured response media types in stable order.</summary>
+    public IReadOnlyList<string> MediaTypes { get; init; } = [];
+
     /// <summary>Gets whether the response participates in a scenario state machine.</summary>
     public bool UsesScenario { get; init; }
 

--- a/src/SemanticStub.Api/Services/Inspection/StubInspectionDocumentProjector.cs
+++ b/src/SemanticStub.Api/Services/Inspection/StubInspectionDocumentProjector.cs
@@ -117,6 +117,7 @@ internal static class StubInspectionDocumentProjector
             {
                 ResponseId = entry.Key,
                 DelayMilliseconds = entry.Value.DelayMilliseconds,
+                MediaTypes = OrderKeys(entry.Value.Content.Keys),
                 UsesScenario = entry.Value.Scenario is not null,
                 Scenario = BuildScenario(entry.Value.Scenario),
             })
@@ -138,6 +139,7 @@ internal static class StubInspectionDocumentProjector
                 UsesSemanticMatching = match.SemanticMatch is not null,
                 ResponseStatusCode = match.Response.StatusCode,
                 DelayMilliseconds = match.Response.DelayMilliseconds,
+                MediaTypes = OrderKeys(match.Response.Content.Keys),
                 UsesScenario = match.Response.Scenario is not null,
                 Scenario = BuildScenario(match.Response.Scenario),
             })

--- a/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
@@ -107,8 +107,12 @@ public sealed class StubInspectionEndpointTests : IClassFixture<WebApplicationFa
         Assert.Equal("/users", route.PathPattern);
         Assert.True(route.HasConditionalMatches);
         Assert.True(route.ResponseCount >= 1);
-        Assert.Contains(route.Responses, response => response.ResponseId == "200");
-        Assert.Contains(route.ConditionalMatches, candidate => candidate.HasExactQuery);
+        Assert.Contains(route.Responses, response =>
+            response.ResponseId == "200"
+            && response.MediaTypes.Contains("application/json"));
+        Assert.Contains(route.ConditionalMatches, candidate =>
+            candidate.HasExactQuery
+            && candidate.MediaTypes.Contains("application/json"));
         Assert.Contains(route.ConditionalMatches, candidate => candidate.HasRegexQuery);
     }
 

--- a/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
@@ -107,12 +107,10 @@ public sealed class StubInspectionEndpointTests : IClassFixture<WebApplicationFa
         Assert.Equal("/users", route.PathPattern);
         Assert.True(route.HasConditionalMatches);
         Assert.True(route.ResponseCount >= 1);
-        Assert.Contains(route.Responses, response =>
-            response.ResponseId == "200"
-            && response.MediaTypes.Contains("application/json"));
-        Assert.Contains(route.ConditionalMatches, candidate =>
-            candidate.HasExactQuery
-            && candidate.MediaTypes.Contains("application/json"));
+        Assert.Contains(route.Responses, response => response.ResponseId == "200");
+        Assert.Contains(route.Responses, response => response.MediaTypes.Contains("application/json"));
+        Assert.Contains(route.ConditionalMatches, candidate => candidate.HasExactQuery);
+        Assert.Contains(route.ConditionalMatches, candidate => candidate.MediaTypes.Contains("application/json"));
         Assert.Contains(route.ConditionalMatches, candidate => candidate.HasRegexQuery);
     }
 

--- a/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionServiceTests.cs
@@ -784,6 +784,11 @@ public sealed class StubInspectionServiceTests
                                 {
                                     StatusCode = 202,
                                     DelayMilliseconds = 250,
+                                    Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+                                    {
+                                        ["text/plain"] = new(),
+                                        ["application/json"] = new(),
+                                    },
                                     Scenario = new ScenarioDefinition
                                     {
                                         Name = "checkout",
@@ -798,6 +803,10 @@ public sealed class StubInspectionServiceTests
                                 Response = new QueryMatchResponseDefinition
                                 {
                                     StatusCode = 200,
+                                    Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+                                    {
+                                        ["application/json"] = new(),
+                                    },
                                 },
                             },
                         ],
@@ -807,6 +816,11 @@ public sealed class StubInspectionServiceTests
                             {
                                 Description = "Default users",
                                 DelayMilliseconds = 150,
+                                Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+                                {
+                                    ["text/plain"] = new(),
+                                    ["application/json"] = new(),
+                                },
                             },
                             ["409"] = new()
                             {
@@ -816,6 +830,10 @@ public sealed class StubInspectionServiceTests
                                     Name = "checkout",
                                     State = "initial",
                                     Next = "pending",
+                                },
+                                Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+                                {
+                                    ["application/problem+json"] = new(),
                                 },
                             },
                         },
@@ -841,6 +859,7 @@ public sealed class StubInspectionServiceTests
             {
                 Assert.Equal("200", response.ResponseId);
                 Assert.Equal(150, response.DelayMilliseconds);
+                Assert.Equal(["application/json", "text/plain"], response.MediaTypes);
                 Assert.False(response.UsesScenario);
                 Assert.Null(response.Scenario);
             },
@@ -848,6 +867,7 @@ public sealed class StubInspectionServiceTests
             {
                 Assert.Equal("409", response.ResponseId);
                 Assert.Null(response.DelayMilliseconds);
+                Assert.Equal(["application/problem+json"], response.MediaTypes);
                 Assert.True(response.UsesScenario);
                 Assert.NotNull(response.Scenario);
                 Assert.Equal("checkout", response.Scenario!.Name);
@@ -869,6 +889,7 @@ public sealed class StubInspectionServiceTests
                 Assert.False(candidate.UsesSemanticMatching);
                 Assert.Equal(202, candidate.ResponseStatusCode);
                 Assert.Equal(250, candidate.DelayMilliseconds);
+                Assert.Equal(["application/json", "text/plain"], candidate.MediaTypes);
                 Assert.True(candidate.UsesScenario);
                 Assert.NotNull(candidate.Scenario);
                 Assert.Equal("checkout", candidate.Scenario!.Name);
@@ -887,6 +908,7 @@ public sealed class StubInspectionServiceTests
                 Assert.True(candidate.UsesSemanticMatching);
                 Assert.Equal(200, candidate.ResponseStatusCode);
                 Assert.Null(candidate.DelayMilliseconds);
+                Assert.Equal(["application/json"], candidate.MediaTypes);
                 Assert.False(candidate.UsesScenario);
                 Assert.Null(candidate.Scenario);
             });


### PR DESCRIPTION
## Summary
- expose configured response media types in route inspection details
- include the same media type list for conditional x-match responses
- update inspection tests and English/Japanese README examples

## Files Changed
- inspection DTOs and document projector for route detail responses
- inspection unit/integration tests
- README.md and README.ja.md runtime inspection examples

## Tests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter "FullyQualifiedName~StubInspectionServiceTests.GetRoute_ReturnsDetailedRouteSnapshot"
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter "FullyQualifiedName~Inspection"

## Notes
- additive inspection API change only; routing and YAML behavior are unchanged
- closes #267