### PR TITLE
feat: expose x-response-file metadata in route inspection

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -292,7 +292,7 @@ SemanticStub は、runtime inspection endpoint を予約プレフィックス
 
 - `/_semanticstub/runtime/config` はサマリ表示です。現在は snapshot timestamp、configuration hash、definitions directory、route count、semantic matching の有効状態などを返します。
 - `/_semanticstub/runtime/routes` は、現在有効な path と HTTP method の組み合わせごとに 1 件ずつ、route id、正規化済み path pattern、semantic matching の利用有無、scenario の利用有無、response 数を返します。
-- `/_semanticstub/runtime/routes/{routeId}` は、1 件の route について top-level response、設定済み response media type、および正規化済み conditional match metadata を含む detail view を返します。
+- `/_semanticstub/runtime/routes/{routeId}` は、1 件の route について top-level response、設定済み response-file metadata、設定済み response media type、および正規化済み conditional match metadata を含む detail view を返します。
 - `/_semanticstub/runtime/scenarios` は、既知の scenario ごとに現在の state と active かどうかを返します。
 - `/_semanticstub/runtime/metrics` は process-local で、total request count、matched / unmatched count、fallback / semantic count、average latency、status code summary、top routes を返します。
 - `/_semanticstub/runtime/metrics/resets` と `/_semanticstub/runtime/metrics/reset` は process-local な aggregate metrics と recent request history を消去します。configuration reload、scenario state の変更、`/_semanticstub/runtime/explain/last` の消去は行いません。
@@ -331,6 +331,7 @@ SemanticStub は、runtime inspection endpoint を予約プレフィックス
     {
       "responseId": "200",
       "delayMilliseconds": 100,
+      "responseFile": "users.json",
       "mediaTypes": ["application/json"],
       "usesScenario": false,
       "scenario": null
@@ -350,6 +351,7 @@ SemanticStub は、runtime inspection endpoint を予約プレフィックス
       "usesSemanticMatching": false,
       "responseStatusCode": 200,
       "delayMilliseconds": null,
+      "responseFile": null,
       "mediaTypes": ["application/json"],
       "usesScenario": false,
       "scenario": null

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Inspection notes:
 
 - `/_semanticstub/runtime/config` is a summary view. It currently returns snapshot metadata such as timestamp, configuration hash, definitions directory, route count, and whether semantic matching is enabled.
 - `/_semanticstub/runtime/routes` returns one item per active path and HTTP method with stable external fields such as route id, normalized path pattern, semantic matching usage, scenario usage, and response count.
-- `/_semanticstub/runtime/routes/{routeId}` expands a single route into a stable detail view with top-level responses, configured response media types, and normalized conditional match metadata.
+- `/_semanticstub/runtime/routes/{routeId}` expands a single route into a stable detail view with top-level responses, configured response-file metadata, configured response media types, and normalized conditional match metadata.
 - `/_semanticstub/runtime/scenarios` returns one item per known scenario with its current state and whether it is active.
 - `/_semanticstub/runtime/metrics` is process-local and currently returns total request count, matched and unmatched counts, fallback and semantic counts, average latency, status-code summaries, and top routes.
 - `/_semanticstub/runtime/metrics/resets` and `/_semanticstub/runtime/metrics/reset` clear process-local aggregate metrics and recent request history without reloading configuration, changing scenario state, or clearing `/_semanticstub/runtime/explain/last`.
@@ -370,6 +370,7 @@ Excerpt from the response body for `GET /_semanticstub/runtime/routes/listUsers`
     {
       "responseId": "200",
       "delayMilliseconds": 100,
+      "responseFile": "users.json",
       "mediaTypes": ["application/json"],
       "usesScenario": false,
       "scenario": null
@@ -389,6 +390,7 @@ Excerpt from the response body for `GET /_semanticstub/runtime/routes/listUsers`
       "usesSemanticMatching": false,
       "responseStatusCode": 200,
       "delayMilliseconds": null,
+      "responseFile": null,
       "mediaTypes": ["application/json"],
       "usesScenario": false,
       "scenario": null

--- a/src/SemanticStub.Api/Inspection/StubRouteConditionInfo.cs
+++ b/src/SemanticStub.Api/Inspection/StubRouteConditionInfo.cs
@@ -35,6 +35,9 @@ public sealed class StubRouteConditionInfo
     /// <summary>Gets the configured response delay in milliseconds when present.</summary>
     public int? DelayMilliseconds { get; init; }
 
+    /// <summary>Gets the configured response file name when <c>x-response-file</c> is used.</summary>
+    public string? ResponseFile { get; init; }
+
     /// <summary>Gets the configured response media types in stable order.</summary>
     public IReadOnlyList<string> MediaTypes { get; init; } = [];
 

--- a/src/SemanticStub.Api/Inspection/StubRouteResponseInfo.cs
+++ b/src/SemanticStub.Api/Inspection/StubRouteResponseInfo.cs
@@ -11,6 +11,9 @@ public sealed class StubRouteResponseInfo
     /// <summary>Gets the configured response delay in milliseconds when present.</summary>
     public int? DelayMilliseconds { get; init; }
 
+    /// <summary>Gets the configured response file name when <c>x-response-file</c> is used.</summary>
+    public string? ResponseFile { get; init; }
+
     /// <summary>Gets the configured response media types in stable order.</summary>
     public IReadOnlyList<string> MediaTypes { get; init; } = [];
 

--- a/src/SemanticStub.Api/Services/Inspection/StubInspectionDocumentProjector.cs
+++ b/src/SemanticStub.Api/Services/Inspection/StubInspectionDocumentProjector.cs
@@ -117,6 +117,7 @@ internal static class StubInspectionDocumentProjector
             {
                 ResponseId = entry.Key,
                 DelayMilliseconds = entry.Value.DelayMilliseconds,
+                ResponseFile = GetResponseFileName(entry.Value.ResponseFile),
                 MediaTypes = OrderKeys(entry.Value.Content.Keys),
                 UsesScenario = entry.Value.Scenario is not null,
                 Scenario = BuildScenario(entry.Value.Scenario),
@@ -139,6 +140,7 @@ internal static class StubInspectionDocumentProjector
                 UsesSemanticMatching = match.SemanticMatch is not null,
                 ResponseStatusCode = match.Response.StatusCode,
                 DelayMilliseconds = match.Response.DelayMilliseconds,
+                ResponseFile = GetResponseFileName(match.Response.ResponseFile),
                 MediaTypes = OrderKeys(match.Response.Content.Keys),
                 UsesScenario = match.Response.Scenario is not null,
                 Scenario = BuildScenario(match.Response.Scenario),
@@ -160,6 +162,11 @@ internal static class StubInspectionDocumentProjector
 
     private static IReadOnlyList<string> OrderKeys(IEnumerable<string> keys)
         => keys.OrderBy(key => key, StringComparer.Ordinal).ToList();
+
+    private static string? GetResponseFileName(string? responseFile)
+        => string.IsNullOrWhiteSpace(responseFile)
+            ? null
+            : Path.GetFileName(responseFile);
 
     private static IReadOnlyList<string> GetEqualsKeys(IReadOnlyDictionary<string, object?> fields)
         => fields

--- a/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
@@ -108,9 +108,11 @@ public sealed class StubInspectionEndpointTests : IClassFixture<WebApplicationFa
         Assert.True(route.HasConditionalMatches);
         Assert.True(route.ResponseCount >= 1);
         Assert.Contains(route.Responses, response => response.ResponseId == "200");
+        Assert.Contains(route.Responses, response => response.ResponseId == "200" && response.ResponseFile == "users.json");
         Assert.Contains(route.Responses, response => response.MediaTypes.Contains("application/json"));
         Assert.Contains(route.ConditionalMatches, candidate => candidate.HasExactQuery);
         Assert.Contains(route.ConditionalMatches, candidate => candidate.MediaTypes.Contains("application/json"));
+        Assert.Contains(route.ConditionalMatches, candidate => candidate.ResponseFile is null);
         Assert.Contains(route.ConditionalMatches, candidate => candidate.HasRegexQuery);
     }
 

--- a/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionServiceTests.cs
@@ -784,6 +784,7 @@ public sealed class StubInspectionServiceTests
                                 {
                                     StatusCode = 202,
                                     DelayMilliseconds = 250,
+                                    ResponseFile = "/stubs/payloads/admin-users.json",
                                     Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
                                     {
                                         ["text/plain"] = new(),
@@ -816,6 +817,7 @@ public sealed class StubInspectionServiceTests
                             {
                                 Description = "Default users",
                                 DelayMilliseconds = 150,
+                                ResponseFile = "/stubs/payloads/users.json",
                                 Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
                                 {
                                     ["text/plain"] = new(),
@@ -859,6 +861,7 @@ public sealed class StubInspectionServiceTests
             {
                 Assert.Equal("200", response.ResponseId);
                 Assert.Equal(150, response.DelayMilliseconds);
+                Assert.Equal("users.json", response.ResponseFile);
                 Assert.Equal(["application/json", "text/plain"], response.MediaTypes);
                 Assert.False(response.UsesScenario);
                 Assert.Null(response.Scenario);
@@ -867,6 +870,7 @@ public sealed class StubInspectionServiceTests
             {
                 Assert.Equal("409", response.ResponseId);
                 Assert.Null(response.DelayMilliseconds);
+                Assert.Null(response.ResponseFile);
                 Assert.Equal(["application/problem+json"], response.MediaTypes);
                 Assert.True(response.UsesScenario);
                 Assert.NotNull(response.Scenario);
@@ -889,6 +893,7 @@ public sealed class StubInspectionServiceTests
                 Assert.False(candidate.UsesSemanticMatching);
                 Assert.Equal(202, candidate.ResponseStatusCode);
                 Assert.Equal(250, candidate.DelayMilliseconds);
+                Assert.Equal("admin-users.json", candidate.ResponseFile);
                 Assert.Equal(["application/json", "text/plain"], candidate.MediaTypes);
                 Assert.True(candidate.UsesScenario);
                 Assert.NotNull(candidate.Scenario);
@@ -908,6 +913,7 @@ public sealed class StubInspectionServiceTests
                 Assert.True(candidate.UsesSemanticMatching);
                 Assert.Equal(200, candidate.ResponseStatusCode);
                 Assert.Null(candidate.DelayMilliseconds);
+                Assert.Null(candidate.ResponseFile);
                 Assert.Equal(["application/json"], candidate.MediaTypes);
                 Assert.False(candidate.UsesScenario);
                 Assert.Null(candidate.Scenario);


### PR DESCRIPTION
## Summary
- expose response-file metadata in route inspection details for top-level responses and x-match candidates
- surface the configured response file name without exposing payload contents
- update inspection tests and English/Japanese README examples

## Files Changed
- inspection DTOs and projector
- inspection unit and integration tests
- README.md and README.ja.md

## Tests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter "FullyQualifiedName~StubInspectionServiceTests|FullyQualifiedName~StubInspectionEndpointTests"

## Notes
- This is a projection-only change and does not modify YAML compatibility or routing behavior.
- Closes #265