### PR TITLE
[codex] docs: update agent guidance documents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@
 Refer to SKILLS.md for reusable task patterns.
 When a task name is specified, follow the corresponding skill.
 
+@SKILLS.md
+
 ## Architecture Constraints
 - Preserve existing structure (Controller / Service / Infrastructure)
 - Do not move logic across layers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,91 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
 @AGENTS.md
 
-## Claude Code
+## Commands
 
-Use plan mode for changes under `src/`,`test/`,`mcp/`.
+```sh
+# Run the application
+dotnet run --project src/SemanticStub.Api
+
+# Run with Development environment (enables appsettings.Development.json)
+ASPNETCORE_ENVIRONMENT=Development dotnet run --project src/SemanticStub.Api
+
+# Run all tests
+dotnet test
+
+# Run a single test project
+dotnet test tests/SemanticStub.Application.Tests
+
+# Run tests with coverage
+dotnet test --collect:"XPlat Code Coverage" --results-directory ./TestResults
+
+# Format code
+dotnet format
+
+# Verify formatting (CI)
+dotnet format --verify-no-changes
+
+# Docker
+docker compose build
+docker compose up -d tei semantic-stub
+```
+
+## Architecture
+
+SemanticStub is an ASP.NET Core API mock server. It loads OpenAPI 3.1 YAML stub definitions and serves responses based on deterministic routing with optional semantic (vector embedding) fallback matching.
+
+### Layers
+
+- **`SemanticStub.Api`** — HTTP entry point: controllers, middleware, request/response shaping. No business logic here.
+- **`SemanticStub.Application`** — Business logic and orchestration: matching, scenario state, response selection, route compilation. Depends only on abstractions (interfaces).
+- **`SemanticStub.Infrastructure`** — Concrete implementations: YAML parsing, embedding HTTP client (`SemanticEmbeddingClient`), file I/O.
+
+Dependency rules: `Api → Application ← Infrastructure`. Application must not reference Infrastructure types directly.
+
+### Request Handling Flow
+
+`StubController` → `StubService` → route resolution (`StubRouteResolver`) → conditional matching (`StubDispatchSelector`) → semantic fallback → response building (`StubResponseBuilder`). Inspection endpoints are handled separately via `StubInspectionController`.
+
+### Key Subsystems
+
+- **`x-match` matching** (`Application/Services/Matching/`): evaluates query, header, body, and form conditions with AND semantics; selects the most specific match.
+- **Scenario state** (`Application/Services/Scenario/`): in-memory state machine per named scenario; transitions are serialized to be deterministic.
+- **Semantic matching** (`Infrastructure/Semantic/`): calls a TEI endpoint for cosine similarity; only runs when all deterministic matches fail.
+- **Inspection endpoints** (`Api/Inspection/`, `Api/Controllers/StubInspectionController.cs`): `/_semanticstub/runtime/*` routes expose routes, scenarios, metrics, and match explanations.
+
+### Configuration
+
+Settings live in `appsettings.json`; `appsettings.Development.json` applies only in the `Development` environment. Use strongly-typed Options classes (`IOptions<T>`); never inject `IConfiguration` into services. Configuration section is `StubSettings`.
+
+## Testing
+
+- **Unit tests** (`Application.Tests`): cover matchers, route parsing, scenario transitions, response selection via public APIs. Use xUnit + Moq + Shouldly.
+- **Integration tests** (`Api.Tests`): use `WebApplicationFactory`; test HTTP pipeline, routing, and DI wiring. Replace only truly external dependencies.
+- **Test naming**: `MethodName_Condition_ExpectedResult` (e.g., `TryMatchRoute_WhenPatternMatches_ReturnsTrue`).
+- Add regression tests for bug fixes; do not remove tests without reason.
+
+## Development Guides
+
+Detailed standards in `docs/development/`:
+
+| File | Covers |
+|------|--------|
+| `testing-strategy.md` | Unit vs integration vs E2E, mocking policy |
+| `naming-conventions.md` | PascalCase/camelCase/`_camelCase` rules, suffixes |
+| `dependency-injection.md` | Service lifetimes, registration style, interface usage |
+| `tech-stack.md` | xUnit, Moq, Shouldly, YamlDotNet, `dotnet format` |
+| `project-structure.md` | Layer responsibilities, feature-level organization |
+| `error-handling.md` | Expected vs unexpected errors, centralized handler |
+| `api-design.md` | REST conventions, thin controllers, DTOs |
+| `configuration.md` | Options pattern, startup validation |
+| `async-guidelines.md` | CancellationToken, no `.Result`/`.Wait()` |
+| `logging.md` | Structured logging, log levels, no sensitive data |
+
+## Language Rules
+
+- All commit messages, PR titles/descriptions, and GitHub issues: English only.
+- Follow Conventional Commits (`feat:`, `fix:`, `refactor:`, etc.).
+- Inline code comments may be in Japanese when it improves clarity.

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -11,25 +11,18 @@ When a task name is mentioned, follow the corresponding instructions.
 Execute the full development workflow for an issue from planning to merge.
 
 ### Workflow
+- Output: "Executing step: run-issue-end-to-end"
 1. Run `plan-issue`
 2. Run `implement-issue`
 3. Run `review`
 4. Run `create-pr`
 
-5. **Pause and wait for review feedback**
-   - Do NOT proceed automatically beyond this point
-   - Resume only when explicit instruction or review comments are provided
+5. **HARD STOP: Wait for review feedback**
+   - You MUST stop execution
+   - You MUST NOT proceed automatically
+   - You MUST wait for explicit user input
 
-6. While review comments exist:
-   - Run `plan-review-response`
-   - Run `implement-review-response`
-   - Run `update-pr-after-review`
-
-   - **Pause and wait for re-review feedback**
-     - Do NOT proceed automatically beyond this point
-     - Resume only when explicit instruction or further comments are provided
-
-   - Stop looping when all review comments are resolved or explicit approval is given
+6. Run `handle-review-loop`
 
 7. Run `merge`
 
@@ -37,24 +30,39 @@ Execute the full development workflow for an issue from planning to merge.
 - Follow AGENTS.md
 - Do not skip steps unless explicitly instructed
 - Ensure each step completes successfully before moving to the next
-- MUST pause after `create-pr` and wait for external input before continuing
-- MUST pause after `update-pr-after-review` and wait for re-review before continuing
-- MUST continue the review loop until all comments are resolved or explicit approval is given, then proceed to `merge`
+- MUST stop after `create-pr` and wait for external input before continuing
 
-### Decision Handling
-- If critical decisions are required, pause and ask for confirmation before proceeding.
+---
 
-Critical decisions include:
-- Ambiguous requirements not clearly defined in the issue
-- Multiple implementation approaches with different trade-offs
-- Changes affecting YAML schema, API behavior, or external contracts
-- Unclear test expectations
+## handle-review-loop
 
-- For non-critical implementation details, proceed autonomously.
+### Goal
+Handle review iterations until approval.
 
-### Output
-- Summary of each step execution
-- Final merge result
+### Workflow
+- Output: "Executing step: handle-review-loop"
+1. While review comments exist:
+   - Run `plan-review-response`
+   - Run `implement-review-response`
+   - Run `update-pr-after-review`
+
+2. **HARD STOP: Wait for re-review feedback**
+   - You MUST stop execution
+   - You MUST NOT proceed automatically
+   - You MUST wait for explicit user input
+
+### Exit Condition
+- All review comments are resolved OR
+- Explicit approval is given
+
+If neither condition is met:
+- Continue the loop
+- DO NOT proceed to merge
+
+### Constraints
+- Follow AGENTS.md
+- Do not skip loop iterations
+- MUST wait for explicit feedback after each iteration
 
 ---
 
@@ -324,12 +332,23 @@ Safely merge a reviewed pull request and synchronize local/remote states.
 3. Verify PR branch has no conflicts with updated `main`
 4. Perform squash merge
 5. Push merge result to remote
-6. Delete source branch (remote and local if applicable)
+6. Delete source branch (remote only)
 7. Ensure local `main` matches merged remote state
 8. Close the related issue
+9. Clean local workspace for next work:
+   - Remove the merged feature branch locally (if exists)
+   - Ensure current branch is `main`
+   - Ensure working tree is clean (no uncommitted changes)
+   - Remove any temporary or stale branches not needed
 
 ### Output
 - merge result (success / failure)
 - performed checks
 - final commit message
 - post-merge local/remote branch status
+- local workspace cleanup status
+
+### Completion Criteria
+- Local main matches remote origin/main
+- Merged source branch is deleted locally
+- Current branch is main


### PR DESCRIPTION
## Summary

- add an explicit `@SKILLS.md` reference in `AGENTS.md`
- expand `CLAUDE.md` with repository-specific commands, architecture, testing, and language guidance
- clarify `SKILLS.md` workflow stop points and merge cleanup expectations

## Why

These updates make the repository guidance more explicit and consistent across agent-facing documents, reducing ambiguity in development workflows.

## Validation

- `git diff --cached --check` (passed before commit)
- verified the committed diff only touches `AGENTS.md`, `CLAUDE.md`, and `SKILLS.md`
