### PR TITLE
feat: expose semantic match summaries in route inspection

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -292,7 +292,7 @@ SemanticStub は、runtime inspection endpoint を予約プレフィックス
 
 - `/_semanticstub/runtime/config` はサマリ表示です。現在は snapshot timestamp、configuration hash、definitions directory、route count、semantic matching の有効状態などを返します。
 - `/_semanticstub/runtime/routes` は、現在有効な path と HTTP method の組み合わせごとに 1 件ずつ、route id、正規化済み path pattern、semantic matching の利用有無、scenario の利用有無、response 数を返します。
-- `/_semanticstub/runtime/routes/{routeId}` は、1 件の route について top-level response、設定済み response-file metadata、設定済み response media type、および正規化済み conditional match metadata を含む detail view を返します。
+- `/_semanticstub/runtime/routes/{routeId}` は、1 件の route について top-level response、設定済み response-file metadata、設定済み response media type、および正規化済み conditional match metadata を含む detail view を返します。`x-semantic-match` が設定されている場合は、簡潔な semantic-match summary も含まれます。
 - `/_semanticstub/runtime/scenarios` は、既知の scenario ごとに現在の state と active かどうかを返します。
 - `/_semanticstub/runtime/metrics` は process-local で、total request count、matched / unmatched count、fallback / semantic count、average latency、status code summary、top routes を返します。
 - `/_semanticstub/runtime/metrics/resets` と `/_semanticstub/runtime/metrics/reset` は process-local な aggregate metrics と recent request history を消去します。configuration reload、scenario state の変更、`/_semanticstub/runtime/explain/last` の消去は行いません。
@@ -349,6 +349,7 @@ SemanticStub は、runtime inspection endpoint を予約プレフィックス
       "headerKeys": [],
       "hasBody": false,
       "usesSemanticMatching": false,
+      "semanticMatchSummary": null,
       "responseStatusCode": 200,
       "delayMilliseconds": null,
       "responseFile": null,

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Inspection notes:
 
 - `/_semanticstub/runtime/config` is a summary view. It currently returns snapshot metadata such as timestamp, configuration hash, definitions directory, route count, and whether semantic matching is enabled.
 - `/_semanticstub/runtime/routes` returns one item per active path and HTTP method with stable external fields such as route id, normalized path pattern, semantic matching usage, scenario usage, and response count.
-- `/_semanticstub/runtime/routes/{routeId}` expands a single route into a stable detail view with top-level responses, configured response-file metadata, configured response media types, and normalized conditional match metadata.
+- `/_semanticstub/runtime/routes/{routeId}` expands a single route into a stable detail view with top-level responses, configured response-file metadata, configured response media types, and normalized conditional match metadata, including a concise semantic-match summary when `x-semantic-match` is configured.
 - `/_semanticstub/runtime/scenarios` returns one item per known scenario with its current state and whether it is active.
 - `/_semanticstub/runtime/metrics` is process-local and currently returns total request count, matched and unmatched counts, fallback and semantic counts, average latency, status-code summaries, and top routes.
 - `/_semanticstub/runtime/metrics/resets` and `/_semanticstub/runtime/metrics/reset` clear process-local aggregate metrics and recent request history without reloading configuration, changing scenario state, or clearing `/_semanticstub/runtime/explain/last`.
@@ -388,6 +388,7 @@ Excerpt from the response body for `GET /_semanticstub/runtime/routes/listUsers`
       "headerKeys": [],
       "hasBody": false,
       "usesSemanticMatching": false,
+      "semanticMatchSummary": null,
       "responseStatusCode": 200,
       "delayMilliseconds": null,
       "responseFile": null,

--- a/src/SemanticStub.Api/Inspection/StubRouteConditionInfo.cs
+++ b/src/SemanticStub.Api/Inspection/StubRouteConditionInfo.cs
@@ -29,6 +29,9 @@ public sealed class StubRouteConditionInfo
     /// <summary>Gets whether the candidate uses semantic matching.</summary>
     public bool UsesSemanticMatching { get; init; }
 
+    /// <summary>Gets the stable, human-readable semantic match summary when configured.</summary>
+    public string? SemanticMatchSummary { get; init; }
+
     /// <summary>Gets the response status code selected by the candidate.</summary>
     public int ResponseStatusCode { get; init; }
 

--- a/src/SemanticStub.Api/Services/Inspection/StubInspectionDocumentProjector.cs
+++ b/src/SemanticStub.Api/Services/Inspection/StubInspectionDocumentProjector.cs
@@ -138,6 +138,7 @@ internal static class StubInspectionDocumentProjector
                 HeaderKeys = OrderKeys(match.Headers.Keys),
                 HasBody = match.Body is not null,
                 UsesSemanticMatching = match.SemanticMatch is not null,
+                SemanticMatchSummary = BuildSemanticMatchSummary(match.SemanticMatch),
                 ResponseStatusCode = match.Response.StatusCode,
                 DelayMilliseconds = match.Response.DelayMilliseconds,
                 ResponseFile = GetResponseFileName(match.Response.ResponseFile),
@@ -167,6 +168,19 @@ internal static class StubInspectionDocumentProjector
         => string.IsNullOrWhiteSpace(responseFile)
             ? null
             : Path.GetFileName(responseFile);
+
+    private static string? BuildSemanticMatchSummary(string? semanticMatch)
+    {
+        if (string.IsNullOrWhiteSpace(semanticMatch))
+        {
+            return null;
+        }
+
+        return string.Join(
+            " ",
+            semanticMatch
+                .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+    }
 
     private static IReadOnlyList<string> GetEqualsKeys(IReadOnlyDictionary<string, object?> fields)
         => fields

--- a/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionServiceTests.cs
@@ -891,6 +891,7 @@ public sealed class StubInspectionServiceTests
                 Assert.Equal(["X-Env"], candidate.HeaderKeys);
                 Assert.True(candidate.HasBody);
                 Assert.False(candidate.UsesSemanticMatching);
+                Assert.Null(candidate.SemanticMatchSummary);
                 Assert.Equal(202, candidate.ResponseStatusCode);
                 Assert.Equal(250, candidate.DelayMilliseconds);
                 Assert.Equal("admin-users.json", candidate.ResponseFile);
@@ -911,6 +912,7 @@ public sealed class StubInspectionServiceTests
                 Assert.Empty(candidate.HeaderKeys);
                 Assert.False(candidate.HasBody);
                 Assert.True(candidate.UsesSemanticMatching);
+                Assert.Equal("find administrator user accounts", candidate.SemanticMatchSummary);
                 Assert.Equal(200, candidate.ResponseStatusCode);
                 Assert.Null(candidate.DelayMilliseconds);
                 Assert.Null(candidate.ResponseFile);
@@ -918,6 +920,45 @@ public sealed class StubInspectionServiceTests
                 Assert.False(candidate.UsesScenario);
                 Assert.Null(candidate.Scenario);
             });
+    }
+
+    [Fact]
+    public void GetRoute_NormalizesSemanticMatchSummaryWhitespace()
+    {
+        var document = new StubDocument
+        {
+            Paths = new Dictionary<string, PathItemDefinition>(StringComparer.Ordinal)
+            {
+                ["/users"] = new()
+                {
+                    Get = new OperationDefinition
+                    {
+                        OperationId = "listUsers",
+                        Matches =
+                        [
+                            new QueryMatchDefinition
+                            {
+                                SemanticMatch = "  find   administrator \n user accounts  ",
+                                Response = new QueryMatchResponseDefinition
+                                {
+                                    StatusCode = 200,
+                                },
+                            },
+                        ],
+                        Responses = new Dictionary<string, ResponseDefinition>(StringComparer.Ordinal)
+                        {
+                            ["200"] = new(),
+                        },
+                    },
+                },
+            },
+        };
+
+        var route = CreateService(document).GetRoute("listUsers");
+
+        Assert.NotNull(route);
+        var candidate = Assert.Single(route!.ConditionalMatches);
+        Assert.Equal("find administrator user accounts", candidate.SemanticMatchSummary);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- expose a normalized semantic match summary on route inspection conditional matches
- keep semantic evaluation behavior unchanged and preserve existing YAML compatibility
- document the new inspection field in both READMEs

## Files Changed
- src/SemanticStub.Api/Inspection/StubRouteConditionInfo.cs
- src/SemanticStub.Api/Services/Inspection/StubInspectionDocumentProjector.cs
- tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionServiceTests.cs
- README.md
- README.ja.md

## Tests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter "GetRoute_ReturnsDetailedRouteSnapshot|GetRoute_NormalizesSemanticMatchSummaryWhitespace"
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter "GetRoute_|GetRoutes_|GetConfigSnapshot_"
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj

## Notes
- Adds the inspection field additively without changing runtime semantic matching behavior.
- Closes #269