### PR TITLE
feat: clarify scenario transitions in route inspection

### DIFF
--- a/src/SemanticStub.Api/Inspection/StubRouteScenarioInfo.cs
+++ b/src/SemanticStub.Api/Inspection/StubRouteScenarioInfo.cs
@@ -11,6 +11,9 @@ public sealed class StubRouteScenarioInfo
     /// <summary>Gets the required current scenario state.</summary>
     public required string State { get; init; }
 
+    /// <summary>Gets whether the response advances the scenario to a different state after it matches.</summary>
+    public bool AdvancesScenarioState { get; init; }
+
     /// <summary>Gets the next scenario state persisted after a match, when configured.</summary>
     public string? Next { get; init; }
 }

--- a/src/SemanticStub.Api/Services/Inspection/StubInspectionDocumentProjector.cs
+++ b/src/SemanticStub.Api/Services/Inspection/StubInspectionDocumentProjector.cs
@@ -157,6 +157,7 @@ internal static class StubInspectionDocumentProjector
             {
                 Name = scenario.Name,
                 State = scenario.State,
+                AdvancesScenarioState = !string.IsNullOrWhiteSpace(scenario.Next),
                 Next = scenario.Next,
             };
     }

--- a/src/SemanticStub.Api/Services/Inspection/StubInspectionDocumentProjector.cs
+++ b/src/SemanticStub.Api/Services/Inspection/StubInspectionDocumentProjector.cs
@@ -157,7 +157,9 @@ internal static class StubInspectionDocumentProjector
             {
                 Name = scenario.Name,
                 State = scenario.State,
-                AdvancesScenarioState = !string.IsNullOrWhiteSpace(scenario.Next),
+                AdvancesScenarioState =
+                    !string.IsNullOrWhiteSpace(scenario.Next)
+                    && !string.Equals(scenario.State, scenario.Next, StringComparison.Ordinal),
                 Next = scenario.Next,
             };
     }

--- a/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
@@ -135,6 +135,7 @@ public sealed class StubInspectionEndpointTests : IClassFixture<WebApplicationFa
             && response.Scenario is not null
             && response.Scenario.Name == "checkout-flow"
             && response.Scenario.State == "initial"
+            && response.Scenario.AdvancesScenarioState
             && response.Scenario.Next == "confirmed");
     }
 

--- a/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionServiceTests.cs
@@ -964,6 +964,43 @@ public sealed class StubInspectionServiceTests
     }
 
     [Fact]
+    public void GetRoute_ScenarioAdvanceFlag_IsFalseForSelfLoopScenario()
+    {
+        var document = new StubDocument
+        {
+            Paths = new Dictionary<string, PathItemDefinition>(StringComparer.Ordinal)
+            {
+                ["/checkout"] = new()
+                {
+                    Post = new OperationDefinition
+                    {
+                        OperationId = "checkout",
+                        Responses = new Dictionary<string, ResponseDefinition>(StringComparer.Ordinal)
+                        {
+                            ["200"] = new()
+                            {
+                                Scenario = new ScenarioDefinition
+                                {
+                                    Name = "checkout-flow",
+                                    State = "confirmed",
+                                    Next = "confirmed",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        var route = CreateService(document).GetRoute("checkout");
+
+        Assert.NotNull(route);
+        var response = Assert.Single(route!.Responses);
+        Assert.NotNull(response.Scenario);
+        Assert.False(response.Scenario!.AdvancesScenarioState);
+    }
+
+    [Fact]
     public void GetRoute_UsesMethodColonPath_WhenOperationIdIsEmpty()
     {
         var document = new StubDocument

--- a/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionServiceTests.cs
@@ -876,6 +876,7 @@ public sealed class StubInspectionServiceTests
                 Assert.NotNull(response.Scenario);
                 Assert.Equal("checkout", response.Scenario!.Name);
                 Assert.Equal("initial", response.Scenario.State);
+                Assert.True(response.Scenario.AdvancesScenarioState);
                 Assert.Equal("pending", response.Scenario.Next);
             });
 
@@ -900,6 +901,7 @@ public sealed class StubInspectionServiceTests
                 Assert.NotNull(candidate.Scenario);
                 Assert.Equal("checkout", candidate.Scenario!.Name);
                 Assert.Equal("pending", candidate.Scenario.State);
+                Assert.True(candidate.Scenario.AdvancesScenarioState);
                 Assert.Equal("complete", candidate.Scenario.Next);
             },
             candidate =>


### PR DESCRIPTION
## Summary
- add an explicit inspection flag for responses that advance scenario state
- keep existing scenario name/state/next metadata intact
- cover top-level and conditional scenario transitions in inspection tests

## Files Changed
- add the AdvancesScenarioState field to route inspection scenario metadata
- populate the derived flag in the inspection document projector
- update unit and integration inspection tests

## Tests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter FullyQualifiedName~StubInspection
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj

## Notes
- additive inspection-only change; no YAML structure or scenario behavior changes
- closes #268