### PR TITLE
docs: clarify merge cleanup in run-issue-end-to-end

### DIFF
--- a/SKILLS.md
+++ b/SKILLS.md
@@ -41,7 +41,7 @@ Execute the full development workflow for an issue from planning to merge.
 
 6. Run `handle-review-loop`
 
-7. Run `merge`
+7. Run `merge` (including post-merge local cleanup)
 
 ### Constraints
 - Follow AGENTS.md


### PR DESCRIPTION
## Summary
- clarify that the merge step in run-issue-end-to-end includes post-merge local cleanup

## Files Changed
- update the run-issue-end-to-end workflow wording in SKILLS.md

## Tests
- not run (documentation-only change)

## Notes
- keeps the merge section unchanged and makes the cleanup expectation visible from the top-level workflow