### PR TITLE
feat: expose selected response source in inspection

### DIFF
--- a/src/SemanticStub.Api/Inspection/MatchSimulationInfo.cs
+++ b/src/SemanticStub.Api/Inspection/MatchSimulationInfo.cs
@@ -41,6 +41,17 @@ public sealed class MatchSimulationInfo
     public int? SelectedResponseStatusCode { get; init; }
 
     /// <summary>
+    /// Gets the YAML response source that produced the selected response when available.
+    /// Expected values are <c>responses</c> and <c>x-match</c>.
+    /// </summary>
+    public string? SelectedResponseSource { get; init; }
+
+    /// <summary>
+    /// Gets the selected conditional candidate index when the response came from <c>x-match</c>.
+    /// </summary>
+    public int? SelectedResponseCandidateIndex { get; init; }
+
+    /// <summary>
     /// Gets the match mode when a response was selected.
     /// </summary>
     public string? MatchMode { get; init; }

--- a/src/SemanticStub.Api/Services/Resolution/StubDispatchSelector.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubDispatchSelector.cs
@@ -63,6 +63,8 @@ internal sealed class StubDispatchSelector
                     Result = StubMatchResult.ResponseNotConfigured,
                     MatchMode = "exact",
                     SelectedCandidate = selectedDeterministicCandidate,
+                    SelectedResponseSource = "x-match",
+                    SelectedResponseCandidateIndex = matchedCandidateIndex,
                     SelectedResponseId = selectedDeterministicCandidate.Response.StatusCode.ToString(),
                     SelectedResponseStatusCode = selectedDeterministicCandidate.Response.StatusCode,
                     SelectionReason = $"Deterministic candidate {matchedCandidateIndex} matched, but its response is not configured.",
@@ -88,6 +90,8 @@ internal sealed class StubDispatchSelector
                 Response = deterministicResponse,
                 MatchMode = "exact",
                 SelectedCandidate = selectedDeterministicCandidate,
+                SelectedResponseSource = "x-match",
+                SelectedResponseCandidateIndex = matchedCandidateIndex,
                 SelectedResponseId = selectedDeterministicCandidate.Response.StatusCode.ToString(),
                 SelectedResponseStatusCode = selectedDeterministicCandidate.Response.StatusCode,
                 SelectionReason = $"Deterministic candidate {matchedCandidateIndex} matched all configured conditions and was selected.",
@@ -109,6 +113,8 @@ internal sealed class StubDispatchSelector
 
         if (semanticExplanation.SelectedCandidate is not null)
         {
+            var selectedSemanticCandidateIndex = operation.Matches.FindIndex(candidate => ReferenceEquals(candidate, semanticExplanation.SelectedCandidate));
+
             if (!_responseBuilder.TryBuild(semanticExplanation.SelectedCandidate.Response, out var semanticResponse))
             {
                 return new StubDispatchSelectionResult
@@ -117,6 +123,8 @@ internal sealed class StubDispatchSelector
                     Response = null,
                     MatchMode = "semantic",
                     SelectedCandidate = semanticExplanation.SelectedCandidate,
+                    SelectedResponseSource = "x-match",
+                    SelectedResponseCandidateIndex = selectedSemanticCandidateIndex,
                     SelectedResponseId = semanticExplanation.SelectedCandidate.Response.StatusCode.ToString(),
                     SelectedResponseStatusCode = semanticExplanation.SelectedCandidate.Response.StatusCode,
                     SelectionReason = "Semantic fallback selected a candidate, but its response is not configured.",
@@ -140,6 +148,8 @@ internal sealed class StubDispatchSelector
                 Response = semanticResponse,
                 MatchMode = "semantic",
                 SelectedCandidate = semanticExplanation.SelectedCandidate,
+                SelectedResponseSource = "x-match",
+                SelectedResponseCandidateIndex = selectedSemanticCandidateIndex,
                 SelectedResponseId = semanticExplanation.SelectedCandidate.Response.StatusCode.ToString(),
                 SelectedResponseStatusCode = semanticExplanation.SelectedCandidate.Response.StatusCode,
                 SelectionReason = "Semantic fallback selected the highest-scoring eligible candidate.",
@@ -154,6 +164,7 @@ internal sealed class StubDispatchSelector
                 Result = StubMatchResult.Matched,
                 Response = defaultSelection.Response,
                 MatchMode = "fallback",
+                SelectedResponseSource = "responses",
                 SelectedResponseId = defaultSelection.ResponseId,
                 SelectedResponseStatusCode = defaultSelection.StatusCode,
                 SelectionReason = "No conditional candidate matched, so the eligible default response was selected.",
@@ -190,6 +201,10 @@ internal sealed class StubDispatchSelectionResult
     public string? MatchMode { get; init; }
 
     public QueryMatchDefinition? SelectedCandidate { get; init; }
+
+    public string? SelectedResponseSource { get; init; }
+
+    public int? SelectedResponseCandidateIndex { get; init; }
 
     public string? SelectedResponseId { get; init; }
 

--- a/src/SemanticStub.Api/Services/Resolution/StubMatchExplanationBuilder.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubMatchExplanationBuilder.cs
@@ -40,6 +40,8 @@ internal static class StubMatchExplanationBuilder
         string? matchMode,
         string? selectedResponseId,
         int? selectedResponseStatusCode,
+        string? selectedResponseSource,
+        int? selectedResponseCandidateIndex,
         string selectionReason)
     {
         return new StubDispatchResult
@@ -62,6 +64,8 @@ internal static class StubMatchExplanationBuilder
                     PathPattern = pathPattern,
                     SelectedResponseId = selectedResponseId,
                     SelectedResponseStatusCode = selectedResponseStatusCode,
+                    SelectedResponseSource = selectedResponseSource,
+                    SelectedResponseCandidateIndex = selectedResponseCandidateIndex,
                     MatchMode = matchMode,
                     Candidates = request.IncludeCandidates ? deterministicCandidates : [],
                 }

--- a/src/SemanticStub.Api/Services/Resolution/StubService.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubService.cs
@@ -187,6 +187,8 @@ public sealed class StubService : IStubService
 
         string? selectedResponseId = selection.SelectedResponseId;
         int? selectedResponseStatusCode = selection.SelectedResponseStatusCode;
+        string? selectedResponseSource = selection.SelectedResponseSource;
+        int? selectedResponseCandidateIndex = selection.SelectedResponseCandidateIndex;
 
         if (selection.SelectedCandidate is not null)
         {
@@ -219,6 +221,8 @@ public sealed class StubService : IStubService
             selection.MatchMode,
             selectedResponseId,
             selectedResponseStatusCode,
+            selectedResponseSource,
+            selectedResponseCandidateIndex,
             selection.SelectionReason);
     }
 

--- a/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionServiceTests.cs
@@ -1203,6 +1203,8 @@ public sealed class StubInspectionServiceTests
         Assert.True(explanation.Result.Matched);
         Assert.Equal("exact", explanation.Result.MatchMode);
         Assert.Equal("listUsers", explanation.Result.RouteId);
+        Assert.Equal("x-match", explanation.Result.SelectedResponseSource);
+        Assert.Equal(0, explanation.Result.SelectedResponseCandidateIndex);
         Assert.Equal(2, explanation.DeterministicCandidates.Count);
         Assert.True(explanation.DeterministicCandidates[0].Matched);
         Assert.False(explanation.DeterministicCandidates[1].Matched);
@@ -1479,6 +1481,8 @@ public sealed class StubInspectionServiceTests
         Assert.True(explanation!.Result.Matched);
         Assert.Equal("fallback", explanation.Result.MatchMode);
         Assert.Equal("listUsers", explanation.Result.RouteId);
+        Assert.Equal("responses", explanation.Result.SelectedResponseSource);
+        Assert.Null(explanation.Result.SelectedResponseCandidateIndex);
     }
 
     [Fact]

--- a/tests/SemanticStub.Api.Tests/Unit/Resolution/StubMatchExplanationBuilderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Resolution/StubMatchExplanationBuilderTests.cs
@@ -55,6 +55,8 @@ public sealed class StubMatchExplanationBuilderTests
             "fallback",
             "200",
             200,
+            "responses",
+            selectedResponseCandidateIndex: null,
             "No conditional candidate matched, so the eligible default response was selected.");
 
         Assert.True(dispatch.Explanation.PathMatched);
@@ -63,5 +65,37 @@ public sealed class StubMatchExplanationBuilderTests
         Assert.Empty(dispatch.Explanation.Result.Candidates);
         Assert.Equal("listUsers", dispatch.Explanation.Result.RouteId);
         Assert.Equal("fallback", dispatch.Explanation.Result.MatchMode);
+        Assert.Equal("responses", dispatch.Explanation.Result.SelectedResponseSource);
+        Assert.Null(dispatch.Explanation.Result.SelectedResponseCandidateIndex);
+    }
+
+    [Fact]
+    public void CreateMatchedDispatchResult_ProjectsConditionalResponseSource()
+    {
+        var request = new MatchRequestInfo
+        {
+            Method = "GET",
+            Path = "/users",
+            IncludeCandidates = true,
+        };
+
+        var dispatch = StubMatchExplanationBuilder.CreateMatchedDispatchResult(
+            request,
+            "listUsers",
+            "GET",
+            "/users",
+            [],
+            semanticEvaluation: null,
+            StubMatchResult.Matched,
+            new StubResponse { StatusCode = 202, Body = "{}", ContentType = "application/json" },
+            "exact",
+            "202",
+            202,
+            "x-match",
+            1,
+            "Deterministic candidate 1 matched all configured conditions and was selected.");
+
+        Assert.Equal("x-match", dispatch.Explanation.Result.SelectedResponseSource);
+        Assert.Equal(1, dispatch.Explanation.Result.SelectedResponseCandidateIndex);
     }
 }

--- a/tests/SemanticStub.Api.Tests/Unit/Resolution/StubMatchExplanationBuilderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Resolution/StubMatchExplanationBuilderTests.cs
@@ -70,7 +70,7 @@ public sealed class StubMatchExplanationBuilderTests
     }
 
     [Fact]
-    public void CreateMatchedDispatchResult_ProjectsConditionalResponseSource()
+    public void CreateMatchedDispatchResult_WhenSourceIsXMatch_SetsSelectedResponseSourceAndCandidateIndex()
     {
         var request = new MatchRequestInfo
         {


### PR DESCRIPTION
## Summary
- expose stable inspection metadata for the selected response source
- distinguish top-level responses from x-match selections with an optional candidate index
- cover fallback and conditional selection cases with focused tests

## Files Changed
- inspection match simulation DTO and selection plumbing
- resolution selection/builder flow for selected response source metadata
- unit tests for fallback and conditional inspection output

## Tests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter "FullyQualifiedName~StubMatchExplanationBuilderTests|FullyQualifiedName~StubInspectionServiceTests"
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter "FullyQualifiedName~StubDispatchSelectorTests|FullyQualifiedName~StubInspectionProjectionBuilderTests|FullyQualifiedName~StubInspectionServiceTests|FullyQualifiedName~StubMatchExplanationBuilderTests|FullyQualifiedName~StubInspectionEndpointTests"

## Notes
- preserves existing routing behavior and YAML compatibility by extending inspection DTOs only