### PR TITLE
chore: add correlated console logging for local debugging

### DIFF
--- a/src/SemanticStub.Api/Controllers/StubController.cs
+++ b/src/SemanticStub.Api/Controllers/StubController.cs
@@ -188,6 +188,16 @@ public sealed class StubController : ControllerBase
             dispatch.Explanation,
             statusCode,
             elapsed);
+
+        _logger.LogInformation(
+            "Request completed for '{Path}' {Method}. StatusCode={StatusCode}, ElapsedMs={ElapsedMs}, RouteId={RouteId}, MatchMode={MatchMode}, MatchResult={MatchResult}.",
+            requestPath,
+            method,
+            statusCode,
+            Math.Max(0, elapsed.TotalMilliseconds),
+            dispatch.Explanation.Result.RouteId,
+            dispatch.Explanation.Result.MatchMode,
+            dispatch.Explanation.Result.MatchResult);
     }
 
 }

--- a/src/SemanticStub.Api/Program.cs
+++ b/src/SemanticStub.Api/Program.cs
@@ -2,11 +2,29 @@ using System.IO.Compression;
 using Microsoft.AspNetCore.HttpLogging;
 using Microsoft.AspNetCore.RequestDecompression;
 using Microsoft.AspNetCore.ResponseCompression;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
 using SemanticStub.Api.Extensions;
 using SemanticStub.Application.Infrastructure.Yaml;
 
 var builder = WebApplication.CreateBuilder(args);
 
+builder.Logging.Configure(options =>
+{
+    options.ActivityTrackingOptions =
+        ActivityTrackingOptions.SpanId |
+        ActivityTrackingOptions.TraceId;
+});
+builder.Services.Configure<ConsoleLoggerOptions>(options =>
+{
+    options.FormatterName = ConsoleFormatterNames.Simple;
+});
+builder.Services.Configure<SimpleConsoleFormatterOptions>(options =>
+{
+    options.SingleLine = true;
+    options.IncludeScopes = true;
+    options.TimestampFormat = "yyyy-MM-dd HH:mm:ss.fff zzz ";
+});
 builder.Services.AddControllers();
 builder.Services.AddHttpLogging(options =>
 {

--- a/src/SemanticStub.Api/Program.cs
+++ b/src/SemanticStub.Api/Program.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.HttpLogging;
 using Microsoft.AspNetCore.RequestDecompression;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Console;
 using SemanticStub.Api.Extensions;
 using SemanticStub.Application.Infrastructure.Yaml;
 
@@ -14,16 +13,6 @@ builder.Logging.Configure(options =>
     options.ActivityTrackingOptions =
         ActivityTrackingOptions.SpanId |
         ActivityTrackingOptions.TraceId;
-});
-builder.Services.Configure<ConsoleLoggerOptions>(options =>
-{
-    options.FormatterName = ConsoleFormatterNames.Simple;
-});
-builder.Services.Configure<SimpleConsoleFormatterOptions>(options =>
-{
-    options.SingleLine = true;
-    options.IncludeScopes = true;
-    options.TimestampFormat = "yyyy-MM-dd HH:mm:ss.fff zzz ";
 });
 builder.Services.AddControllers();
 builder.Services.AddHttpLogging(options =>

--- a/src/SemanticStub.Api/appsettings.Development.json
+++ b/src/SemanticStub.Api/appsettings.Development.json
@@ -8,8 +8,7 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning",
-      "SemanticStub.Api": "Debug",
-      "SemanticStub.Api.Services.SemanticMatcherService": "Trace"
+      "SemanticStub.Application.Services.Semantic.SemanticMatcherService": "Debug"
     }
   },
   "StubSettings": {

--- a/src/SemanticStub.Api/appsettings.json
+++ b/src/SemanticStub.Api/appsettings.json
@@ -1,5 +1,13 @@
 {
   "Logging": {
+    "Console": {
+      "FormatterName": "simple",
+      "FormatterOptions": {
+        "SingleLine": true,
+        "IncludeScopes": true,
+        "TimestampFormat": "yyyy-MM-dd HH:mm:ss.fff zzz "
+      }
+    },
     "LogLevel": {
       "Default": "Warning",
       "Microsoft.AspNetCore.HttpLogging": "Information",

--- a/src/SemanticStub.Application/Services/Semantic/SemanticMatcherService.cs
+++ b/src/SemanticStub.Application/Services/Semantic/SemanticMatcherService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using SemanticStub.Application.Infrastructure.Yaml;
@@ -38,6 +39,7 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
     {
         var semanticSettings = _settings.SemanticMatching;
         var normalizedMethod = method.ToUpperInvariant();
+        var totalStopwatch = Stopwatch.StartNew();
 
         if (!IsEnabled(out var disabledReason))
         {
@@ -73,6 +75,7 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
                 semanticSettings.TopScoreMargin,
                 semanticCandidates.Count);
 
+            var embeddingStopwatch = Stopwatch.StartNew();
             var allEmbeddings = await GetEmbeddingsAsync(
                 method,
                 path,
@@ -81,8 +84,16 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
                 body,
                 semanticCandidates,
                 cancellationToken);
+            embeddingStopwatch.Stop();
 
-            return ScoreAndLogExplanation(
+            _logger.LogDebug(
+                "Semantic embedding request completed for '{Path}' {Method}. ElapsedMs={ElapsedMs}, Candidates={CandidateCount}.",
+                path,
+                normalizedMethod,
+                Math.Max(0, embeddingStopwatch.Elapsed.TotalMilliseconds),
+                semanticCandidates.Count);
+
+            var explanation = ScoreAndLogExplanation(
                 path,
                 normalizedMethod,
                 semanticCandidates,
@@ -90,33 +101,51 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
                 semanticSettings.Threshold,
                 semanticSettings.TopScoreMargin,
                 includeCandidateScores);
+
+            totalStopwatch.Stop();
+
+            _logger.LogInformation(
+                "Semantic matching completed for '{Path}' {Method}. ElapsedMs={ElapsedMs}, MatchSelected={MatchSelected}, CandidateCount={CandidateCount}.",
+                path,
+                normalizedMethod,
+                Math.Max(0, totalStopwatch.Elapsed.TotalMilliseconds),
+                explanation.SelectedCandidate is not null,
+                semanticCandidates.Count);
+
+            return explanation;
         }
         catch (HttpRequestException ex)
         {
+            totalStopwatch.Stop();
             _logger.LogWarning(
                 ex,
-                "Semantic matching failed for '{Path}' {Method}: the embedding endpoint request failed. Treating the request as a non-match.",
+                "Semantic matching failed for '{Path}' {Method}: the embedding endpoint request failed after {ElapsedMs}ms. Treating the request as a non-match.",
                 path,
-                normalizedMethod);
+                normalizedMethod,
+                Math.Max(0, totalStopwatch.Elapsed.TotalMilliseconds));
             return CreateFailedExplanation(semanticSettings);
         }
         catch (TaskCanceledException ex)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            totalStopwatch.Stop();
             _logger.LogWarning(
                 ex,
-                "Semantic matching failed for '{Path}' {Method}: the embedding endpoint request timed out. Treating the request as a non-match.",
+                "Semantic matching failed for '{Path}' {Method}: the embedding endpoint request timed out after {ElapsedMs}ms. Treating the request as a non-match.",
                 path,
-                normalizedMethod);
+                normalizedMethod,
+                Math.Max(0, totalStopwatch.Elapsed.TotalMilliseconds));
             return CreateFailedExplanation(semanticSettings);
         }
         catch (InvalidOperationException ex)
         {
+            totalStopwatch.Stop();
             _logger.LogWarning(
                 ex,
-                "Semantic matching failed for '{Path}' {Method}: the embedding endpoint returned an unexpected response. Treating the request as a non-match.",
+                "Semantic matching failed for '{Path}' {Method}: the embedding endpoint returned an unexpected response after {ElapsedMs}ms. Treating the request as a non-match.",
                 path,
-                normalizedMethod);
+                normalizedMethod,
+                Math.Max(0, totalStopwatch.Elapsed.TotalMilliseconds));
             return CreateFailedExplanation(semanticSettings);
         }
     }

--- a/tests/SemanticStub.Api.Tests/Integration/HttpLoggingTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/HttpLoggingTests.cs
@@ -93,6 +93,17 @@ public sealed class HttpLoggingTests
     }
 
     [Fact]
+    public void CreateClient_DevelopmentConfiguresSemanticMatcherCategoryAtDebug()
+    {
+        using var factory = new HttpLoggingFactory("Development");
+        using var client = factory.CreateClient();
+
+        var configuration = factory.Services.GetRequiredService<IConfiguration>();
+
+        Assert.Equal("Debug", configuration["Logging:LogLevel:SemanticStub.Application.Services.Semantic.SemanticMatcherService"]);
+    }
+
+    [Fact]
     public void CreateClient_ConfiguresConsoleLoggingForReadableCorrelatedOutput()
     {
         using var factory = new HttpLoggingFactory("Production");

--- a/tests/SemanticStub.Api.Tests/Integration/HttpLoggingTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/HttpLoggingTests.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
 using Microsoft.Extensions.Options;
 using Xunit;
 
@@ -92,6 +93,23 @@ public sealed class HttpLoggingTests
     }
 
     [Fact]
+    public void CreateClient_ConfiguresConsoleLoggingForReadableCorrelatedOutput()
+    {
+        using var factory = new HttpLoggingFactory("Production");
+        using var client = factory.CreateClient();
+
+        var loggerFactoryOptions = factory.Services.GetRequiredService<IOptions<LoggerFactoryOptions>>().Value;
+        var consoleOptions = factory.Services.GetRequiredService<IOptions<ConsoleLoggerOptions>>().Value;
+        var formatterOptions = factory.Services.GetRequiredService<IOptions<SimpleConsoleFormatterOptions>>().Value;
+
+        Assert.True(loggerFactoryOptions.ActivityTrackingOptions.HasFlag(ActivityTrackingOptions.TraceId));
+        Assert.Equal(ConsoleFormatterNames.Simple, consoleOptions.FormatterName);
+        Assert.True(formatterOptions.SingleLine);
+        Assert.True(formatterOptions.IncludeScopes);
+        Assert.Equal("yyyy-MM-dd HH:mm:ss.fff zzz ", formatterOptions.TimestampFormat);
+    }
+
+    [Fact]
     public async Task GetPlainText_WritesTextResponseBodyToHttpLogs()
     {
         using var workspace = HttpLoggingWorkspace.Create(
@@ -120,6 +138,42 @@ public sealed class HttpLoggingTests
             sink.Entries,
             entry => entry.Category.Contains("HttpLoggingMiddleware", StringComparison.Ordinal) &&
                      entry.Message.Contains("plain text response", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task GetHello_WritesRequestCompletionLogWithRouteAndMatchContext()
+    {
+        using var workspace = HttpLoggingWorkspace.Create(
+            """
+            openapi: 3.1.0
+            paths:
+              /hello:
+                get:
+                  responses:
+                    "200":
+                      description: ok
+                      content:
+                        application/json:
+                          example:
+                            message: hello
+            """);
+        var sink = new TestLoggerProvider();
+
+        using var factory = new HttpLoggingFactory("Development", sink, workspace.RootPath);
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/hello");
+
+        response.EnsureSuccessStatusCode();
+
+        Assert.Contains(
+            sink.Entries,
+            entry => entry.Category.Contains("StubController", StringComparison.Ordinal) &&
+                     entry.Message.Contains("Request completed for '/hello' GET.", StringComparison.Ordinal) &&
+                     entry.Message.Contains("StatusCode=200", StringComparison.Ordinal) &&
+                     entry.Message.Contains("RouteId=GET:/hello", StringComparison.Ordinal) &&
+                     entry.Message.Contains("MatchMode=fallback", StringComparison.Ordinal) &&
+                     entry.Message.Contains("MatchResult=Matched", StringComparison.Ordinal));
     }
 
     private sealed class HttpLoggingFactory(


### PR DESCRIPTION
## Summary
- configure single-line console logging with timestamps, scopes, and traceId activity tracking
- add request completion logs with status, elapsedMs, routeId, matchMode, and match result
- add semantic matching timing logs and regression coverage for the new logging behavior

## Files Changed
- src/SemanticStub.Api/Program.cs
- src/SemanticStub.Api/Controllers/StubController.cs
- src/SemanticStub.Application/Services/Semantic/SemanticMatcherService.cs
- tests/SemanticStub.Api.Tests/Integration/HttpLoggingTests.cs

## Tests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter HttpLoggingTests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj

## Notes
- preserves YAML compatibility and routing behavior
- keeps the change limited to observability and test coverage