### PR TITLE
perf: cache semantic candidate embeddings

### DIFF
--- a/src/SemanticStub.Application/Infrastructure/Yaml/IStubDefinitionVersionProvider.cs
+++ b/src/SemanticStub.Application/Infrastructure/Yaml/IStubDefinitionVersionProvider.cs
@@ -1,0 +1,12 @@
+namespace SemanticStub.Application.Infrastructure.Yaml;
+
+/// <summary>
+/// Exposes the active stub definition version so process-wide caches can invalidate after reload.
+/// </summary>
+public interface IStubDefinitionVersionProvider
+{
+    /// <summary>
+    /// Gets the monotonic version of the currently active stub definition snapshot.
+    /// </summary>
+    long CurrentVersion { get; }
+}

--- a/src/SemanticStub.Application/Services/Semantic/SemanticMatcherService.cs
+++ b/src/SemanticStub.Application/Services/Semantic/SemanticMatcherService.cs
@@ -235,9 +235,11 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
             newlyFetchedEmbeddings[missingCandidateTexts[i]] = candidateEmbeddings[i];
         }
 
+        var publishedCacheSnapshot = cacheSnapshot;
+
         if (newlyFetchedEmbeddings.Count > 0)
         {
-            cacheSnapshot = PublishCandidateEmbeddings(
+            publishedCacheSnapshot = PublishCandidateEmbeddings(
                 cacheSnapshot.DefinitionVersion,
                 candidateEmbeddings[0].Length,
                 newlyFetchedEmbeddings);
@@ -246,7 +248,8 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
         foreach (var text in candidateTexts.Distinct(StringComparer.Ordinal))
         {
             if (newlyFetchedEmbeddings.TryGetValue(text, out var embedding) ||
-                cacheSnapshot.Embeddings.TryGetValue(text, out embedding))
+                cacheSnapshot.Embeddings.TryGetValue(text, out embedding) ||
+                publishedCacheSnapshot.Embeddings.TryGetValue(text, out embedding))
             {
                 candidateEmbeddingsByText[text] = embedding;
             }

--- a/src/SemanticStub.Application/Services/Semantic/SemanticMatcherService.cs
+++ b/src/SemanticStub.Application/Services/Semantic/SemanticMatcherService.cs
@@ -239,11 +239,51 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
             _cachedCandidateEmbeddingDimension = candidateEmbeddings[0].Length;
         }
 
+        var candidateEmbeddingsByText = new Dictionary<string, float[]>(StringComparer.Ordinal);
+
+        for (var i = 0; i < missingCandidateTexts.Length; i++)
+        {
+            candidateEmbeddingsByText[missingCandidateTexts[i]] = candidateEmbeddings[i];
+        }
+
+        var refetchCandidateTexts = candidateTexts
+            .Where(text => !candidateEmbeddingsByText.ContainsKey(text) &&
+                           !_candidateEmbeddingCache.TryGetValue(text, out _))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        if (refetchCandidateTexts.Length > 0)
+        {
+            var refetchedCandidateEmbeddings = await _embeddingClient.GetEmbeddingsAsync(refetchCandidateTexts, cancellationToken);
+
+            for (var i = 0; i < refetchCandidateTexts.Length; i++)
+            {
+                _candidateEmbeddingCache[refetchCandidateTexts[i]] = refetchedCandidateEmbeddings[i];
+                candidateEmbeddingsByText[refetchCandidateTexts[i]] = refetchedCandidateEmbeddings[i];
+            }
+
+            _cachedCandidateEmbeddingDimension = refetchedCandidateEmbeddings[0].Length;
+        }
+
         var allEmbeddings = new List<float[]>(semanticCandidates.Count + 1)
         {
             requestEmbedding
         };
-        allEmbeddings.AddRange(candidateTexts.Select(text => _candidateEmbeddingCache[text]));
+        allEmbeddings.AddRange(candidateTexts.Select(text =>
+        {
+            if (candidateEmbeddingsByText.TryGetValue(text, out var embedding))
+            {
+                return embedding;
+            }
+
+            if (_candidateEmbeddingCache.TryGetValue(text, out embedding))
+            {
+                candidateEmbeddingsByText[text] = embedding;
+                return embedding;
+            }
+
+            throw new InvalidOperationException($"Failed to resolve a cached embedding for semantic candidate '{text}'.");
+        }));
 
         return allEmbeddings;
     }

--- a/src/SemanticStub.Application/Services/Semantic/SemanticMatcherService.cs
+++ b/src/SemanticStub.Application/Services/Semantic/SemanticMatcherService.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using SemanticStub.Application.Infrastructure.Yaml;
@@ -14,6 +15,7 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
     private readonly ISemanticEmbeddingClient _embeddingClient;
     private readonly StubSettings _settings;
     private readonly ILogger<SemanticMatcherService> _logger;
+    private readonly ConcurrentDictionary<string, float[]> _candidateEmbeddingCache = new(StringComparer.Ordinal);
 
     public SemanticMatcherService(
         ISemanticEmbeddingClient embeddingClient,
@@ -189,13 +191,36 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
         IReadOnlyList<QueryMatchDefinition> semanticCandidates,
         CancellationToken cancellationToken)
     {
-        var allTexts = new List<string>(semanticCandidates.Count + 1)
-        {
-            SemanticRequestTextBuilder.Build(method, path, query, headers, body)
-        };
+        var requestText = SemanticRequestTextBuilder.Build(method, path, query, headers, body);
+        var candidateTexts = semanticCandidates
+            .Select(candidate => candidate.SemanticMatch!)
+            .ToArray();
+        var missingCandidateTexts = candidateTexts
+            .Where(text => !_candidateEmbeddingCache.ContainsKey(text))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
 
-        allTexts.AddRange(semanticCandidates.Select(candidate => candidate.SemanticMatch!));
-        return await _embeddingClient.GetEmbeddingsAsync(allTexts, cancellationToken);
+        var textsToEmbed = new List<string>(missingCandidateTexts.Length + 1)
+        {
+            requestText
+        };
+        textsToEmbed.AddRange(missingCandidateTexts);
+
+        var newEmbeddings = await _embeddingClient.GetEmbeddingsAsync(textsToEmbed, cancellationToken);
+        var requestEmbedding = newEmbeddings[0];
+
+        for (var i = 0; i < missingCandidateTexts.Length; i++)
+        {
+            _candidateEmbeddingCache[missingCandidateTexts[i]] = newEmbeddings[i + 1];
+        }
+
+        var allEmbeddings = new List<float[]>(semanticCandidates.Count + 1)
+        {
+            requestEmbedding
+        };
+        allEmbeddings.AddRange(candidateTexts.Select(text => _candidateEmbeddingCache[text]));
+
+        return allEmbeddings;
     }
 
     private SemanticMatchExplanation ScoreAndLogExplanation(

--- a/src/SemanticStub.Application/Services/Semantic/SemanticMatcherService.cs
+++ b/src/SemanticStub.Application/Services/Semantic/SemanticMatcherService.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using SemanticStub.Application.Infrastructure.Yaml;
@@ -16,9 +15,8 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
     private readonly IStubDefinitionVersionProvider _definitionVersionProvider;
     private readonly StubSettings _settings;
     private readonly ILogger<SemanticMatcherService> _logger;
-    private readonly ConcurrentDictionary<string, float[]> _candidateEmbeddingCache = new(StringComparer.Ordinal);
-    private int? _cachedCandidateEmbeddingDimension;
-    private long _cachedDefinitionVersion;
+    private readonly object _cacheSyncRoot = new();
+    private CandidateEmbeddingCacheState _candidateEmbeddingCache;
 
     public SemanticMatcherService(
         ISemanticEmbeddingClient embeddingClient,
@@ -30,7 +28,7 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
         _settings = settings;
         _embeddingClient = embeddingClient;
         _logger = logger;
-        _cachedDefinitionVersion = definitionVersionProvider.CurrentVersion;
+        _candidateEmbeddingCache = CandidateEmbeddingCacheState.CreateEmpty(definitionVersionProvider.CurrentVersion);
     }
 
     /// <inheritdoc/>
@@ -197,14 +195,14 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
         IReadOnlyList<QueryMatchDefinition> semanticCandidates,
         CancellationToken cancellationToken)
     {
-        InvalidateCacheIfDefinitionsReloaded();
+        var cacheSnapshot = InvalidateCacheIfDefinitionsReloaded();
 
         var requestText = SemanticRequestTextBuilder.Build(method, path, query, headers, body);
         var candidateTexts = semanticCandidates
             .Select(candidate => candidate.SemanticMatch!)
             .ToArray();
         var missingCandidateTexts = candidateTexts
-            .Where(text => !_candidateEmbeddingCache.ContainsKey(text))
+            .Where(text => !cacheSnapshot.Embeddings.ContainsKey(text))
             .Distinct(StringComparer.Ordinal)
             .ToArray();
         var textsToEmbed = new List<string>(missingCandidateTexts.Length + 1)
@@ -217,10 +215,10 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
         var requestEmbedding = embeddings[0];
         IReadOnlyList<float[]> candidateEmbeddings = embeddings.Skip(1).ToArray();
 
-        if (_cachedCandidateEmbeddingDimension.HasValue &&
-            _cachedCandidateEmbeddingDimension.Value != requestEmbedding.Length)
+        if (cacheSnapshot.EmbeddingDimension.HasValue &&
+            cacheSnapshot.EmbeddingDimension.Value != requestEmbedding.Length)
         {
-            ClearCandidateEmbeddingCache();
+            cacheSnapshot = ReplaceCache(CandidateEmbeddingCacheState.CreateEmpty(cacheSnapshot.DefinitionVersion));
             missingCandidateTexts = candidateTexts
                 .Distinct(StringComparer.Ordinal)
                 .ToArray();
@@ -229,52 +227,29 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
                 : await _embeddingClient.GetEmbeddingsAsync(missingCandidateTexts, cancellationToken);
         }
 
-        for (var i = 0; i < missingCandidateTexts.Length; i++)
-        {
-            _candidateEmbeddingCache[missingCandidateTexts[i]] = candidateEmbeddings[i];
-        }
-
-        if (missingCandidateTexts.Length > 0)
-        {
-            _cachedCandidateEmbeddingDimension = candidateEmbeddings[0].Length;
-        }
-
         var candidateEmbeddingsByText = new Dictionary<string, float[]>(StringComparer.Ordinal);
+        var newlyFetchedEmbeddings = new Dictionary<string, float[]>(StringComparer.Ordinal);
 
         for (var i = 0; i < missingCandidateTexts.Length; i++)
         {
-            candidateEmbeddingsByText[missingCandidateTexts[i]] = candidateEmbeddings[i];
+            newlyFetchedEmbeddings[missingCandidateTexts[i]] = candidateEmbeddings[i];
         }
 
-        var refetchCandidateTexts = new List<string>();
+        if (newlyFetchedEmbeddings.Count > 0)
+        {
+            cacheSnapshot = PublishCandidateEmbeddings(
+                cacheSnapshot.DefinitionVersion,
+                candidateEmbeddings[0].Length,
+                newlyFetchedEmbeddings);
+        }
 
         foreach (var text in candidateTexts.Distinct(StringComparer.Ordinal))
         {
-            if (candidateEmbeddingsByText.ContainsKey(text))
+            if (newlyFetchedEmbeddings.TryGetValue(text, out var embedding) ||
+                cacheSnapshot.Embeddings.TryGetValue(text, out embedding))
             {
-                continue;
+                candidateEmbeddingsByText[text] = embedding;
             }
-
-            if (_candidateEmbeddingCache.TryGetValue(text, out var cachedEmbedding))
-            {
-                candidateEmbeddingsByText[text] = cachedEmbedding;
-                continue;
-            }
-
-            refetchCandidateTexts.Add(text);
-        }
-
-        if (refetchCandidateTexts.Count > 0)
-        {
-            var refetchedCandidateEmbeddings = await _embeddingClient.GetEmbeddingsAsync(refetchCandidateTexts, cancellationToken);
-
-            for (var i = 0; i < refetchCandidateTexts.Count; i++)
-            {
-                _candidateEmbeddingCache[refetchCandidateTexts[i]] = refetchedCandidateEmbeddings[i];
-                candidateEmbeddingsByText[refetchCandidateTexts[i]] = refetchedCandidateEmbeddings[i];
-            }
-
-            _cachedCandidateEmbeddingDimension = refetchedCandidateEmbeddings[0].Length;
         }
 
         var allEmbeddings = new List<float[]>(semanticCandidates.Count + 1)
@@ -286,23 +261,56 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
         return allEmbeddings;
     }
 
-    private void InvalidateCacheIfDefinitionsReloaded()
+    private CandidateEmbeddingCacheState InvalidateCacheIfDefinitionsReloaded()
     {
         var currentDefinitionVersion = _definitionVersionProvider.CurrentVersion;
+        var cacheSnapshot = Volatile.Read(ref _candidateEmbeddingCache);
 
-        if (currentDefinitionVersion == _cachedDefinitionVersion)
+        if (currentDefinitionVersion == cacheSnapshot.DefinitionVersion)
         {
-            return;
+            return cacheSnapshot;
         }
 
-        ClearCandidateEmbeddingCache();
-        _cachedDefinitionVersion = currentDefinitionVersion;
+        return ReplaceCache(CandidateEmbeddingCacheState.CreateEmpty(currentDefinitionVersion));
     }
 
-    private void ClearCandidateEmbeddingCache()
+    private CandidateEmbeddingCacheState ReplaceCache(CandidateEmbeddingCacheState nextState)
     {
-        _candidateEmbeddingCache.Clear();
-        _cachedCandidateEmbeddingDimension = null;
+        lock (_cacheSyncRoot)
+        {
+            Volatile.Write(ref _candidateEmbeddingCache, nextState);
+            return nextState;
+        }
+    }
+
+    private CandidateEmbeddingCacheState PublishCandidateEmbeddings(
+        long definitionVersion,
+        int embeddingDimension,
+        IReadOnlyDictionary<string, float[]> embeddings)
+    {
+        lock (_cacheSyncRoot)
+        {
+            var currentCache = Volatile.Read(ref _candidateEmbeddingCache);
+
+            if (currentCache.DefinitionVersion != definitionVersion)
+            {
+                return currentCache;
+            }
+
+            var mergedEmbeddings = new Dictionary<string, float[]>(currentCache.Embeddings, StringComparer.Ordinal);
+
+            foreach (var pair in embeddings)
+            {
+                mergedEmbeddings[pair.Key] = pair.Value;
+            }
+
+            var nextState = new CandidateEmbeddingCacheState(
+                definitionVersion,
+                embeddingDimension,
+                mergedEmbeddings);
+            Volatile.Write(ref _candidateEmbeddingCache, nextState);
+            return nextState;
+        }
     }
 
     private SemanticMatchExplanation ScoreAndLogExplanation(
@@ -371,5 +379,19 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
             Threshold = semanticSettings.Threshold,
             RequiredMargin = semanticSettings.TopScoreMargin,
         };
+    }
+
+    private sealed record CandidateEmbeddingCacheState(
+        long DefinitionVersion,
+        int? EmbeddingDimension,
+        IReadOnlyDictionary<string, float[]> Embeddings)
+    {
+        public static CandidateEmbeddingCacheState CreateEmpty(long definitionVersion)
+        {
+            return new CandidateEmbeddingCacheState(
+                definitionVersion,
+                EmbeddingDimension: null,
+                new Dictionary<string, float[]>(StringComparer.Ordinal));
+        }
     }
 }

--- a/src/SemanticStub.Application/Services/Semantic/SemanticMatcherService.cs
+++ b/src/SemanticStub.Application/Services/Semantic/SemanticMatcherService.cs
@@ -246,17 +246,29 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
             candidateEmbeddingsByText[missingCandidateTexts[i]] = candidateEmbeddings[i];
         }
 
-        var refetchCandidateTexts = candidateTexts
-            .Where(text => !candidateEmbeddingsByText.ContainsKey(text) &&
-                           !_candidateEmbeddingCache.TryGetValue(text, out _))
-            .Distinct(StringComparer.Ordinal)
-            .ToArray();
+        var refetchCandidateTexts = new List<string>();
 
-        if (refetchCandidateTexts.Length > 0)
+        foreach (var text in candidateTexts.Distinct(StringComparer.Ordinal))
+        {
+            if (candidateEmbeddingsByText.ContainsKey(text))
+            {
+                continue;
+            }
+
+            if (_candidateEmbeddingCache.TryGetValue(text, out var cachedEmbedding))
+            {
+                candidateEmbeddingsByText[text] = cachedEmbedding;
+                continue;
+            }
+
+            refetchCandidateTexts.Add(text);
+        }
+
+        if (refetchCandidateTexts.Count > 0)
         {
             var refetchedCandidateEmbeddings = await _embeddingClient.GetEmbeddingsAsync(refetchCandidateTexts, cancellationToken);
 
-            for (var i = 0; i < refetchCandidateTexts.Length; i++)
+            for (var i = 0; i < refetchCandidateTexts.Count; i++)
             {
                 _candidateEmbeddingCache[refetchCandidateTexts[i]] = refetchedCandidateEmbeddings[i];
                 candidateEmbeddingsByText[refetchCandidateTexts[i]] = refetchedCandidateEmbeddings[i];
@@ -269,21 +281,7 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
         {
             requestEmbedding
         };
-        allEmbeddings.AddRange(candidateTexts.Select(text =>
-        {
-            if (candidateEmbeddingsByText.TryGetValue(text, out var embedding))
-            {
-                return embedding;
-            }
-
-            if (_candidateEmbeddingCache.TryGetValue(text, out embedding))
-            {
-                candidateEmbeddingsByText[text] = embedding;
-                return embedding;
-            }
-
-            throw new InvalidOperationException($"Failed to resolve a cached embedding for semantic candidate '{text}'.");
-        }));
+        allEmbeddings.AddRange(candidateTexts.Select(text => candidateEmbeddingsByText[text]));
 
         return allEmbeddings;
     }

--- a/src/SemanticStub.Application/Services/Semantic/SemanticMatcherService.cs
+++ b/src/SemanticStub.Application/Services/Semantic/SemanticMatcherService.cs
@@ -13,18 +13,24 @@ namespace SemanticStub.Application.Services.Semantic;
 public sealed class SemanticMatcherService : ISemanticMatcherService
 {
     private readonly ISemanticEmbeddingClient _embeddingClient;
+    private readonly IStubDefinitionVersionProvider _definitionVersionProvider;
     private readonly StubSettings _settings;
     private readonly ILogger<SemanticMatcherService> _logger;
     private readonly ConcurrentDictionary<string, float[]> _candidateEmbeddingCache = new(StringComparer.Ordinal);
+    private int? _cachedCandidateEmbeddingDimension;
+    private long _cachedDefinitionVersion;
 
     public SemanticMatcherService(
         ISemanticEmbeddingClient embeddingClient,
+        IStubDefinitionVersionProvider definitionVersionProvider,
         StubSettings settings,
         ILogger<SemanticMatcherService> logger)
     {
+        _definitionVersionProvider = definitionVersionProvider;
         _settings = settings;
         _embeddingClient = embeddingClient;
         _logger = logger;
+        _cachedDefinitionVersion = definitionVersionProvider.CurrentVersion;
     }
 
     /// <inheritdoc/>
@@ -191,6 +197,8 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
         IReadOnlyList<QueryMatchDefinition> semanticCandidates,
         CancellationToken cancellationToken)
     {
+        InvalidateCacheIfDefinitionsReloaded();
+
         var requestText = SemanticRequestTextBuilder.Build(method, path, query, headers, body);
         var candidateTexts = semanticCandidates
             .Select(candidate => candidate.SemanticMatch!)
@@ -199,19 +207,36 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
             .Where(text => !_candidateEmbeddingCache.ContainsKey(text))
             .Distinct(StringComparer.Ordinal)
             .ToArray();
-
         var textsToEmbed = new List<string>(missingCandidateTexts.Length + 1)
         {
             requestText
         };
         textsToEmbed.AddRange(missingCandidateTexts);
 
-        var newEmbeddings = await _embeddingClient.GetEmbeddingsAsync(textsToEmbed, cancellationToken);
-        var requestEmbedding = newEmbeddings[0];
+        var embeddings = await _embeddingClient.GetEmbeddingsAsync(textsToEmbed, cancellationToken);
+        var requestEmbedding = embeddings[0];
+        IReadOnlyList<float[]> candidateEmbeddings = embeddings.Skip(1).ToArray();
+
+        if (_cachedCandidateEmbeddingDimension.HasValue &&
+            _cachedCandidateEmbeddingDimension.Value != requestEmbedding.Length)
+        {
+            ClearCandidateEmbeddingCache();
+            missingCandidateTexts = candidateTexts
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+            candidateEmbeddings = missingCandidateTexts.Length == 0
+                ? []
+                : await _embeddingClient.GetEmbeddingsAsync(missingCandidateTexts, cancellationToken);
+        }
 
         for (var i = 0; i < missingCandidateTexts.Length; i++)
         {
-            _candidateEmbeddingCache[missingCandidateTexts[i]] = newEmbeddings[i + 1];
+            _candidateEmbeddingCache[missingCandidateTexts[i]] = candidateEmbeddings[i];
+        }
+
+        if (missingCandidateTexts.Length > 0)
+        {
+            _cachedCandidateEmbeddingDimension = candidateEmbeddings[0].Length;
         }
 
         var allEmbeddings = new List<float[]>(semanticCandidates.Count + 1)
@@ -221,6 +246,25 @@ public sealed class SemanticMatcherService : ISemanticMatcherService
         allEmbeddings.AddRange(candidateTexts.Select(text => _candidateEmbeddingCache[text]));
 
         return allEmbeddings;
+    }
+
+    private void InvalidateCacheIfDefinitionsReloaded()
+    {
+        var currentDefinitionVersion = _definitionVersionProvider.CurrentVersion;
+
+        if (currentDefinitionVersion == _cachedDefinitionVersion)
+        {
+            return;
+        }
+
+        ClearCandidateEmbeddingCache();
+        _cachedDefinitionVersion = currentDefinitionVersion;
+    }
+
+    private void ClearCandidateEmbeddingCache()
+    {
+        _candidateEmbeddingCache.Clear();
+        _cachedCandidateEmbeddingDimension = null;
     }
 
     private SemanticMatchExplanation ScoreAndLogExplanation(

--- a/src/SemanticStub.Infrastructure/Extensions/YamlInfrastructureServiceCollectionExtensions.cs
+++ b/src/SemanticStub.Infrastructure/Extensions/YamlInfrastructureServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ public static class YamlInfrastructureServiceCollectionExtensions
         services.AddSingleton<IStubDefinitionLoader, StubDefinitionLoader>();
         // The loaded YAML definition is process-wide runtime state and is replaced atomically on reload.
         services.AddSingleton<StubDefinitionState>();
+        services.AddSingleton<IStubDefinitionVersionProvider>(serviceProvider => serviceProvider.GetRequiredService<StubDefinitionState>());
         services.AddHostedService<StubDefinitionStartupValidator>();
         services.AddHostedService<StubDefinitionWatcher>();
 

--- a/src/SemanticStub.Infrastructure/Infrastructure/Yaml/StubDefinitionState.cs
+++ b/src/SemanticStub.Infrastructure/Infrastructure/Yaml/StubDefinitionState.cs
@@ -8,13 +8,14 @@ namespace SemanticStub.Infrastructure.Yaml;
 /// <summary>
 /// Holds the current process-wide YAML definition snapshot and swaps it atomically during reloads.
 /// </summary>
-public sealed class StubDefinitionState
+public sealed class StubDefinitionState : IStubDefinitionVersionProvider
 {
     private readonly IStubDefinitionLoader _loader;
     private readonly ScenarioService _scenarioService;
     private readonly ILogger<StubDefinitionState> _logger;
     private readonly object _syncRoot = new();
     private StubDocument _currentDocument;
+    private long _currentVersion;
 
     /// <summary>
     /// Initializes the process-wide definition state from the default YAML definition.
@@ -37,6 +38,9 @@ public sealed class StubDefinitionState
     {
         return Volatile.Read(ref _currentDocument);
     }
+
+    /// <inheritdoc/>
+    public long CurrentVersion => Interlocked.Read(ref _currentVersion);
 
     /// <summary>
     /// Loads response file content relative to the configured YAML definition root.
@@ -74,6 +78,7 @@ public sealed class StubDefinitionState
         _scenarioService.ExecuteLocked(() =>
         {
             Volatile.Write(ref _currentDocument, reloadedDocument);
+            Interlocked.Increment(ref _currentVersion);
             ResetScenarioStatesWithinLock(reloadedDocument);
             return 0;
         });

--- a/tests/SemanticStub.Api.Tests/Unit/Semantic/SemanticMatcherServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Semantic/SemanticMatcherServiceTests.cs
@@ -923,6 +923,82 @@ public sealed class SemanticMatcherServiceTests
         Assert.Same(candidate, invalidatingExplanation.SelectedCandidate);
     }
 
+    [Fact]
+    public async Task ExplainMatchAsync_PreservesCachedHitsWhenReloadOccursDuringMissFetch()
+    {
+        var definitionVersionProvider = new MutableStubDefinitionVersionProvider();
+        var missFetchStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseMissFetch = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestBodies = new List<string[]>();
+        var service = CreateService(
+            new StubSettings
+            {
+                SemanticMatching = new SemanticMatchingSettings
+                {
+                    Enabled = true,
+                    Endpoint = "http://tei"
+                }
+            },
+            async (request, _) =>
+            {
+                var body = await request.Content!.ReadAsStringAsync();
+                using var document = JsonDocument.Parse(body);
+                var inputs = document.RootElement.GetProperty("inputs")
+                    .EnumerateArray()
+                    .Select(element => element.GetString()!)
+                    .ToArray();
+                requestBodies.Add(inputs);
+
+                if (inputs.SequenceEqual(["method: POST\npath: /search\nbody:\nadmin search", "show invoices"]))
+                {
+                    missFetchStarted.SetResult();
+                    await releaseMissFetch.Task;
+                }
+
+                var embeddings = inputs.Select(input => input switch
+                {
+                    "method: POST\npath: /search\nbody:\nadmin search" => new[] { 1.0f, 0.0f },
+                    "find admin users" => new[] { 0.9f, 0.1f },
+                    "show invoices" => new[] { 0.0f, 1.0f },
+                    _ => throw new InvalidOperationException($"Unexpected input '{input}'.")
+                });
+
+                return CreateEmbeddingsResponse(embeddings);
+            },
+            definitionVersionProvider);
+
+        var cachedCandidate = CreateCandidate("find admin users");
+        var missingCandidate = CreateCandidate("show invoices");
+
+        await service.ExplainMatchAsync(
+            "POST",
+            "/search",
+            new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            "admin search",
+            [cachedCandidate]);
+
+        var inFlightRequest = service.ExplainMatchAsync(
+            "POST",
+            "/search",
+            new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            "admin search",
+            [cachedCandidate, missingCandidate],
+            includeCandidateScores: true);
+
+        await missFetchStarted.Task;
+        definitionVersionProvider.CurrentVersion = 1;
+        releaseMissFetch.SetResult();
+
+        var explanation = await inFlightRequest;
+
+        Assert.Same(cachedCandidate, explanation.SelectedCandidate);
+        Assert.Equal(2, explanation.CandidateScores.Count);
+        Assert.Contains(requestBodies, inputs => inputs.SequenceEqual(["method: POST\npath: /search\nbody:\nadmin search", "find admin users"]));
+        Assert.Contains(requestBodies, inputs => inputs.SequenceEqual(["method: POST\npath: /search\nbody:\nadmin search", "show invoices"]));
+    }
+
     private static QueryMatchDefinition CreateCandidate(string semanticMatch)
     {
         return new QueryMatchDefinition

--- a/tests/SemanticStub.Api.Tests/Unit/Semantic/SemanticMatcherServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Semantic/SemanticMatcherServiceTests.cs
@@ -698,6 +698,148 @@ public sealed class SemanticMatcherServiceTests
             requestedInputs[1]);
     }
 
+    [Fact]
+    public async Task ExplainMatchAsync_InvalidatesCandidateCacheWhenDefinitionVersionChanges()
+    {
+        var requestedInputs = new List<string[]>();
+        var definitionVersionProvider = new MutableStubDefinitionVersionProvider();
+        var service = CreateService(
+            new StubSettings
+            {
+                SemanticMatching = new SemanticMatchingSettings
+                {
+                    Enabled = true,
+                    Endpoint = "http://tei"
+                }
+            },
+            async (request, _) =>
+            {
+                var body = await request.Content!.ReadAsStringAsync();
+                using var document = JsonDocument.Parse(body);
+                var inputs = document.RootElement.GetProperty("inputs")
+                    .EnumerateArray()
+                    .Select(element => element.GetString()!)
+                    .ToArray();
+                requestedInputs.Add(inputs);
+
+                return CreateEmbeddingsResponse(inputs.Select(input => input switch
+                {
+                    "method: POST\npath: /search\nbody:\nadmin search" => new[] { 1.0f, 0.0f },
+                    "find admin users" => new[] { 0.9f, 0.1f },
+                    _ => throw new InvalidOperationException($"Unexpected input '{input}'.")
+                }));
+            },
+            definitionVersionProvider);
+
+        var candidate = CreateCandidate("find admin users");
+
+        await service.ExplainMatchAsync(
+            "POST",
+            "/search",
+            new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            "admin search",
+            [candidate]);
+
+        definitionVersionProvider.CurrentVersion = 1;
+
+        await service.ExplainMatchAsync(
+            "POST",
+            "/search",
+            new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            "admin search",
+            [candidate]);
+
+        Assert.Equal(2, requestedInputs.Count);
+        Assert.Equal(
+            ["method: POST\npath: /search\nbody:\nadmin search", "find admin users"],
+            requestedInputs[0]);
+        Assert.Equal(
+            ["method: POST\npath: /search\nbody:\nadmin search", "find admin users"],
+            requestedInputs[1]);
+    }
+
+    [Fact]
+    public async Task ExplainMatchAsync_RebuildsCandidateCacheWhenEmbeddingDimensionChanges()
+    {
+        var requestedInputs = new List<string[]>();
+        var requestCount = 0;
+        var service = CreateService(
+            new StubSettings
+            {
+                SemanticMatching = new SemanticMatchingSettings
+                {
+                    Enabled = true,
+                    Endpoint = "http://tei"
+                }
+            },
+            async (request, _) =>
+            {
+                var body = await request.Content!.ReadAsStringAsync();
+                using var document = JsonDocument.Parse(body);
+                var inputs = document.RootElement.GetProperty("inputs")
+                    .EnumerateArray()
+                    .Select(element => element.GetString()!)
+                    .ToArray();
+                requestedInputs.Add(inputs);
+                requestCount++;
+
+                var embeddings = requestCount switch
+                {
+                    1 => inputs.Select(input => input switch
+                    {
+                        "method: POST\npath: /search\nbody:\nadmin search" => new[] { 1.0f, 0.0f },
+                        "find admin users" => new[] { 0.9f, 0.1f },
+                        _ => throw new InvalidOperationException($"Unexpected input '{input}'.")
+                    }),
+                    2 => inputs.Select(input => input switch
+                    {
+                        "method: POST\npath: /search\nbody:\nadmin search" => new[] { 1.0f, 0.0f, 0.0f },
+                        _ => throw new InvalidOperationException($"Unexpected input '{input}'.")
+                    }),
+                    3 => inputs.Select(input => input switch
+                    {
+                        "find admin users" => new[] { 0.9f, 0.1f, 0.0f },
+                        _ => throw new InvalidOperationException($"Unexpected input '{input}'.")
+                    }),
+                    _ => throw new InvalidOperationException("Unexpected embedding request count.")
+                };
+
+                return CreateEmbeddingsResponse(embeddings);
+            });
+
+        var candidate = CreateCandidate("find admin users");
+
+        await service.ExplainMatchAsync(
+            "POST",
+            "/search",
+            new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            "admin search",
+            [candidate]);
+
+        var explanation = await service.ExplainMatchAsync(
+            "POST",
+            "/search",
+            new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            "admin search",
+            [candidate]);
+
+        Assert.Same(candidate, explanation.SelectedCandidate);
+        Assert.Equal(3, requestedInputs.Count);
+        Assert.Equal(
+            ["method: POST\npath: /search\nbody:\nadmin search", "find admin users"],
+            requestedInputs[0]);
+        Assert.Equal(
+            ["method: POST\npath: /search\nbody:\nadmin search"],
+            requestedInputs[1]);
+        Assert.Equal(
+            ["find admin users"],
+            requestedInputs[2]);
+    }
+
     private static QueryMatchDefinition CreateCandidate(string semanticMatch)
     {
         return new QueryMatchDefinition
@@ -722,12 +864,14 @@ public sealed class SemanticMatcherServiceTests
 
     private static SemanticMatcherService CreateService(
         StubSettings settings,
-        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler,
+        IStubDefinitionVersionProvider? definitionVersionProvider = null)
     {
         var services = new ServiceCollection();
         services.AddSingleton(Options.Create(settings));
         services.AddLogging();
         services.AddSingleton<IHttpClientFactory>(_ => new TestHttpClientFactory(new HttpClient(new DelegatingTestHandler(handler))));
+        services.AddSingleton(definitionVersionProvider ?? new MutableStubDefinitionVersionProvider());
         services.AddSingleton<ISemanticEmbeddingClient, SemanticEmbeddingClient>();
         services.AddSingleton(serviceProvider => serviceProvider.GetRequiredService<IOptions<StubSettings>>().Value);
         services.AddSingleton<ISemanticMatcherService, SemanticMatcherService>();
@@ -797,5 +941,10 @@ public sealed class SemanticMatcherServiceTests
         {
             return client;
         }
+    }
+
+    private sealed class MutableStubDefinitionVersionProvider : IStubDefinitionVersionProvider
+    {
+        public long CurrentVersion { get; set; }
     }
 }

--- a/tests/SemanticStub.Api.Tests/Unit/Semantic/SemanticMatcherServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Semantic/SemanticMatcherServiceTests.cs
@@ -580,6 +580,124 @@ public sealed class SemanticMatcherServiceTests
             cancellationToken: cancellationSource.Token));
     }
 
+    [Fact]
+    public async Task ExplainMatchAsync_ReusesCachedCandidateEmbeddingsAcrossRequests()
+    {
+        var requestedInputs = new List<string[]>();
+        var service = CreateService(
+            new StubSettings
+            {
+                SemanticMatching = new SemanticMatchingSettings
+                {
+                    Enabled = true,
+                    Endpoint = "http://tei"
+                }
+            },
+            async (request, _) =>
+            {
+                var body = await request.Content!.ReadAsStringAsync();
+                using var document = JsonDocument.Parse(body);
+                var inputs = document.RootElement.GetProperty("inputs")
+                    .EnumerateArray()
+                    .Select(element => element.GetString()!)
+                    .ToArray();
+                requestedInputs.Add(inputs);
+
+                return CreateEmbeddingsResponse(inputs.Select(input => input switch
+                {
+                    "method: POST\npath: /search\nbody:\nadmin search" => new[] { 1.0f, 0.0f },
+                    "find admin users" => new[] { 0.9f, 0.1f },
+                    _ => throw new InvalidOperationException($"Unexpected input '{input}'.")
+                }));
+            });
+
+        var candidate = CreateCandidate("find admin users");
+
+        await service.ExplainMatchAsync(
+            "POST",
+            "/search",
+            new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            "admin search",
+            [candidate]);
+
+        await service.ExplainMatchAsync(
+            "POST",
+            "/search",
+            new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            "admin search",
+            [candidate]);
+
+        Assert.Equal(2, requestedInputs.Count);
+        Assert.Equal(
+            ["method: POST\npath: /search\nbody:\nadmin search", "find admin users"],
+            requestedInputs[0]);
+        Assert.Equal(
+            ["method: POST\npath: /search\nbody:\nadmin search"],
+            requestedInputs[1]);
+    }
+
+    [Fact]
+    public async Task ExplainMatchAsync_OnlyRequestsEmbeddingsForCandidatesMissingFromCache()
+    {
+        var requestedInputs = new List<string[]>();
+        var service = CreateService(
+            new StubSettings
+            {
+                SemanticMatching = new SemanticMatchingSettings
+                {
+                    Enabled = true,
+                    Endpoint = "http://tei"
+                }
+            },
+            async (request, _) =>
+            {
+                var body = await request.Content!.ReadAsStringAsync();
+                using var document = JsonDocument.Parse(body);
+                var inputs = document.RootElement.GetProperty("inputs")
+                    .EnumerateArray()
+                    .Select(element => element.GetString()!)
+                    .ToArray();
+                requestedInputs.Add(inputs);
+
+                return CreateEmbeddingsResponse(inputs.Select(input => input switch
+                {
+                    "method: POST\npath: /search\nbody:\nadmin search" => new[] { 1.0f, 0.0f },
+                    "find admin users" => new[] { 0.9f, 0.1f },
+                    "show invoices" => new[] { 0.0f, 1.0f },
+                    _ => throw new InvalidOperationException($"Unexpected input '{input}'.")
+                }));
+            });
+
+        var adminCandidate = CreateCandidate("find admin users");
+        var invoiceCandidate = CreateCandidate("show invoices");
+
+        await service.ExplainMatchAsync(
+            "POST",
+            "/search",
+            new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            "admin search",
+            [adminCandidate]);
+
+        await service.ExplainMatchAsync(
+            "POST",
+            "/search",
+            new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            "admin search",
+            [adminCandidate, invoiceCandidate]);
+
+        Assert.Equal(2, requestedInputs.Count);
+        Assert.Equal(
+            ["method: POST\npath: /search\nbody:\nadmin search", "find admin users"],
+            requestedInputs[0]);
+        Assert.Equal(
+            ["method: POST\npath: /search\nbody:\nadmin search", "show invoices"],
+            requestedInputs[1]);
+    }
+
     private static QueryMatchDefinition CreateCandidate(string semanticMatch)
     {
         return new QueryMatchDefinition
@@ -654,6 +772,14 @@ public sealed class SemanticMatcherServiceTests
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
         };
+    }
+
+    private static HttpResponseMessage CreateEmbeddingsResponse(IEnumerable<float[]> embeddings)
+    {
+        var embeddingJson = embeddings
+            .Select(embedding => $"[{string.Join(",", embedding.Select(value => value.ToString("R")))}]");
+
+        return CreateEmbeddingResponse($"[{string.Join(",", embeddingJson)}]");
     }
 
     private sealed class DelegatingTestHandler(

--- a/tests/SemanticStub.Api.Tests/Unit/Semantic/SemanticMatcherServiceTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Semantic/SemanticMatcherServiceTests.cs
@@ -840,6 +840,89 @@ public sealed class SemanticMatcherServiceTests
             requestedInputs[2]);
     }
 
+    [Fact]
+    public async Task ExplainMatchAsync_RefetchesCandidateEmbeddingWhenConcurrentInvalidationClearsCache()
+    {
+        var definitionVersionProvider = new MutableStubDefinitionVersionProvider();
+        var secondRequestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSecondRequest = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestCount = 0;
+        var service = CreateService(
+            new StubSettings
+            {
+                SemanticMatching = new SemanticMatchingSettings
+                {
+                    Enabled = true,
+                    Endpoint = "http://tei"
+                }
+            },
+            async (request, _) =>
+            {
+                var body = await request.Content!.ReadAsStringAsync();
+                using var document = JsonDocument.Parse(body);
+                var inputs = document.RootElement.GetProperty("inputs")
+                    .EnumerateArray()
+                    .Select(element => element.GetString()!)
+                    .ToArray();
+                requestCount++;
+
+                if (requestCount == 2)
+                {
+                    secondRequestStarted.SetResult();
+                    await releaseSecondRequest.Task;
+                }
+
+                var embeddings = inputs.Select(input => input switch
+                {
+                    "method: POST\npath: /search\nbody:\nadmin search" => requestCount == 2
+                        ? new[] { 1.0f, 0.0f }
+                        : new[] { 1.0f, 0.0f },
+                    "find admin users" => new[] { 0.9f, 0.1f },
+                    _ => throw new InvalidOperationException($"Unexpected input '{input}'.")
+                });
+
+                return CreateEmbeddingsResponse(embeddings);
+            },
+            definitionVersionProvider);
+
+        var candidate = CreateCandidate("find admin users");
+
+        await service.ExplainMatchAsync(
+            "POST",
+            "/search",
+            new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            "admin search",
+            [candidate]);
+
+        var inFlightRequest = service.ExplainMatchAsync(
+            "POST",
+            "/search",
+            new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            "admin search",
+            [candidate]);
+
+        await secondRequestStarted.Task;
+        definitionVersionProvider.CurrentVersion = 1;
+
+        var invalidatingRequest = service.ExplainMatchAsync(
+            "POST",
+            "/search",
+            new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            "admin search",
+            [candidate]);
+
+        releaseSecondRequest.SetResult();
+
+        var inFlightExplanation = await inFlightRequest;
+        var invalidatingExplanation = await invalidatingRequest;
+
+        Assert.Same(candidate, inFlightExplanation.SelectedCandidate);
+        Assert.Same(candidate, invalidatingExplanation.SelectedCandidate);
+    }
+
     private static QueryMatchDefinition CreateCandidate(string semanticMatch)
     {
         return new QueryMatchDefinition


### PR DESCRIPTION
## Summary
- cache x-semantic-match candidate embeddings inside SemanticMatcherService
- keep request embeddings uncached so each incoming request is still scored freshly
- add regression tests covering cache reuse and partial cache misses

## Testing
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --filter "FullyQualifiedName~SemanticMatcherServiceTests|FullyQualifiedName~StubServiceCollectionExtensionsTests"

Closes #278