### PR TITLE
[codex] sync README inspection guidance

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -297,7 +297,7 @@ SemanticStub は、runtime inspection endpoint を予約プレフィックス
 - `/_semanticstub/runtime/metrics` は process-local で、total request count、matched / unmatched count、fallback / semantic count、average latency、status code summary、top routes を返します。
 - `/_semanticstub/runtime/metrics/resets` と `/_semanticstub/runtime/metrics/reset` は process-local な aggregate metrics と recent request history を消去します。configuration reload、scenario state の変更、`/_semanticstub/runtime/explain/last` の消去は行いません。
 - `/_semanticstub/runtime/requests` は process-local で、最大 100 件の recent request history を新しい順で返します。各 item には timestamp、method、path、利用可能な場合の route id、status code、elapsed time、match mode、および unmatched request の failure reason が含まれます。`limit` query parameter のデフォルトは `20` です。
-- `/_semanticstub/runtime/test-match` と `/_semanticstub/runtime/explain` は、method、path、省略可能な query / header / body、および省略可能な candidate detail flag を持つ virtual request payload を受け取ります。
+- `/_semanticstub/runtime/test-match` と `/_semanticstub/runtime/explain` は、method、path、省略可能な query / header / body、および省略可能な candidate detail flag を持つ virtual request payload を受け取ります。結果には、該当する場合に selected response の id、status code、response source（`responses` または `x-match`）、candidate index も含まれます。
 - `/_semanticstub/runtime/explain/last` は process-local で、実リクエストが stub response に match した後だけ更新されます。
 - `/_semanticstub/runtime/scenarios/resets`、`/_semanticstub/runtime/scenarios/reset`、`/_semanticstub/runtime/scenarios/{name}/resets`、`/_semanticstub/runtime/scenarios/{name}/reset` は、現在のプロセスの in-memory scenario state だけを変更します。
 - これらの endpoint は、raw YAML、内部 domain object、完全な response payload body は公開しません。
@@ -342,8 +342,6 @@ SemanticStub は、runtime inspection endpoint を予約プレフィックス
       "candidateIndex": 0,
       "hasExactQuery": true,
       "exactQueryKeys": ["role"],
-      "hasPartialQuery": false,
-      "partialQueryKeys": [],
       "hasRegexQuery": false,
       "regexQueryKeys": [],
       "headerKeys": [],
@@ -387,7 +385,8 @@ SemanticStub は、runtime inspection endpoint を予約プレフィックス
 設定に関する補足:
 
 - `appsettings.json` はデフォルトの実行時設定です。
-- `appsettings.Development.json` は `Development` 環境で起動したときだけ反映され、ローカルでの semantic matching 設定や詳細なログ出力の確認に向いています。
+- `appsettings.Development.json` は `Development` 環境で起動したときだけ反映され、ローカルでの semantic matching 設定や、request / response body を含むより詳細な HTTP ログの確認に向いています。
+- コンソールログは、trace / span の相関情報を含む single-line 形式で出力され、ローカルでのリクエスト追跡をしやすくしています。
 - `SemanticStub.http` のサンプルリクエストはローカル起動を前提としており、`Development` 環境を有効にすると確認しやすいケースがあります。
 
 サンプルファイル:
@@ -420,13 +419,21 @@ docker compose build
 SemanticStub と埋め込みサービスをバックグラウンドで起動します:
 
 ```sh
-docker compose up -d tei semantic-stub
+docker compose up -d
 ```
 
 この構成では SemanticStub を `http://localhost:8080` で公開します。
 `samples/` ディレクトリはコンテナへマウントされるため、stub YAML を編集しても
 イメージの再ビルドは不要です。TEI は Docker 内部ネットワークだけで使用され、
 ホストには公開しません。
+
+Claude Desktop に登録する前に、MCP サーバーをビルドします:
+
+```sh
+cd mcp
+npm install
+npm run build
+```
 
 Claude Desktop には次のように MCP サーバーを追加します:
 

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Inspection notes:
 - `/_semanticstub/runtime/metrics` is process-local and currently returns total request count, matched and unmatched counts, fallback and semantic counts, average latency, status-code summaries, and top routes.
 - `/_semanticstub/runtime/metrics/resets` and `/_semanticstub/runtime/metrics/reset` clear process-local aggregate metrics and recent request history without reloading configuration, changing scenario state, or clearing `/_semanticstub/runtime/explain/last`.
 - `/_semanticstub/runtime/requests` is process-local and currently returns up to 100 recent real requests in newest-first order. Each item includes timestamp, method, path, resolved route id when available, status code, elapsed time, match mode, and failure reason for unmatched requests. The `limit` query parameter defaults to `20`.
-- `/_semanticstub/runtime/test-match` and `/_semanticstub/runtime/explain` accept a virtual request payload with method, path, optional query/header/body values, and optional candidate-detail flags.
+- `/_semanticstub/runtime/test-match` and `/_semanticstub/runtime/explain` accept a virtual request payload with method, path, optional query/header/body values, and optional candidate-detail flags. Their result payload also includes the selected response id, status code, response source (`responses` or `x-match`), and candidate index when applicable.
 - `/_semanticstub/runtime/explain/last` is process-local and only updates after a real request produces a matched stub response.
 - `/_semanticstub/runtime/scenarios/resets`, `/_semanticstub/runtime/scenarios/reset`, `/_semanticstub/runtime/scenarios/{name}/resets`, and `/_semanticstub/runtime/scenarios/{name}/reset` mutate only in-memory scenario state for the current process.
 - These endpoints do not expose raw YAML, internal domain objects, or full response payload bodies.
@@ -381,8 +381,6 @@ Excerpt from the response body for `GET /_semanticstub/runtime/routes/listUsers`
       "candidateIndex": 0,
       "hasExactQuery": true,
       "exactQueryKeys": ["role"],
-      "hasPartialQuery": false,
-      "partialQueryKeys": [],
       "hasRegexQuery": false,
       "regexQueryKeys": [],
       "headerKeys": [],
@@ -425,7 +423,8 @@ Example response body for `GET /_semanticstub/runtime/requests?limit=1`:
 Configuration notes:
 
 - `appsettings.json` provides the default runtime settings.
-- `appsettings.Development.json` is applied only when the app runs with the `Development` environment, for example to enable local semantic matching settings or more verbose logging.
+- `appsettings.Development.json` is applied only when the app runs with the `Development` environment. It enables local semantic matching settings and more detailed HTTP logging, including request and response bodies.
+- Console logs use a readable single-line format with trace and span correlation metadata so local request flows are easier to follow.
 - The sample requests in `SemanticStub.http` assume the app is running locally and may be easier to verify with the `Development` environment enabled.
 
 Sample files:
@@ -458,13 +457,21 @@ docker compose build
 Run SemanticStub and the embedding service in the background:
 
 ```sh
-docker compose up -d tei semantic-stub
+docker compose up -d
 ```
 
 This setup exposes SemanticStub on `http://localhost:8080`. The `samples/`
 directory is mounted into the container, so editing stub YAML files does not
 require rebuilding the image. The TEI service stays on the internal Docker
 network only.
+
+Build the MCP server before registering it with Claude Desktop:
+
+```sh
+cd mcp
+npm install
+npm run build
+```
 
 Add the MCP server to Claude Desktop:
 

--- a/mcp/README.ja.md
+++ b/mcp/README.ja.md
@@ -47,23 +47,25 @@ npm run build
 
 | ツール名 | 対応エンドポイント | 説明 |
 |---|---|---|
-| `get_config` | `GET /runtime/config` | 設定スナップショット |
-| `list_routes` | `GET /runtime/routes` | ルート一覧 |
-| `get_route` | `GET /runtime/routes/{id}` | ルート詳細 |
-| `get_scenarios` | `GET /runtime/scenarios` | シナリオ状態 |
-| `get_metrics` | `GET /runtime/metrics` | メトリクス |
-| `reset_metrics` | `POST /runtime/metrics/reset` | メトリクスとリクエスト履歴のリセット |
-| `get_requests` | `GET /runtime/requests?limit=` | 件数指定つきリクエスト履歴 |
-| `test_match` | `POST /runtime/test-match` | マッチ確認（副作用なし） |
-| `explain_match` | `POST /runtime/explain` | マッチ詳細説明 |
-| `get_last_explain` | `GET /runtime/explain/last` | 直近の explain 結果 |
-| `reset_scenario_state` | `POST /runtime/scenarios/reset` / `POST /runtime/scenarios/{name}/reset` | シナリオ状態のリセット |
+| `get_config` | `GET /_semanticstub/runtime/config` | 設定スナップショット |
+| `list_routes` | `GET /_semanticstub/runtime/routes` | ルート一覧 |
+| `get_route` | `GET /_semanticstub/runtime/routes/{id}` | ルート詳細 |
+| `get_scenarios` | `GET /_semanticstub/runtime/scenarios` | シナリオ状態 |
+| `get_metrics` | `GET /_semanticstub/runtime/metrics` | メトリクス |
+| `reset_metrics` | `POST /_semanticstub/runtime/metrics/reset` | メトリクスとリクエスト履歴のリセット |
+| `get_requests` | `GET /_semanticstub/runtime/requests?limit=` | 件数指定つきリクエスト履歴 |
+| `test_match` | `POST /_semanticstub/runtime/test-match` | マッチ確認（副作用なし） |
+| `explain_match` | `POST /_semanticstub/runtime/explain` | マッチ詳細説明 |
+| `get_last_explain` | `GET /_semanticstub/runtime/explain/last` | 直近の explain 結果 |
+| `reset_scenario_state` | `POST /_semanticstub/runtime/scenarios/reset` / `POST /_semanticstub/runtime/scenarios/{name}/reset` | シナリオ状態のリセット |
 
 ## 入力メモ
 
 - `test_match` と `explain_match` の `body` は JSON object ではなく raw string です。
 - JSON body を送りたい場合は、たとえば `"{\"message\":\"hello\"}"` のように文字列化して渡してください。
+- `includeCandidates` のデフォルトは `test_match` では `false`、`explain_match` では `true` です。
 - `includeSemanticCandidates` を指定すると、semantic matching 実行時の候補スコアを含められます。
+- `test_match` と `explain_match` の結果には、該当する場合に response id、status code、source（`responses` または `x-match`）、candidate index などの selected response 情報も含まれます。
 
 ## 制約
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -48,23 +48,25 @@ Add this server to `claude_desktop_config.json`.
 
 | Tool | Endpoint | Description |
 |---|---|---|
-| `get_config` | `GET /runtime/config` | Configuration snapshot metadata |
-| `list_routes` | `GET /runtime/routes` | Active route list |
-| `get_route` | `GET /runtime/routes/{id}` | Detailed route information |
-| `get_scenarios` | `GET /runtime/scenarios` | Current scenario state |
-| `get_metrics` | `GET /runtime/metrics` | Runtime metrics |
-| `reset_metrics` | `POST /runtime/metrics/reset` | Reset runtime metrics and recent request history |
-| `get_requests` | `GET /runtime/requests?limit=` | Recent request history with limit |
-| `test_match` | `POST /runtime/test-match` | Match simulation without side effects |
-| `explain_match` | `POST /runtime/explain` | Detailed match explanation |
-| `get_last_explain` | `GET /runtime/explain/last` | Latest real-request explanation |
-| `reset_scenario_state` | `POST /runtime/scenarios/reset` / `POST /runtime/scenarios/{name}/reset` | Reset scenario state |
+| `get_config` | `GET /_semanticstub/runtime/config` | Configuration snapshot metadata |
+| `list_routes` | `GET /_semanticstub/runtime/routes` | Active route list |
+| `get_route` | `GET /_semanticstub/runtime/routes/{id}` | Detailed route information |
+| `get_scenarios` | `GET /_semanticstub/runtime/scenarios` | Current scenario state |
+| `get_metrics` | `GET /_semanticstub/runtime/metrics` | Runtime metrics |
+| `reset_metrics` | `POST /_semanticstub/runtime/metrics/reset` | Reset runtime metrics and recent request history |
+| `get_requests` | `GET /_semanticstub/runtime/requests?limit=` | Recent request history with limit |
+| `test_match` | `POST /_semanticstub/runtime/test-match` | Match simulation without side effects |
+| `explain_match` | `POST /_semanticstub/runtime/explain` | Detailed match explanation |
+| `get_last_explain` | `GET /_semanticstub/runtime/explain/last` | Latest real-request explanation |
+| `reset_scenario_state` | `POST /_semanticstub/runtime/scenarios/reset` / `POST /_semanticstub/runtime/scenarios/{name}/reset` | Reset scenario state |
 
 ## Input Notes
 
 - The `body` field for `test_match` and `explain_match` must be a raw string, not a JSON object.
 - If you want to send JSON content, stringify it first, for example `"{\"message\":\"hello\"}"`.
+- `test_match` defaults `includeCandidates` to `false`, while `explain_match` defaults it to `true`.
 - Set `includeSemanticCandidates` to include semantic candidate scores when semantic matching is attempted.
+- The result payload for `test_match` and `explain_match` includes selected response metadata such as response id, status code, source (`responses` or `x-match`), and candidate index when applicable.
 
 ## Constraints
 


### PR DESCRIPTION
## Summary
- sync the root README files with the current inspection and local development behavior
- sync the MCP README files with the current inspection endpoint base path and tool behavior
- clarify MCP build steps in the main README files

## Why
The documentation had drifted from the current inspection surface and local setup details. This update brings the English and Japanese README files back in line with the current behavior.

## Validation
- `git diff --check -- README.md README.ja.md mcp/README.md mcp/README.ja.md`

## Notes
- docs only; no automated tests were run
