### PR TITLE
[codex] Track MCP inspection API compatibility

### DIFF
--- a/mcp/README.ja.md
+++ b/mcp/README.ja.md
@@ -52,12 +52,12 @@ npm run build
 | `get_route` | `GET /_semanticstub/runtime/routes/{id}` | ルート詳細 |
 | `get_scenarios` | `GET /_semanticstub/runtime/scenarios` | シナリオ状態 |
 | `get_metrics` | `GET /_semanticstub/runtime/metrics` | メトリクス |
-| `reset_metrics` | `POST /_semanticstub/runtime/metrics/reset` | メトリクスとリクエスト履歴のリセット |
+| `reset_metrics` | `POST /_semanticstub/runtime/metrics/resets` | メトリクスとリクエスト履歴のリセット |
 | `get_requests` | `GET /_semanticstub/runtime/requests?limit=` | 件数指定つきリクエスト履歴 |
 | `test_match` | `POST /_semanticstub/runtime/test-match` | マッチ確認（副作用なし） |
 | `explain_match` | `POST /_semanticstub/runtime/explain` | マッチ詳細説明 |
 | `get_last_explain` | `GET /_semanticstub/runtime/explain/last` | 直近の explain 結果 |
-| `reset_scenario_state` | `POST /_semanticstub/runtime/scenarios/reset` / `POST /_semanticstub/runtime/scenarios/{name}/reset` | シナリオ状態のリセット |
+| `reset_scenario_state` | `POST /_semanticstub/runtime/scenarios/resets` / `POST /_semanticstub/runtime/scenarios/{name}/resets` | シナリオ状態のリセット |
 
 ## 入力メモ
 
@@ -79,6 +79,10 @@ npm run build
 # ビルドなしで直接実行
 npm run dev
 ```
+
+この MCP パッケージが依存する inspection API の契約は、
+[`tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs`](../tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs)
+で回帰テストしています。
 
 ## 環境変数
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -53,12 +53,12 @@ Add this server to `claude_desktop_config.json`.
 | `get_route` | `GET /_semanticstub/runtime/routes/{id}` | Detailed route information |
 | `get_scenarios` | `GET /_semanticstub/runtime/scenarios` | Current scenario state |
 | `get_metrics` | `GET /_semanticstub/runtime/metrics` | Runtime metrics |
-| `reset_metrics` | `POST /_semanticstub/runtime/metrics/reset` | Reset runtime metrics and recent request history |
+| `reset_metrics` | `POST /_semanticstub/runtime/metrics/resets` | Reset runtime metrics and recent request history |
 | `get_requests` | `GET /_semanticstub/runtime/requests?limit=` | Recent request history with limit |
 | `test_match` | `POST /_semanticstub/runtime/test-match` | Match simulation without side effects |
 | `explain_match` | `POST /_semanticstub/runtime/explain` | Detailed match explanation |
 | `get_last_explain` | `GET /_semanticstub/runtime/explain/last` | Latest real-request explanation |
-| `reset_scenario_state` | `POST /_semanticstub/runtime/scenarios/reset` / `POST /_semanticstub/runtime/scenarios/{name}/reset` | Reset scenario state |
+| `reset_scenario_state` | `POST /_semanticstub/runtime/scenarios/resets` / `POST /_semanticstub/runtime/scenarios/{name}/resets` | Reset scenario state |
 
 ## Input Notes
 
@@ -80,6 +80,9 @@ Add this server to `claude_desktop_config.json`.
 # Run without building
 npm run dev
 ```
+
+The inspection API contract used by this MCP package is regression-tested in
+[`tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs`](../tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs).
 
 ## Environment Variables
 

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -130,7 +130,7 @@ server.registerTool(
     },
   },
   async () => {
-    await postNoContent("/metrics/reset");
+    await postNoContent("/metrics/resets");
 
     return toText({
       operation: "reset_metrics",
@@ -276,8 +276,8 @@ server.registerTool(
     // Reuse the existing reset endpoints so MCP does not redefine scenario mutation behavior.
     const hasScenarioName = scenarioName !== undefined;
     const path = hasScenarioName
-      ? `/scenarios/${encodeURIComponent(scenarioName)}/reset`
-      : "/scenarios/reset";
+      ? `/scenarios/${encodeURIComponent(scenarioName)}/resets`
+      : "/scenarios/resets";
 
     await postNoContent(path);
 

--- a/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
@@ -372,6 +372,18 @@ public sealed class StubInspectionEndpointTests : IClassFixture<WebApplicationFa
     }
 
     [Fact]
+    public async Task McpCompatibility_CanonicalResetEndpointsRemainAvailable()
+    {
+        var metricsResponse = await client.PostAsync("/_semanticstub/runtime/metrics/resets", content: null);
+        var scenariosResponse = await client.PostAsync("/_semanticstub/runtime/scenarios/resets", content: null);
+        var scenarioResponse = await client.PostAsync("/_semanticstub/runtime/scenarios/checkout-flow/resets", content: null);
+
+        Assert.Equal(HttpStatusCode.NoContent, metricsResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.NoContent, scenariosResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.NoContent, scenarioResponse.StatusCode);
+    }
+
+    [Fact]
     public async Task TestMatch_ReturnsSimulationPayload()
     {
         var response = await client.PostAsJsonAsync("/_semanticstub/runtime/test-match", new MatchRequestInfo
@@ -388,6 +400,37 @@ public sealed class StubInspectionEndpointTests : IClassFixture<WebApplicationFa
         Assert.True(payload.Matched);
         Assert.Equal("Matched", payload.MatchResult);
         Assert.Equal("getHello", payload.RouteId);
+    }
+
+    [Fact]
+    public async Task TestMatch_AcceptsMcpRequestShape()
+    {
+        var response = await client.PostAsJsonAsync("/_semanticstub/runtime/test-match", new
+        {
+            method = "GET",
+            path = "/users",
+            query = new Dictionary<string, string[]>
+            {
+                ["role"] = ["admin"]
+            },
+            headers = new Dictionary<string, string>
+            {
+                ["content-type"] = "application/json"
+            },
+            body = "{\"message\":\"hello\"}",
+            includeCandidates = true,
+            includeSemanticCandidates = false
+        });
+        response.EnsureSuccessStatusCode();
+
+        var payload = await response.Content.ReadFromJsonAsync<MatchSimulationInfo>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.NotNull(payload);
+        Assert.True(payload!.Matched);
+        Assert.Equal("Matched", payload.MatchResult);
+        Assert.Equal("listUsers", payload.RouteId);
+        Assert.NotEmpty(payload.Candidates);
     }
 
     [Fact]
@@ -412,6 +455,38 @@ public sealed class StubInspectionEndpointTests : IClassFixture<WebApplicationFa
         Assert.True(payload.PathMatched);
         Assert.True(payload.MethodMatched);
         Assert.Equal("Matched", payload.Result.MatchResult);
+        Assert.NotEmpty(payload.DeterministicCandidates);
+    }
+
+    [Fact]
+    public async Task ExplainMatch_AcceptsMcpRequestShape()
+    {
+        var response = await client.PostAsJsonAsync("/_semanticstub/runtime/explain", new
+        {
+            method = "GET",
+            path = "/users",
+            query = new Dictionary<string, string[]>
+            {
+                ["role"] = ["admin"]
+            },
+            headers = new Dictionary<string, string>
+            {
+                ["x-client"] = "mcp"
+            },
+            body = string.Empty,
+            includeCandidates = true,
+            includeSemanticCandidates = false
+        });
+        response.EnsureSuccessStatusCode();
+
+        var payload = await response.Content.ReadFromJsonAsync<MatchExplanationInfo>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.NotNull(payload);
+        Assert.True(payload!.PathMatched);
+        Assert.True(payload.MethodMatched);
+        Assert.Equal("Matched", payload.Result.MatchResult);
+        Assert.Equal("listUsers", payload.Result.RouteId);
         Assert.NotEmpty(payload.DeterministicCandidates);
     }
 


### PR DESCRIPTION
## Summary
- add MCP compatibility regression coverage for canonical reset endpoints and the request shape used by test/explain tools
- switch the MCP server to the canonical inspection reset endpoints under /resets
- align the English and Japanese MCP READMEs with the verified endpoint usage and document where the compatibility checks live

## Why
- issue #283 identified that the MCP layer relied on the inspection API contract without automated drift detection
- using the canonical reset endpoints keeps the MCP package aligned with the intended inspection surface while compatibility aliases remain covered on the API side

## Validation
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj
- npm --prefix mcp run build