### PR TITLE
docs: require Ready for review status in create-pr skill

### DIFF
--- a/SKILLS.md
+++ b/SKILLS.md
@@ -132,6 +132,7 @@ Create clean PR
 - PR title
 - PR body
 - PR link
+- PR status (must be Ready for review, not Draft)
 
 ---
 


### PR DESCRIPTION
## Summary

- Add explicit output requirement to `create-pr` skill: PR status must be **Ready for review**, not Draft
- Prevents accidentally leaving PRs in Draft state after running the `create-pr` workflow

## Test plan

- [ ] Verify SKILLS.md renders correctly
- [ ] Confirm `create-pr` skill output section lists the new requirement