### PR TITLE
feat: export recorded requests as curl commands (#293)

### DIFF
--- a/src/SemanticStub.Api/Controllers/StubController.cs
+++ b/src/SemanticStub.Api/Controllers/StubController.cs
@@ -74,7 +74,10 @@ public sealed class StubController : ControllerBase
     {
         var stopwatch = Stopwatch.StartNew();
         var requestPath = NormalizeRequestPath(path);
-        var dispatch = await DispatchRequestAsync(method, requestPath);
+        var query = Request.Query.ToDictionary(entry => entry.Key, entry => entry.Value, StringComparer.Ordinal);
+        var headers = Request.Headers.ToDictionary(entry => entry.Key, entry => entry.Value.ToString(), StringComparer.OrdinalIgnoreCase);
+        var requestBody = await StubRequestBodyReader.ReadAsync(Request, _logger);
+        var dispatch = await _stubService.DispatchAsync(method, requestPath, query, headers, requestBody, HttpContext.RequestAborted);
         int? statusCode = null;
 
         try
@@ -87,7 +90,8 @@ public sealed class StubController : ControllerBase
 
             if (statusCode.HasValue)
             {
-                RecordRequestObservation(dispatch, method, requestPath, statusCode.Value, stopwatch.Elapsed);
+                var querySnapshot = query.ToDictionary(e => e.Key, e => e.Value.OfType<string>().ToArray(), StringComparer.Ordinal);
+                RecordRequestObservation(dispatch, method, requestPath, statusCode.Value, stopwatch.Elapsed, querySnapshot, headers, requestBody);
             }
         }
     }
@@ -95,14 +99,6 @@ public sealed class StubController : ControllerBase
     private static string NormalizeRequestPath(string? path)
     {
         return string.IsNullOrEmpty(path) ? "/" : "/" + path;
-    }
-
-    private async Task<StubDispatchResult> DispatchRequestAsync(string method, string requestPath)
-    {
-        var query = Request.Query.ToDictionary(entry => entry.Key, entry => entry.Value, StringComparer.Ordinal);
-        var headers = Request.Headers.ToDictionary(entry => entry.Key, entry => entry.Value.ToString(), StringComparer.OrdinalIgnoreCase);
-        var requestBody = await StubRequestBodyReader.ReadAsync(Request, _logger);
-        return await _stubService.DispatchAsync(method, requestPath, query, headers, requestBody, HttpContext.RequestAborted);
     }
 
     private async Task<IActionResult> CreateActionResultAsync(StubDispatchResult dispatch, string requestPath, Action<int> setStatusCode)
@@ -178,7 +174,15 @@ public sealed class StubController : ControllerBase
         }
     }
 
-    private void RecordRequestObservation(StubDispatchResult dispatch, string method, string requestPath, int statusCode, TimeSpan elapsed)
+    private void RecordRequestObservation(
+        StubDispatchResult dispatch,
+        string method,
+        string requestPath,
+        int statusCode,
+        TimeSpan elapsed,
+        IReadOnlyDictionary<string, string[]> query,
+        IReadOnlyDictionary<string, string> headers,
+        string? body)
     {
         _inspectionService.RecordRequestMetrics(dispatch.Explanation, statusCode, elapsed);
         _inspectionService.RecordRecentRequest(
@@ -187,7 +191,10 @@ public sealed class StubController : ControllerBase
             requestPath,
             dispatch.Explanation,
             statusCode,
-            elapsed);
+            elapsed,
+            query,
+            headers,
+            body);
 
         _logger.LogInformation(
             "Request completed for '{Path}' {Method}. StatusCode={StatusCode}, ElapsedMs={ElapsedMs}, RouteId={RouteId}, MatchMode={MatchMode}, MatchResult={MatchResult}.",

--- a/src/SemanticStub.Api/Controllers/StubInspectionController.cs
+++ b/src/SemanticStub.Api/Controllers/StubInspectionController.cs
@@ -62,6 +62,28 @@ public sealed class StubInspectionController : ControllerBase
     [HttpGet("requests")]
     public IActionResult GetRecentRequests([FromQuery] int limit = 20) => Ok(_inspectionService.GetRecentRequests(limit));
 
+    /// <summary>Exports a recorded real request as a runnable curl command.</summary>
+    /// <param name="index">Zero-based index into the recent request history (0 = most recent).</param>
+    [HttpGet("requests/{index:int}/export/curl")]
+    public IActionResult ExportRequestAsCurl(int index)
+    {
+        if (index < 0)
+        {
+            return NotFoundProblem("Request not found", $"No recorded request at index {index}.");
+        }
+
+        var requests = _inspectionService.GetRecentRequests(index + 1);
+
+        if (index >= requests.Count)
+        {
+            return NotFoundProblem("Request not found", $"No recorded request at index {index}.");
+        }
+
+        var baseUrl = $"{Request.Scheme}://{Request.Host}";
+        var curl = CurlExporter.Export(requests[index], baseUrl);
+        return Content(curl, "text/plain");
+    }
+
     /// <summary>Simulates how the runtime would match a virtual request without executing a response.</summary>
     [HttpPost("test-match")]
     public async Task<IActionResult> TestMatch([FromBody] MatchRequestInfo request)

--- a/src/SemanticStub.Api/Controllers/StubInspectionController.cs
+++ b/src/SemanticStub.Api/Controllers/StubInspectionController.cs
@@ -79,7 +79,7 @@ public sealed class StubInspectionController : ControllerBase
             return NotFoundProblem("Request not found", $"No recorded request at index {index}.");
         }
 
-        var baseUrl = $"{Request.Scheme}://{Request.Host}";
+        var baseUrl = $"{Request.Scheme}://{Request.Host}{Request.PathBase}";
         var curl = CurlExporter.Export(requests[index], baseUrl);
         return Content(curl, "text/plain");
     }

--- a/src/SemanticStub.Api/Inspection/CurlExporter.cs
+++ b/src/SemanticStub.Api/Inspection/CurlExporter.cs
@@ -1,0 +1,77 @@
+using System.Text;
+using System.Web;
+
+namespace SemanticStub.Api.Inspection;
+
+/// <summary>
+/// Formats a <see cref="RecentRequestInfo"/> as a runnable curl command.
+/// </summary>
+public static class CurlExporter
+{
+    private static readonly HashSet<string> _skippedHeaders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Host",
+        "Connection",
+        "Content-Length",
+        "Transfer-Encoding",
+    };
+
+    /// <summary>
+    /// Exports a recorded request as a curl command string.
+    /// </summary>
+    /// <param name="request">The recorded request to export.</param>
+    /// <param name="baseUrl">The base URL (scheme + host) to prepend to the request path.</param>
+    /// <returns>A single curl command that reproduces the recorded request.</returns>
+    public static string Export(RecentRequestInfo request, string baseUrl)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrEmpty(baseUrl);
+
+        var sb = new StringBuilder();
+        sb.Append("curl -X ");
+        sb.Append(request.Method.ToUpperInvariant());
+        sb.Append(" '");
+        sb.Append(EscapeSingleQuote(BuildUrl(baseUrl, request.Path, request.Query)));
+        sb.Append('\'');
+
+        if (request.Headers is { Count: > 0 })
+        {
+            foreach (var (key, value) in request.Headers.OrderBy(h => h.Key, StringComparer.OrdinalIgnoreCase))
+            {
+                if (_skippedHeaders.Contains(key))
+                {
+                    continue;
+                }
+
+                sb.Append(" \\\n  -H '");
+                sb.Append(EscapeSingleQuote($"{key}: {value}"));
+                sb.Append('\'');
+            }
+        }
+
+        if (!string.IsNullOrEmpty(request.Body))
+        {
+            sb.Append(" \\\n  --data-raw '");
+            sb.Append(EscapeSingleQuote(request.Body));
+            sb.Append('\'');
+        }
+
+        return sb.ToString();
+    }
+
+    private static string BuildUrl(string baseUrl, string path, IReadOnlyDictionary<string, string[]>? query)
+    {
+        if (query is null || query.Count == 0)
+        {
+            return baseUrl + path;
+        }
+
+        var queryString = string.Join("&", query
+            .OrderBy(p => p.Key, StringComparer.Ordinal)
+            .SelectMany(p => p.Value.Select(v => $"{HttpUtility.UrlEncode(p.Key)}={HttpUtility.UrlEncode(v)}")));
+
+        return $"{baseUrl}{path}?{queryString}";
+    }
+
+    private static string EscapeSingleQuote(string value) => value.Replace("'", "'\\''");
+}

--- a/src/SemanticStub.Api/Inspection/CurlExporter.cs
+++ b/src/SemanticStub.Api/Inspection/CurlExporter.cs
@@ -61,16 +61,18 @@ public static class CurlExporter
 
     private static string BuildUrl(string baseUrl, string path, IReadOnlyDictionary<string, string[]>? query)
     {
+        var encodedPath = string.Join("/", path.Split('/').Select(Uri.EscapeDataString));
+
         if (query is null || query.Count == 0)
         {
-            return baseUrl + path;
+            return baseUrl + encodedPath;
         }
 
         var queryString = string.Join("&", query
             .OrderBy(p => p.Key, StringComparer.Ordinal)
             .SelectMany(p => p.Value.Select(v => $"{HttpUtility.UrlEncode(p.Key)}={HttpUtility.UrlEncode(v)}")));
 
-        return $"{baseUrl}{path}?{queryString}";
+        return $"{baseUrl}{encodedPath}?{queryString}";
     }
 
     private static string EscapeSingleQuote(string value) => value.Replace("'", "'\\''");

--- a/src/SemanticStub.Api/Inspection/RecentRequestInfo.cs
+++ b/src/SemanticStub.Api/Inspection/RecentRequestInfo.cs
@@ -44,4 +44,19 @@ public sealed class RecentRequestInfo
     /// Gets the failure reason when the request did not produce a matched response.
     /// </summary>
     public string? FailureReason { get; init; }
+
+    /// <summary>
+    /// Gets the query parameters captured from the original request, when available.
+    /// </summary>
+    public IReadOnlyDictionary<string, string[]>? Query { get; init; }
+
+    /// <summary>
+    /// Gets the request headers captured from the original request, when available.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? Headers { get; init; }
+
+    /// <summary>
+    /// Gets the request body captured from the original request, when present.
+    /// </summary>
+    public string? Body { get; init; }
 }

--- a/src/SemanticStub.Api/Services/Inspection/IStubInspectionService.cs
+++ b/src/SemanticStub.Api/Services/Inspection/IStubInspectionService.cs
@@ -81,7 +81,19 @@ public interface IStubInspectionService
     /// <param name="explanation">The explanation captured from the same dispatch evaluation.</param>
     /// <param name="statusCode">The final HTTP status code returned to the caller.</param>
     /// <param name="elapsed">The end-to-end elapsed time observed by the controller for the request.</param>
-    void RecordRecentRequest(DateTimeOffset timestamp, string method, string path, MatchExplanationInfo explanation, int statusCode, TimeSpan elapsed);
+    /// <param name="query">The query parameters captured from the original request.</param>
+    /// <param name="headers">The request headers captured from the original request.</param>
+    /// <param name="body">The request body captured from the original request.</param>
+    void RecordRecentRequest(
+        DateTimeOffset timestamp,
+        string method,
+        string path,
+        MatchExplanationInfo explanation,
+        int statusCode,
+        TimeSpan elapsed,
+        IReadOnlyDictionary<string, string[]>? query = null,
+        IReadOnlyDictionary<string, string>? headers = null,
+        string? body = null);
 
     /// <summary>
     /// Resets aggregate runtime metrics and recent request history for the current process.

--- a/src/SemanticStub.Api/Services/Inspection/StubInspectionRuntimeStore.cs
+++ b/src/SemanticStub.Api/Services/Inspection/StubInspectionRuntimeStore.cs
@@ -8,6 +8,15 @@ namespace SemanticStub.Api.Services;
 internal sealed class StubInspectionRuntimeStore
 {
     private const int MaxRecentRequestCount = 100;
+    private const int MaxBodyLengthChars = 4096;
+
+    private static readonly HashSet<string> _sensitiveHeaders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Authorization",
+        "Cookie",
+        "Set-Cookie",
+        "Proxy-Authorization",
+    };
     private readonly object _lastMatchSyncRoot = new();
     private readonly object _metricsSyncRoot = new();
     private readonly Dictionary<int, long> _statusCodeCounts = [];
@@ -181,9 +190,40 @@ internal sealed class StubInspectionRuntimeStore
                     ? null
                     : explanation.SelectionReason,
                 Query = query,
-                Headers = headers,
-                Body = body,
+                Headers = RedactSensitiveHeaders(headers),
+                Body = TruncateBody(body),
             });
         }
+    }
+
+    private static IReadOnlyDictionary<string, string>? RedactSensitiveHeaders(IReadOnlyDictionary<string, string>? headers)
+    {
+        if (headers is null || headers.Count == 0)
+        {
+            return headers;
+        }
+
+        Dictionary<string, string>? redacted = null;
+
+        foreach (var (key, value) in headers)
+        {
+            if (_sensitiveHeaders.Contains(key))
+            {
+                redacted ??= new Dictionary<string, string>(headers, StringComparer.OrdinalIgnoreCase);
+                redacted[key] = "[redacted]";
+            }
+        }
+
+        return redacted ?? headers;
+    }
+
+    private static string? TruncateBody(string? body)
+    {
+        if (string.IsNullOrEmpty(body) || body.Length <= MaxBodyLengthChars)
+        {
+            return body;
+        }
+
+        return body[..MaxBodyLengthChars] + "...[truncated]";
     }
 }

--- a/src/SemanticStub.Api/Services/Inspection/StubInspectionRuntimeStore.cs
+++ b/src/SemanticStub.Api/Services/Inspection/StubInspectionRuntimeStore.cs
@@ -146,7 +146,16 @@ internal sealed class StubInspectionRuntimeStore
         }
     }
 
-    public void RecordRecentRequest(DateTimeOffset timestamp, string method, string path, MatchExplanationInfo explanation, int statusCode, TimeSpan elapsed)
+    public void RecordRecentRequest(
+        DateTimeOffset timestamp,
+        string method,
+        string path,
+        MatchExplanationInfo explanation,
+        int statusCode,
+        TimeSpan elapsed,
+        IReadOnlyDictionary<string, string[]>? query = null,
+        IReadOnlyDictionary<string, string>? headers = null,
+        string? body = null)
     {
         ArgumentException.ThrowIfNullOrEmpty(method);
         ArgumentException.ThrowIfNullOrEmpty(path);
@@ -171,6 +180,9 @@ internal sealed class StubInspectionRuntimeStore
                 FailureReason = explanation.Result.Matched || string.IsNullOrWhiteSpace(explanation.SelectionReason)
                     ? null
                     : explanation.SelectionReason,
+                Query = query,
+                Headers = headers,
+                Body = body,
             });
         }
     }

--- a/src/SemanticStub.Api/Services/Inspection/StubInspectionService.cs
+++ b/src/SemanticStub.Api/Services/Inspection/StubInspectionService.cs
@@ -112,9 +112,18 @@ internal sealed class StubInspectionService : IStubInspectionService
     }
 
     /// <inheritdoc/>
-    public void RecordRecentRequest(DateTimeOffset timestamp, string method, string path, MatchExplanationInfo explanation, int statusCode, TimeSpan elapsed)
+    public void RecordRecentRequest(
+        DateTimeOffset timestamp,
+        string method,
+        string path,
+        MatchExplanationInfo explanation,
+        int statusCode,
+        TimeSpan elapsed,
+        IReadOnlyDictionary<string, string[]>? query = null,
+        IReadOnlyDictionary<string, string>? headers = null,
+        string? body = null)
     {
-        _runtimeStore.RecordRecentRequest(timestamp, method, path, explanation, statusCode, elapsed);
+        _runtimeStore.RecordRecentRequest(timestamp, method, path, explanation, statusCode, elapsed, query, headers, body);
     }
 
     /// <inheritdoc/>

--- a/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
@@ -542,6 +542,64 @@ public sealed class StubInspectionEndpointTests : IClassFixture<WebApplicationFa
         await AssertNotFoundProblemDetails(response, "Last match explanation not found");
     }
 
+    [Fact]
+    public async Task ExportRequestAsCurl_ReturnsNotFound_WhenNoRequestsRecorded()
+    {
+        await using var factory = new WebApplicationFactory<Program>();
+        using var freshClient = factory.CreateClient();
+
+        var response = await freshClient.GetAsync("/_semanticstub/runtime/requests/0/export/curl");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ExportRequestAsCurl_ReturnsNotFound_WhenIndexOutOfRange()
+    {
+        var routedResponse = await client.GetAsync("/hello");
+        routedResponse.EnsureSuccessStatusCode();
+
+        var response = await client.GetAsync("/_semanticstub/runtime/requests/99/export/curl");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ExportRequestAsCurl_ReturnsPlainTextCurlCommand_ForMostRecentRequest()
+    {
+        var routedResponse = await client.GetAsync("/hello");
+        routedResponse.EnsureSuccessStatusCode();
+
+        var response = await client.GetAsync("/_semanticstub/runtime/requests/0/export/curl");
+        response.EnsureSuccessStatusCode();
+
+        Assert.Equal("text/plain", response.Content.Headers.ContentType?.MediaType);
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.StartsWith("curl -X GET", content);
+        Assert.Contains("/hello", content);
+    }
+
+    [Fact]
+    public async Task ExportRequestAsCurl_IncludesQueryParameters_WhenPresent()
+    {
+        var routedResponse = await client.GetAsync("/users?role=admin");
+        routedResponse.EnsureSuccessStatusCode();
+
+        var response = await client.GetAsync("/_semanticstub/runtime/requests/0/export/curl");
+        response.EnsureSuccessStatusCode();
+
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.Contains("role=admin", content);
+    }
+
+    [Fact]
+    public async Task ExportRequestAsCurl_ReturnsNotFound_WhenIndexIsNegative()
+    {
+        var response = await client.GetAsync("/_semanticstub/runtime/requests/-1/export/curl");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
     private static async Task AssertNotFoundProblemDetails(HttpResponseMessage response, string expectedTitle)
     {
         Assert.Equal("application/problem+json", response.Content.Headers.ContentType?.MediaType);

--- a/tests/SemanticStub.Api.Tests/Unit/Controllers/StubControllerTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Controllers/StubControllerTests.cs
@@ -420,7 +420,16 @@ public sealed class StubControllerTests
             RecordRequestMetricsCallCount++;
         }
 
-        public void RecordRecentRequest(DateTimeOffset timestamp, string method, string path, MatchExplanationInfo explanation, int statusCode, TimeSpan elapsed)
+        public void RecordRecentRequest(
+            DateTimeOffset timestamp,
+            string method,
+            string path,
+            MatchExplanationInfo explanation,
+            int statusCode,
+            TimeSpan elapsed,
+            IReadOnlyDictionary<string, string[]>? query = null,
+            IReadOnlyDictionary<string, string>? headers = null,
+            string? body = null)
         {
             LastRecentRequestMethod = method;
             LastRecentRequestPath = path;
@@ -434,6 +443,9 @@ public sealed class StubControllerTests
                 ElapsedMilliseconds = elapsed.TotalMilliseconds,
                 MatchMode = explanation.Result.MatchMode,
                 FailureReason = explanation.SelectionReason,
+                Query = query,
+                Headers = headers,
+                Body = body,
             };
             RecordRecentRequestCallCount++;
         }

--- a/tests/SemanticStub.Api.Tests/Unit/Inspection/CurlExporterTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Inspection/CurlExporterTests.cs
@@ -1,0 +1,296 @@
+using SemanticStub.Api.Inspection;
+using Xunit;
+
+namespace SemanticStub.Api.Tests.Unit.Inspection;
+
+public sealed class CurlExporterTests
+{
+    private static RecentRequestInfo MakeRequest(
+        string method = "GET",
+        string path = "/hello",
+        IReadOnlyDictionary<string, string[]>? query = null,
+        IReadOnlyDictionary<string, string>? headers = null,
+        string? body = null)
+    {
+        return new RecentRequestInfo
+        {
+            Method = method,
+            Path = path,
+            Query = query,
+            Headers = headers,
+            Body = body,
+        };
+    }
+
+    [Fact]
+    public void Export_SimpleGetRequest_ReturnsCurlWithMethodAndUrl()
+    {
+        var request = MakeRequest("GET", "/hello");
+
+        var result = CurlExporter.Export(request, "http://localhost:5000");
+
+        Assert.Equal("curl -X GET 'http://localhost:5000/hello'", result);
+    }
+
+    [Fact]
+    public void Export_PostRequest_IncludesMethod()
+    {
+        var request = MakeRequest("POST", "/orders");
+
+        var result = CurlExporter.Export(request, "http://localhost:5000");
+
+        Assert.StartsWith("curl -X POST", result);
+    }
+
+    [Fact]
+    public void Export_WithQueryParameters_AppendsEncodedQueryString()
+    {
+        var request = MakeRequest("GET", "/users", query: new Dictionary<string, string[]>
+        {
+            ["role"] = ["admin"],
+            ["active"] = ["true"],
+        });
+
+        var result = CurlExporter.Export(request, "http://localhost:5000");
+
+        Assert.Contains("/users?", result);
+        Assert.Contains("role=admin", result);
+        Assert.Contains("active=true", result);
+    }
+
+    [Fact]
+    public void Export_WithMultiValueQueryParameter_RepeatsKey()
+    {
+        var request = MakeRequest("GET", "/items", query: new Dictionary<string, string[]>
+        {
+            ["id"] = ["1", "2", "3"],
+        });
+
+        var result = CurlExporter.Export(request, "http://localhost:5000");
+
+        Assert.Contains("id=1", result);
+        Assert.Contains("id=2", result);
+        Assert.Contains("id=3", result);
+    }
+
+    [Fact]
+    public void Export_WithHeaders_AddsHeaderLines()
+    {
+        var request = MakeRequest("GET", "/hello", headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Content-Type"] = "application/json",
+            ["Accept"] = "application/json",
+        });
+
+        var result = CurlExporter.Export(request, "http://localhost:5000");
+
+        Assert.Contains("-H 'Accept: application/json'", result);
+        Assert.Contains("-H 'Content-Type: application/json'", result);
+    }
+
+    [Fact]
+    public void Export_SkipsTransportHeaders()
+    {
+        var request = MakeRequest("GET", "/hello", headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Host"] = "localhost:5000",
+            ["Connection"] = "keep-alive",
+            ["Content-Length"] = "0",
+            ["Transfer-Encoding"] = "chunked",
+            ["Accept"] = "application/json",
+        });
+
+        var result = CurlExporter.Export(request, "http://localhost:5000");
+
+        Assert.DoesNotContain("Host:", result);
+        Assert.DoesNotContain("Connection:", result);
+        Assert.DoesNotContain("Content-Length:", result);
+        Assert.DoesNotContain("Transfer-Encoding:", result);
+        Assert.Contains("-H 'Accept: application/json'", result);
+    }
+
+    [Fact]
+    public void Export_WithBody_AddsDataRawFlag()
+    {
+        var request = MakeRequest("POST", "/orders", body: "{\"name\":\"test\"}");
+
+        var result = CurlExporter.Export(request, "http://localhost:5000");
+
+        Assert.Contains("--data-raw '{\"name\":\"test\"}'", result);
+    }
+
+    [Fact]
+    public void Export_WithHeadersAndBody_OutputsMultilineCommand()
+    {
+        var request = MakeRequest("POST", "/orders",
+            headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Content-Type"] = "application/json",
+            },
+            body: "{\"name\":\"test\"}");
+
+        var result = CurlExporter.Export(request, "http://localhost:5000");
+
+        Assert.Contains(" \\\n", result);
+        Assert.Contains("-H 'Content-Type: application/json'", result);
+        Assert.Contains("--data-raw", result);
+    }
+
+    [Fact]
+    public void Export_EscapesSingleQuotesInUrl()
+    {
+        var request = MakeRequest("GET", "/it's/a/path");
+
+        var result = CurlExporter.Export(request, "http://localhost:5000");
+
+        Assert.Contains("it'\\''s", result);
+    }
+
+    [Fact]
+    public void Export_EscapesSingleQuotesInBody()
+    {
+        var request = MakeRequest("POST", "/orders", body: "it's a value");
+
+        var result = CurlExporter.Export(request, "http://localhost:5000");
+
+        Assert.Contains("it'\\''s a value", result);
+    }
+
+    [Fact]
+    public void Export_EscapesSingleQuotesInHeaders()
+    {
+        var request = MakeRequest("GET", "/hello", headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["X-Custom"] = "val'ue",
+        });
+
+        var result = CurlExporter.Export(request, "http://localhost:5000");
+
+        Assert.Contains("val'\\''ue", result);
+    }
+
+    [Fact]
+    public void Export_WithNullQuery_DoesNotAppendQueryString()
+    {
+        var request = MakeRequest("GET", "/hello", query: null);
+
+        var result = CurlExporter.Export(request, "http://localhost:5000");
+
+        Assert.DoesNotContain("?", result);
+    }
+
+    [Fact]
+    public void Export_WithNullHeaders_DoesNotAddHeaderLines()
+    {
+        var request = MakeRequest("GET", "/hello", headers: null);
+
+        var result = CurlExporter.Export(request, "http://localhost:5000");
+
+        Assert.DoesNotContain("-H", result);
+    }
+
+    [Fact]
+    public void Export_WithNullBody_DoesNotAddDataRaw()
+    {
+        var request = MakeRequest("POST", "/orders", body: null);
+
+        var result = CurlExporter.Export(request, "http://localhost:5000");
+
+        Assert.DoesNotContain("--data-raw", result);
+    }
+
+    [Fact]
+    public void Export_WithEmptyBody_DoesNotAddDataRaw()
+    {
+        var request = MakeRequest("POST", "/orders", body: string.Empty);
+
+        var result = CurlExporter.Export(request, "http://localhost:5000");
+
+        Assert.DoesNotContain("--data-raw", result);
+    }
+
+    [Fact]
+    public void Export_HeadersAreSortedAlphabetically()
+    {
+        var request = MakeRequest("GET", "/hello", headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["X-Request-Id"] = "abc",
+            ["Accept"] = "application/json",
+            ["Content-Type"] = "text/plain",
+        });
+
+        var result = CurlExporter.Export(request, "http://localhost:5000");
+
+        var acceptPos = result.IndexOf("Accept:", StringComparison.Ordinal);
+        var contentTypePos = result.IndexOf("Content-Type:", StringComparison.Ordinal);
+        var xRequestIdPos = result.IndexOf("X-Request-Id:", StringComparison.Ordinal);
+
+        Assert.True(acceptPos < contentTypePos);
+        Assert.True(contentTypePos < xRequestIdPos);
+    }
+
+    [Fact]
+    public void Export_QueryKeysAreSortedAlphabetically()
+    {
+        var request = MakeRequest("GET", "/search", query: new Dictionary<string, string[]>
+        {
+            ["z"] = ["last"],
+            ["a"] = ["first"],
+            ["m"] = ["middle"],
+        });
+
+        var result = CurlExporter.Export(request, "http://localhost:5000");
+
+        var aPos = result.IndexOf("a=first", StringComparison.Ordinal);
+        var mPos = result.IndexOf("m=middle", StringComparison.Ordinal);
+        var zPos = result.IndexOf("z=last", StringComparison.Ordinal);
+
+        Assert.True(aPos < mPos);
+        Assert.True(mPos < zPos);
+    }
+
+    [Fact]
+    public void Export_MethodIsUpperCased()
+    {
+        var request = MakeRequest("get", "/hello");
+
+        var result = CurlExporter.Export(request, "http://localhost:5000");
+
+        Assert.StartsWith("curl -X GET", result);
+    }
+
+    [Fact]
+    public void Export_ThrowsWhenRequestIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => CurlExporter.Export(null!, "http://localhost:5000"));
+    }
+
+    [Fact]
+    public void Export_ThrowsArgumentNullException_WhenBaseUrlIsNull()
+    {
+        var request = MakeRequest();
+
+        Assert.Throws<ArgumentNullException>(() => CurlExporter.Export(request, null!));
+    }
+
+    [Fact]
+    public void Export_ThrowsArgumentException_WhenBaseUrlIsEmpty()
+    {
+        var request = MakeRequest();
+
+        Assert.Throws<ArgumentException>(() => CurlExporter.Export(request, string.Empty));
+    }
+
+    [Fact]
+    public void Export_WithSpecialCharsInQueryValue_EncodesValue()
+    {
+        var request = MakeRequest("GET", "/search", query: new Dictionary<string, string[]>
+        {
+            ["q"] = ["hello world"],
+        });
+
+        var result = CurlExporter.Export(request, "http://localhost:5000");
+
+        Assert.Contains("q=hello+world", result);
+    }
+}

--- a/tests/SemanticStub.Api.Tests/Unit/Inspection/CurlExporterTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Inspection/CurlExporterTests.cs
@@ -137,13 +137,13 @@ public sealed class CurlExporterTests
     }
 
     [Fact]
-    public void Export_EscapesSingleQuotesInUrl()
+    public void Export_EncodesReservedCharsInPath_IncludingSingleQuote()
     {
         var request = MakeRequest("GET", "/it's/a/path");
 
         var result = CurlExporter.Export(request, "http://localhost:5000");
 
-        Assert.Contains("it'\\''s", result);
+        Assert.Contains("it%27s", result);
     }
 
     [Fact]
@@ -292,5 +292,37 @@ public sealed class CurlExporterTests
         var result = CurlExporter.Export(request, "http://localhost:5000");
 
         Assert.Contains("q=hello+world", result);
+    }
+
+    [Fact]
+    public void Export_WithSpaceInPath_EncodesPathSegment()
+    {
+        var request = MakeRequest("GET", "/search/hello world");
+
+        var result = CurlExporter.Export(request, "http://localhost:5000");
+
+        Assert.Contains("/search/hello%20world", result);
+        Assert.DoesNotContain("hello world", result);
+    }
+
+    [Fact]
+    public void Export_WithHashInPath_EncodesPathSegment()
+    {
+        var request = MakeRequest("GET", "/items/item#1");
+
+        var result = CurlExporter.Export(request, "http://localhost:5000");
+
+        Assert.Contains("/items/item%231", result);
+    }
+
+    [Fact]
+    public void Export_WithNormalAsciiPath_PreservesSlashSeparators()
+    {
+        var request = MakeRequest("GET", "/users/123/orders");
+
+        var result = CurlExporter.Export(request, "http://localhost:5000");
+
+        Assert.Contains("'http://localhost:5000/users/123/orders'", result);
+        Assert.DoesNotContain("%2F", result);
     }
 }

--- a/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionRuntimeMetricsTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Inspection/StubInspectionRuntimeMetricsTests.cs
@@ -419,4 +419,114 @@ public sealed class StubInspectionRuntimeMetricsTests
 
         Assert.Same(explanation, store.GetLastMatchExplanation());
     }
+
+    [Fact]
+    public void RecordRecentRequest_RedactsSensitiveHeaders_BeforeStoring()
+    {
+        var store = new StubInspectionRuntimeStore();
+        var explanation = CreateRecordedExplanation(matched: true, matchResult: "Matched", routeId: "listUsers");
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Authorization"] = "Bearer secret-token",
+            ["Cookie"] = "session=abc123",
+            ["Proxy-Authorization"] = "Basic dXNlcjpwYXNz",
+            ["Set-Cookie"] = "id=xyz; HttpOnly",
+            ["Content-Type"] = "application/json",
+            ["Accept"] = "application/json",
+        };
+
+        store.RecordRecentRequest(
+            DateTimeOffset.UtcNow,
+            HttpMethods.Get,
+            "/users",
+            explanation,
+            StatusCodes.Status200OK,
+            TimeSpan.FromMilliseconds(10),
+            headers: headers);
+
+        var requests = store.GetRecentRequests(1);
+        var stored = Assert.Single(requests);
+
+        Assert.NotNull(stored.Headers);
+        Assert.Equal("[redacted]", stored.Headers!["Authorization"]);
+        Assert.Equal("[redacted]", stored.Headers["Cookie"]);
+        Assert.Equal("[redacted]", stored.Headers["Proxy-Authorization"]);
+        Assert.Equal("[redacted]", stored.Headers["Set-Cookie"]);
+        Assert.Equal("application/json", stored.Headers["Content-Type"]);
+        Assert.Equal("application/json", stored.Headers["Accept"]);
+    }
+
+    [Fact]
+    public void RecordRecentRequest_TruncatesLargeBody_BeforeStoring()
+    {
+        var store = new StubInspectionRuntimeStore();
+        var explanation = CreateRecordedExplanation(matched: true, matchResult: "Matched", routeId: "createOrder");
+        var largeBody = new string('x', 5000);
+
+        store.RecordRecentRequest(
+            DateTimeOffset.UtcNow,
+            HttpMethods.Post,
+            "/orders",
+            explanation,
+            StatusCodes.Status201Created,
+            TimeSpan.FromMilliseconds(20),
+            body: largeBody);
+
+        var requests = store.GetRecentRequests(1);
+        var stored = Assert.Single(requests);
+
+        Assert.NotNull(stored.Body);
+        Assert.True(stored.Body!.Length < largeBody.Length);
+        Assert.EndsWith("...[truncated]", stored.Body);
+    }
+
+    [Fact]
+    public void RecordRecentRequest_DoesNotTruncate_WhenBodyIsWithinLimit()
+    {
+        var store = new StubInspectionRuntimeStore();
+        var explanation = CreateRecordedExplanation(matched: true, matchResult: "Matched", routeId: "createOrder");
+        var smallBody = "{\"name\":\"test\"}";
+
+        store.RecordRecentRequest(
+            DateTimeOffset.UtcNow,
+            HttpMethods.Post,
+            "/orders",
+            explanation,
+            StatusCodes.Status201Created,
+            TimeSpan.FromMilliseconds(20),
+            body: smallBody);
+
+        var requests = store.GetRecentRequests(1);
+        var stored = Assert.Single(requests);
+
+        Assert.Equal(smallBody, stored.Body);
+    }
+
+    [Fact]
+    public void RecordRecentRequest_PreservesNonSensitiveHeaders_Unchanged()
+    {
+        var store = new StubInspectionRuntimeStore();
+        var explanation = CreateRecordedExplanation(matched: true, matchResult: "Matched", routeId: "listUsers");
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Content-Type"] = "application/json",
+            ["X-Correlation-Id"] = "abc-123",
+        };
+
+        store.RecordRecentRequest(
+            DateTimeOffset.UtcNow,
+            HttpMethods.Get,
+            "/users",
+            explanation,
+            StatusCodes.Status200OK,
+            TimeSpan.FromMilliseconds(10),
+            headers: headers);
+
+        var requests = store.GetRecentRequests(1);
+        var stored = Assert.Single(requests);
+
+        Assert.NotNull(stored.Headers);
+        Assert.Equal("application/json", stored.Headers!["Content-Type"]);
+        Assert.Equal("abc-123", stored.Headers["X-Correlation-Id"]);
+    }
 }


### PR DESCRIPTION
## Summary

- Add `GET /_semanticstub/runtime/requests/{index}/export/curl` endpoint that returns a runnable curl command for a recorded real request (index 0 = most recent)
- Extend `RecentRequestInfo` with optional `Query`, `Headers`, `Body` fields captured from the real HTTP request
- Add `CurlExporter` static class that produces a deterministic, multi-line curl command (alphabetically sorted headers/query, single-quote escaping, transport headers skipped)
- Redact sensitive headers (`Authorization`, `Cookie`, `Set-Cookie`, `Proxy-Authorization`) before storing to prevent credential exposure via inspection APIs
- Truncate body to 4096 chars before storing; truncated bodies are marked with `...[truncated]`
- Percent-encode path segments (`Uri.EscapeDataString`) so paths with spaces, `#`, `?`, etc. produce valid curl commands
- Include `Request.PathBase` in the export base URL for sub-path deployments

## Known limitation (v1)

Paths that contain `%2F` (percent-encoded forward slash) as preserved by ASP.NET Core will be double-encoded to `%252F` in the exported curl command. Solving all encoded-character edge cases is an explicit non-goal of this issue.

## Changes

| File | Change |
|------|--------|
| `Inspection/RecentRequestInfo.cs` | Add optional `Query`, `Headers`, `Body` fields |
| `Inspection/CurlExporter.cs` (new) | Formats `RecentRequestInfo` as a curl command string; encodes path segments |
| `Controllers/StubController.cs` | Inline `DispatchRequestAsync`, capture and pass request data to recording chain |
| `Services/Inspection/IStubInspectionService.cs` | Extend `RecordRecentRequest` with optional `query`/`headers`/`body` params |
| `Services/Inspection/StubInspectionService.cs` | Pass through new params |
| `Services/Inspection/StubInspectionRuntimeStore.cs` | Store `Query`, `Headers`, `Body`; redact sensitive headers; truncate large bodies |
| `Controllers/StubInspectionController.cs` | Add `GET requests/{index:int}/export/curl` endpoint; include `PathBase` in base URL |

## Test plan

- [x] `CurlExporterTests` (unit): 25 cases covering GET+query, POST+body, custom headers, transport header skipping, quote escaping, sorting, null/empty inputs, path encoding
- [x] Redaction tests: `Authorization`/`Cookie`/`Set-Cookie`/`Proxy-Authorization` stored as `[redacted]`, non-sensitive headers preserved
- [x] Truncation tests: body over 4096 chars truncated with `...[truncated]` suffix; small body preserved as-is
- [x] Integration tests: 200 with `text/plain` curl output, 404 for empty history, 404 for out-of-range index, 404 for negative index, query parameters included in output
- [x] All 409 tests pass

Closes #293

https://claude.ai/code/session_01HUXLNCWZZETJxEN3Ew5Xen