### PR TITLE
feat: add replay-ready request export model (#292)

### DIFF
--- a/src/SemanticStub.Api/Controllers/StubInspectionController.cs
+++ b/src/SemanticStub.Api/Controllers/StubInspectionController.cs
@@ -84,6 +84,26 @@ public sealed class StubInspectionController : ControllerBase
         return Content(curl, "text/plain");
     }
 
+    /// <summary>Exports a recorded real request as a replay-ready structured model.</summary>
+    /// <param name="index">Zero-based index into the recent request history (0 = most recent).</param>
+    [HttpGet("requests/{index:int}/export/replay")]
+    public IActionResult ExportRequestAsReplay(int index)
+    {
+        if (index < 0)
+        {
+            return NotFoundProblem("Request not found", $"No recorded request at index {index}.");
+        }
+
+        var requests = _inspectionService.GetRecentRequests(index + 1);
+
+        if (index >= requests.Count)
+        {
+            return NotFoundProblem("Request not found", $"No recorded request at index {index}.");
+        }
+
+        return Ok(ReplayRequestExporter.Export(requests[index]));
+    }
+
     /// <summary>Simulates how the runtime would match a virtual request without executing a response.</summary>
     [HttpPost("test-match")]
     public async Task<IActionResult> TestMatch([FromBody] MatchRequestInfo request)

--- a/src/SemanticStub.Api/Inspection/ReplayReadyRequestInfo.cs
+++ b/src/SemanticStub.Api/Inspection/ReplayReadyRequestInfo.cs
@@ -1,0 +1,35 @@
+namespace SemanticStub.Api.Inspection;
+
+/// <summary>
+/// Describes a recorded request in a structured, replay-ready form.
+/// Contains only the fields needed to reproduce the request; runtime metadata such as
+/// timestamps, match results, and status codes are intentionally excluded.
+/// </summary>
+public sealed class ReplayReadyRequestInfo
+{
+    /// <summary>
+    /// Gets the HTTP method, normalised to upper case.
+    /// </summary>
+    public required string Method { get; init; }
+
+    /// <summary>
+    /// Gets the absolute request path.
+    /// </summary>
+    public required string Path { get; init; }
+
+    /// <summary>
+    /// Gets the query parameters captured from the original request, when present.
+    /// Multi-value parameters are preserved as arrays.
+    /// </summary>
+    public IReadOnlyDictionary<string, string[]>? Query { get; init; }
+
+    /// <summary>
+    /// Gets the request headers, with transport-only headers removed.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? Headers { get; init; }
+
+    /// <summary>
+    /// Gets the request body captured from the original request, when present.
+    /// </summary>
+    public string? Body { get; init; }
+}

--- a/src/SemanticStub.Api/Inspection/ReplayRequestExporter.cs
+++ b/src/SemanticStub.Api/Inspection/ReplayRequestExporter.cs
@@ -1,0 +1,52 @@
+namespace SemanticStub.Api.Inspection;
+
+/// <summary>
+/// Converts a <see cref="RecentRequestInfo"/> into a <see cref="ReplayReadyRequestInfo"/>
+/// by retaining only the fields required for replay and dropping runtime metadata.
+/// </summary>
+public static class ReplayRequestExporter
+{
+    private static readonly HashSet<string> _skippedHeaders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Host",
+        "Connection",
+        "Content-Length",
+        "Transfer-Encoding",
+    };
+
+    /// <summary>
+    /// Exports a recorded request as a replay-ready structured model.
+    /// </summary>
+    /// <param name="request">The recorded request to export.</param>
+    /// <returns>
+    /// A <see cref="ReplayReadyRequestInfo"/> containing the method, path, query, headers, and body
+    /// needed to reproduce the request. Transport-only headers are omitted.
+    /// </returns>
+    public static ReplayReadyRequestInfo Export(RecentRequestInfo request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        IReadOnlyDictionary<string, string>? filteredHeaders = null;
+
+        if (request.Headers is { Count: > 0 })
+        {
+            var dict = request.Headers
+                .Where(h => !_skippedHeaders.Contains(h.Key))
+                .ToDictionary(h => h.Key, h => h.Value, StringComparer.OrdinalIgnoreCase);
+
+            if (dict.Count > 0)
+            {
+                filteredHeaders = dict;
+            }
+        }
+
+        return new ReplayReadyRequestInfo
+        {
+            Method = request.Method.ToUpperInvariant(),
+            Path = request.Path,
+            Query = request.Query,
+            Headers = filteredHeaders,
+            Body = request.Body,
+        };
+    }
+}

--- a/tests/SemanticStub.Api.Tests/Unit/Inspection/ReplayRequestExporterTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Inspection/ReplayRequestExporterTests.cs
@@ -1,0 +1,246 @@
+using SemanticStub.Api.Inspection;
+using Xunit;
+
+namespace SemanticStub.Api.Tests.Unit.Inspection;
+
+public sealed class ReplayRequestExporterTests
+{
+    private static RecentRequestInfo MakeRequest(
+        string method = "GET",
+        string path = "/hello",
+        IReadOnlyDictionary<string, string[]>? query = null,
+        IReadOnlyDictionary<string, string>? headers = null,
+        string? body = null)
+    {
+        return new RecentRequestInfo
+        {
+            Method = method,
+            Path = path,
+            Query = query,
+            Headers = headers,
+            Body = body,
+        };
+    }
+
+    [Fact]
+    public void Export_SimpleGetRequest_ReturnsMethodAndPath()
+    {
+        var request = MakeRequest("GET", "/hello");
+
+        var result = ReplayRequestExporter.Export(request);
+
+        Assert.Equal("GET", result.Method);
+        Assert.Equal("/hello", result.Path);
+    }
+
+    [Fact]
+    public void Export_MethodIsUpperCased()
+    {
+        var request = MakeRequest("get", "/hello");
+
+        var result = ReplayRequestExporter.Export(request);
+
+        Assert.Equal("GET", result.Method);
+    }
+
+    [Fact]
+    public void Export_PostRequest_PreservesMethod()
+    {
+        var request = MakeRequest("POST", "/orders");
+
+        var result = ReplayRequestExporter.Export(request);
+
+        Assert.Equal("POST", result.Method);
+    }
+
+    [Fact]
+    public void Export_WithQuery_PreservesQuery()
+    {
+        var query = new Dictionary<string, string[]>
+        {
+            ["role"] = ["admin"],
+            ["active"] = ["true"],
+        };
+        var request = MakeRequest("GET", "/users", query: query);
+
+        var result = ReplayRequestExporter.Export(request);
+
+        Assert.NotNull(result.Query);
+        Assert.Equal(["admin"], result.Query["role"]);
+        Assert.Equal(["true"], result.Query["active"]);
+    }
+
+    [Fact]
+    public void Export_WithMultiValueQuery_PreservesAllValues()
+    {
+        var query = new Dictionary<string, string[]>
+        {
+            ["id"] = ["1", "2", "3"],
+        };
+        var request = MakeRequest("GET", "/items", query: query);
+
+        var result = ReplayRequestExporter.Export(request);
+
+        Assert.NotNull(result.Query);
+        Assert.Equal(["1", "2", "3"], result.Query["id"]);
+    }
+
+    [Fact]
+    public void Export_WithNullQuery_ReturnsNullQuery()
+    {
+        var request = MakeRequest("GET", "/hello", query: null);
+
+        var result = ReplayRequestExporter.Export(request);
+
+        Assert.Null(result.Query);
+    }
+
+    [Fact]
+    public void Export_WithHeaders_PreservesNonTransportHeaders()
+    {
+        var request = MakeRequest("GET", "/hello", headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Content-Type"] = "application/json",
+            ["Accept"] = "application/json",
+        });
+
+        var result = ReplayRequestExporter.Export(request);
+
+        Assert.NotNull(result.Headers);
+        Assert.Equal("application/json", result.Headers["Content-Type"]);
+        Assert.Equal("application/json", result.Headers["Accept"]);
+    }
+
+    [Fact]
+    public void Export_FiltersTransportHeaders()
+    {
+        var request = MakeRequest("GET", "/hello", headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Host"] = "localhost:5000",
+            ["Connection"] = "keep-alive",
+            ["Content-Length"] = "42",
+            ["Transfer-Encoding"] = "chunked",
+            ["Accept"] = "application/json",
+        });
+
+        var result = ReplayRequestExporter.Export(request);
+
+        Assert.NotNull(result.Headers);
+        Assert.False(result.Headers.ContainsKey("Host"));
+        Assert.False(result.Headers.ContainsKey("Connection"));
+        Assert.False(result.Headers.ContainsKey("Content-Length"));
+        Assert.False(result.Headers.ContainsKey("Transfer-Encoding"));
+        Assert.True(result.Headers.ContainsKey("Accept"));
+    }
+
+    [Fact]
+    public void Export_WithOnlyTransportHeaders_ReturnsNullHeaders()
+    {
+        var request = MakeRequest("GET", "/hello", headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Host"] = "localhost:5000",
+            ["Connection"] = "keep-alive",
+        });
+
+        var result = ReplayRequestExporter.Export(request);
+
+        Assert.Null(result.Headers);
+    }
+
+    [Fact]
+    public void Export_WithNullHeaders_ReturnsNullHeaders()
+    {
+        var request = MakeRequest("GET", "/hello", headers: null);
+
+        var result = ReplayRequestExporter.Export(request);
+
+        Assert.Null(result.Headers);
+    }
+
+    [Fact]
+    public void Export_WithBody_PreservesBody()
+    {
+        var request = MakeRequest("POST", "/orders", body: "{\"name\":\"test\"}");
+
+        var result = ReplayRequestExporter.Export(request);
+
+        Assert.Equal("{\"name\":\"test\"}", result.Body);
+    }
+
+    [Fact]
+    public void Export_WithNullBody_ReturnsNullBody()
+    {
+        var request = MakeRequest("POST", "/orders", body: null);
+
+        var result = ReplayRequestExporter.Export(request);
+
+        Assert.Null(result.Body);
+    }
+
+    [Fact]
+    public void Export_WithEmptyBody_ReturnsEmptyBody()
+    {
+        var request = MakeRequest("POST", "/orders", body: string.Empty);
+
+        var result = ReplayRequestExporter.Export(request);
+
+        Assert.Equal(string.Empty, result.Body);
+    }
+
+    [Fact]
+    public void Export_WithAllFields_MapsAllReplayFields()
+    {
+        var request = MakeRequest(
+            method: "PUT",
+            path: "/items/42",
+            query: new Dictionary<string, string[]> { ["dry-run"] = ["true"] },
+            headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Content-Type"] = "application/json",
+                ["X-Request-Id"] = "abc123",
+            },
+            body: "{\"value\":1}");
+
+        var result = ReplayRequestExporter.Export(request);
+
+        Assert.Equal("PUT", result.Method);
+        Assert.Equal("/items/42", result.Path);
+        Assert.NotNull(result.Query);
+        Assert.Equal(["true"], result.Query["dry-run"]);
+        Assert.NotNull(result.Headers);
+        Assert.Equal("application/json", result.Headers["Content-Type"]);
+        Assert.Equal("abc123", result.Headers["X-Request-Id"]);
+        Assert.Equal("{\"value\":1}", result.Body);
+    }
+
+    [Fact]
+    public void Export_DoesNotIncludeRuntimeMetadata()
+    {
+        var request = new RecentRequestInfo
+        {
+            Method = "GET",
+            Path = "/hello",
+            StatusCode = 200,
+            ElapsedMilliseconds = 42.5,
+            RouteId = "some-route",
+            MatchMode = "exact",
+            FailureReason = null,
+            Timestamp = DateTimeOffset.UtcNow,
+        };
+
+        var result = ReplayRequestExporter.Export(request);
+
+        // ReplayReadyRequestInfo has no runtime metadata fields
+        Assert.Equal("GET", result.Method);
+        Assert.Equal("/hello", result.Path);
+        Assert.Null(result.Query);
+        Assert.Null(result.Headers);
+        Assert.Null(result.Body);
+    }
+
+    [Fact]
+    public void Export_ThrowsWhenRequestIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => ReplayRequestExporter.Export(null!));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ReplayReadyRequestInfo` DTO that captures only the fields needed for replay: method, path, query, headers, and body. Runtime metadata (timestamp, status code, route ID, match mode, elapsed time) is intentionally excluded.
- Add `ReplayRequestExporter` that converts a `RecentRequestInfo` into a `ReplayReadyRequestInfo`, normalising the method to upper case and filtering out transport-only headers (Host, Connection, Content-Length, Transfer-Encoding).
- Expose `GET /_semanticstub/runtime/requests/{index}/export/replay` which returns the replay-ready model as JSON.

The new endpoint follows the same index-based access pattern as the existing curl export (`/export/curl`) introduced in #293.

## Test plan

- [x] `ReplayRequestExporterTests` — 16 unit tests covering representative request shapes (GET, POST, body, query, headers), missing-field cases (null query / headers / body), transport header filtering, method normalisation, and argument validation
- [x] All existing tests continue to pass (506 total)

Closes #292

---
_Generated by [Claude Code](https://claude.ai/code/session_018F7zoDi8qJZpRmRXZCP6Wo)_