### PR TITLE
feat: add replay endpoint for recorded requests (#294)

### DIFF
--- a/src/SemanticStub.Api/Controllers/StubInspectionController.cs
+++ b/src/SemanticStub.Api/Controllers/StubInspectionController.cs
@@ -104,6 +104,53 @@ public sealed class StubInspectionController : ControllerBase
         return Ok(ReplayRequestExporter.Export(requests[index]));
     }
 
+    /// <summary>Replays a recorded real request through the stub matching pipeline and returns the result.</summary>
+    /// <param name="index">Zero-based index into the recent request history (0 = most recent).</param>
+    /// <remarks>
+    /// Replay is a dry run: it evaluates matching without executing a response or advancing scenario state.
+    /// The replayed body and headers reflect what was captured at recording time.
+    /// Bodies longer than 4096 characters and sensitive headers are redacted by the recording pipeline.
+    /// </remarks>
+    [HttpPost("requests/{index:int}/replay")]
+    public async Task<IActionResult> ReplayRequest(int index)
+    {
+        if (index < 0)
+        {
+            return NotFoundProblem("Request not found", $"No recorded request at index {index}.");
+        }
+
+        var requests = _inspectionService.GetRecentRequests(index + 1);
+
+        if (index >= requests.Count)
+        {
+            return NotFoundProblem("Request not found", $"No recorded request at index {index}.");
+        }
+
+        var replayRequest = ReplayRequestExporter.Export(requests[index]);
+
+        var matchRequest = new MatchRequestInfo
+        {
+            Method = replayRequest.Method,
+            Path = replayRequest.Path,
+            Query = replayRequest.Query is { Count: > 0 }
+                ? new Dictionary<string, string[]>(replayRequest.Query, StringComparer.Ordinal)
+                : new Dictionary<string, string[]>(),
+            Headers = replayRequest.Headers is { Count: > 0 }
+                ? new Dictionary<string, string>(replayRequest.Headers, StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            Body = replayRequest.Body,
+            IncludeCandidates = true,
+        };
+
+        var explanation = await _inspectionService.ExplainMatchAsync(matchRequest, HttpContext.RequestAborted);
+
+        return Ok(new ReplayResultInfo
+        {
+            Request = replayRequest,
+            Explanation = explanation,
+        });
+    }
+
     /// <summary>Simulates how the runtime would match a virtual request without executing a response.</summary>
     [HttpPost("test-match")]
     public async Task<IActionResult> TestMatch([FromBody] MatchRequestInfo request)

--- a/src/SemanticStub.Api/Inspection/ReplayResultInfo.cs
+++ b/src/SemanticStub.Api/Inspection/ReplayResultInfo.cs
@@ -1,0 +1,18 @@
+namespace SemanticStub.Api.Inspection;
+
+/// <summary>
+/// Describes the result of replaying a recorded request through the stub matching pipeline.
+/// Contains the normalised replay request and the full match explanation produced by the dry run.
+/// </summary>
+public sealed class ReplayResultInfo
+{
+    /// <summary>
+    /// Gets the request that was replayed.
+    /// </summary>
+    public required ReplayReadyRequestInfo Request { get; init; }
+
+    /// <summary>
+    /// Gets the match explanation produced by replaying the request.
+    /// </summary>
+    public required MatchExplanationInfo Explanation { get; init; }
+}

--- a/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
@@ -600,6 +600,103 @@ public sealed class StubInspectionEndpointTests : IClassFixture<WebApplicationFa
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
+    [Fact]
+    public async Task ReplayRequest_WhenNoRequestsRecorded_ReturnsNotFound()
+    {
+        await using var factory = new WebApplicationFactory<Program>();
+        using var freshClient = factory.CreateClient();
+
+        var response = await freshClient.PostAsync("/_semanticstub/runtime/requests/0/replay", content: null);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ReplayRequest_WhenIndexIsNegative_ReturnsNotFound()
+    {
+        var response = await client.PostAsync("/_semanticstub/runtime/requests/-1/replay", content: null);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ReplayRequest_WhenIndexOutOfRange_ReturnsNotFound()
+    {
+        var routedResponse = await client.GetAsync("/hello");
+        routedResponse.EnsureSuccessStatusCode();
+
+        var response = await client.PostAsync("/_semanticstub/runtime/requests/99/replay", content: null);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ReplayRequest_AfterRealRequest_ReturnsOk()
+    {
+        var routedResponse = await client.GetAsync("/hello");
+        routedResponse.EnsureSuccessStatusCode();
+
+        var response = await client.PostAsync("/_semanticstub/runtime/requests/0/replay", content: null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ReplayRequest_AfterRealRequest_ResponseDeserializesToReplayResultInfo()
+    {
+        var routedResponse = await client.GetAsync("/hello");
+        routedResponse.EnsureSuccessStatusCode();
+
+        var response = await client.PostAsync("/_semanticstub/runtime/requests/0/replay", content: null);
+        response.EnsureSuccessStatusCode();
+
+        var payload = await response.Content.ReadFromJsonAsync<ReplayResultInfo>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.NotNull(payload);
+        Assert.NotNull(payload!.Request);
+        Assert.NotNull(payload.Explanation);
+    }
+
+    [Fact]
+    public async Task ReplayRequest_AfterRealRequest_ReplayMatchesOriginalRequest()
+    {
+        var routedResponse = await client.GetAsync("/users?role=admin");
+        routedResponse.EnsureSuccessStatusCode();
+
+        var response = await client.PostAsync("/_semanticstub/runtime/requests/0/replay", content: null);
+        response.EnsureSuccessStatusCode();
+
+        var payload = await response.Content.ReadFromJsonAsync<ReplayResultInfo>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.NotNull(payload);
+        Assert.Equal("GET", payload!.Request.Method);
+        Assert.Equal("/users", payload.Request.Path);
+        Assert.NotNull(payload.Request.Query);
+        Assert.Contains("role", payload.Request.Query!.Keys);
+        Assert.Equal("Matched", payload.Explanation.Result.MatchResult);
+        Assert.Equal("listUsers", payload.Explanation.Result.RouteId);
+        Assert.True(payload.Explanation.PathMatched);
+        Assert.True(payload.Explanation.MethodMatched);
+    }
+
+    [Fact]
+    public async Task ReplayRequest_ExplanationIncludesCandidates()
+    {
+        var routedResponse = await client.GetAsync("/users?role=admin");
+        routedResponse.EnsureSuccessStatusCode();
+
+        var response = await client.PostAsync("/_semanticstub/runtime/requests/0/replay", content: null);
+        response.EnsureSuccessStatusCode();
+
+        var payload = await response.Content.ReadFromJsonAsync<ReplayResultInfo>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.NotNull(payload);
+        Assert.NotEmpty(payload!.Explanation.DeterministicCandidates);
+    }
+
     private static async Task AssertNotFoundProblemDetails(HttpResponseMessage response, string expectedTitle)
     {
         Assert.Equal("application/problem+json", response.Content.Headers.ContentType?.MediaType);


### PR DESCRIPTION
## Summary

- Add `POST /_semanticstub/runtime/requests/{index}/replay` endpoint that replays a recorded real request through the stub matching pipeline as a dry run
- Add `ReplayResultInfo` DTO containing `Request` (`ReplayReadyRequestInfo`) and `Explanation` (`MatchExplanationInfo`)
- Reuse the existing `ReplayRequestExporter` and `ExplainMatchAsync` pipeline; no new abstractions introduced
- Replay always includes candidates (`IncludeCandidates = true`) for full observability

## Behaviour

- `POST /_semanticstub/runtime/requests/{index}/replay` accepts a zero-based index into the recent request history (0 = most recent)
- Returns 404 when index is negative or out of range
- Replay is a **dry run**: evaluates matching without executing a response or advancing scenario state
- The result is inspectable via `ReplayResultInfo.Request` (the normalised replay shape) and `ReplayResultInfo.Explanation` (full match explanation)
- Bodies longer than 4096 characters and sensitive headers reflect what was captured at recording time (pre-existing recording constraints)

## Test plan

- [ ] `ReplayRequest_WhenNoRequestsRecorded_ReturnsNotFound`
- [ ] `ReplayRequest_WhenIndexIsNegative_ReturnsNotFound`
- [ ] `ReplayRequest_WhenIndexOutOfRange_ReturnsNotFound`
- [ ] `ReplayRequest_AfterRealRequest_ReturnsOk`
- [ ] `ReplayRequest_AfterRealRequest_ResponseDeserializesToReplayResultInfo`
- [ ] `ReplayRequest_AfterRealRequest_ReplayMatchesOriginalRequest`
- [ ] `ReplayRequest_ExplanationIncludesCandidates`
- [ ] All 513 tests pass (`dotnet test`)

Closes #294

https://claude.ai/code/session_01SsRSxfGX3KSzksvbATzpRJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsRSxfGX3KSzksvbATzpRJ)_