### PR TITLE
feat: group recorded requests into stub suggestions

### DIFF
--- a/SemanticStub.http
+++ b/SemanticStub.http
@@ -36,6 +36,10 @@ Accept: application/json
 GET {{host}}/_semanticstub/runtime/requests?limit=5
 Accept: application/json
 
+### Runtime inspection grouped draft YAML suggestions from recent requests
+GET {{host}}/_semanticstub/runtime/requests/export/yaml?limit=5
+Accept: application/yaml
+
 ### Runtime inspection test-match
 POST {{host}}/_semanticstub/runtime/test-match
 Content-Type: application/json

--- a/src/SemanticStub.Api/Controllers/StubInspectionController.cs
+++ b/src/SemanticStub.Api/Controllers/StubInspectionController.cs
@@ -62,6 +62,20 @@ public sealed class StubInspectionController : ControllerBase
     [HttpGet("requests")]
     public IActionResult GetRecentRequests([FromQuery] int limit = 20) => Ok(_inspectionService.GetRecentRequests(limit));
 
+    /// <summary>Exports recent real requests as grouped draft YAML stub suggestions.</summary>
+    [HttpGet("requests/export/yaml")]
+    public IActionResult ExportRequestsAsYaml([FromQuery] int limit = 20)
+    {
+        var requests = _inspectionService.GetRecentRequests(limit);
+        if (requests.Count == 0)
+        {
+            return NotFoundProblem("Request not found", "No recorded requests are available for YAML suggestions.");
+        }
+
+        var yaml = DraftYamlExporter.Export(requests.Select(ReplayRequestExporter.Export));
+        return Content(yaml, "application/yaml");
+    }
+
     /// <summary>Exports a recorded real request as a runnable curl command.</summary>
     /// <param name="index">Zero-based index into the recent request history (0 = most recent).</param>
     [HttpGet("requests/{index:int}/export/curl")]

--- a/src/SemanticStub.Api/Inspection/DraftYamlExporter.cs
+++ b/src/SemanticStub.Api/Inspection/DraftYamlExporter.cs
@@ -5,7 +5,7 @@ using YamlDotNet.Serialization.NamingConventions;
 namespace SemanticStub.Api.Inspection;
 
 /// <summary>
-/// Generates a reviewable draft YAML stub definition from a single recorded request.
+/// Generates reviewable draft YAML stub definitions from recorded requests.
 /// The output follows OpenAPI 3.1 conventions with x-* extensions used by SemanticStub.
 /// </summary>
 public static class DraftYamlExporter
@@ -39,77 +39,99 @@ public static class DraftYamlExporter
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        var matchHeaders = BuildMatchHeaders(request.Headers);
-        var (matchBody, hasSkippedBodyFields) = BuildMatchBody(request.Body, request.Headers);
-        var hasXMatch = request.Query is { Count: > 0 } || matchHeaders.Count > 0
-            || matchBody is not null || hasSkippedBodyFields;
+        return Export([request]);
+    }
+
+    /// <summary>
+    /// Exports recorded requests as grouped draft YAML stub suggestions.
+    /// </summary>
+    /// <param name="requests">The recorded requests to use as a basis for the suggestions.</param>
+    /// <returns>A YAML string containing reviewable OpenAPI 3.1 stub suggestions.</returns>
+    public static string Export(IEnumerable<ReplayReadyRequestInfo> requests)
+    {
+        ArgumentNullException.ThrowIfNull(requests);
+
+        var requestList = requests.ToList();
+        if (requestList.Any(request => request is null))
+        {
+            throw new ArgumentException("Requests must not contain null entries.", nameof(requests));
+        }
+
+        var paths = new Dictionary<string, object>(StringComparer.Ordinal);
+        var hasSkippedBodyFields = false;
+
+        foreach (var pathGroup in requestList.GroupBy(r => r.Path, StringComparer.Ordinal))
+        {
+            var pathItem = new Dictionary<string, object>(StringComparer.Ordinal);
+
+            foreach (var operationGroup in pathGroup.GroupBy(r => r.Method, StringComparer.OrdinalIgnoreCase))
+            {
+                var operationRequests = operationGroup.ToList();
+                var operation = BuildOperation(operationRequests, out var operationHasSkippedBodyFields);
+                pathItem[operationGroup.Key.ToLowerInvariant()] = operation;
+                hasSkippedBodyFields |= operationHasSkippedBodyFields;
+            }
+
+            paths[pathGroup.Key] = pathItem;
+        }
+
+        var document = new Dictionary<string, object>
+        {
+            ["openapi"] = "3.1.0",
+            ["info"] = new Dictionary<string, object>
+            {
+                ["title"] = "Draft Stub",
+                ["version"] = "0.0.0",
+            },
+            ["paths"] = paths,
+        };
+
+        var yaml = _serializer.Serialize(document);
+
+        if (hasSkippedBodyFields)
+        {
+            yaml += "# TODO: body contained nested fields that were skipped — complete x-match.body manually\n";
+        }
+
+        return yaml;
+    }
+
+    private static Dictionary<string, object> BuildOperation(
+        IReadOnlyList<ReplayReadyRequestInfo> requests,
+        out bool hasSkippedBodyFields)
+    {
+        var firstRequest = requests[0];
 
         var operation = new Dictionary<string, object>
         {
-            ["operationId"] = BuildOperationId(request.Method, request.Path),
+            ["operationId"] = BuildOperationId(firstRequest.Method, firstRequest.Path),
         };
 
-        if (hasXMatch)
+        var matchEntries = new List<object>();
+        hasSkippedBodyFields = false;
+
+        foreach (var request in requests)
         {
-            var matchEntry = new Dictionary<string, object>();
+            var matchEntry = BuildMatchEntry(request, out var requestHasSkippedBodyFields);
+            hasSkippedBodyFields |= requestHasSkippedBodyFields;
 
-            if (request.Query is { Count: > 0 })
+            if (matchEntry is not null)
             {
-                var queryMap = new Dictionary<string, object>();
-                foreach (var (key, values) in request.Query.OrderBy(q => q.Key, StringComparer.Ordinal))
-                {
-                    queryMap[key] = values.Length == 1 ? (object)values[0] : values;
-                }
-                matchEntry["query"] = queryMap;
+                matchEntries.Add(matchEntry);
             }
-
-            if (matchHeaders.Count > 0)
-            {
-                var headerMap = new Dictionary<string, object>();
-                foreach (var (key, value) in matchHeaders.OrderBy(h => h.Key, StringComparer.OrdinalIgnoreCase))
-                {
-                    headerMap[key] = value;
-                }
-                matchEntry["headers"] = headerMap;
-            }
-
-            if (matchBody is not null)
-            {
-                var bodyMap = new Dictionary<string, object?>();
-                foreach (var (key, value) in matchBody.OrderBy(p => p.Key, StringComparer.Ordinal))
-                {
-                    bodyMap[key] = value;
-                }
-                matchEntry["body"] = bodyMap;
-            }
-
-            matchEntry["response"] = new Dictionary<string, object>
-            {
-                ["statusCode"] = 200,
-                ["content"] = new Dictionary<string, object>
-                {
-                    ["application/json"] = new Dictionary<string, object>
-                    {
-                        ["example"] = new Dictionary<string, object>(),
-                    },
-                },
-            };
-
-            operation["x-match"] = new List<object> { matchEntry };
         }
 
-        var contentType = DetectContentType(request.Headers);
-        if (!string.IsNullOrEmpty(request.Body) && contentType is not null)
+        if (matchEntries.Count > 0)
+        {
+            operation["x-match"] = matchEntries;
+        }
+
+        var requestBodyContent = BuildRequestBodyContent(requests);
+        if (requestBodyContent.Count > 0)
         {
             operation["requestBody"] = new Dictionary<string, object>
             {
-                ["content"] = new Dictionary<string, object>
-                {
-                    [contentType] = new Dictionary<string, object>
-                    {
-                        ["example"] = new Dictionary<string, object>(),
-                    },
-                },
+                ["content"] = requestBodyContent,
             };
         }
 
@@ -128,31 +150,89 @@ public static class DraftYamlExporter
             },
         };
 
-        var document = new Dictionary<string, object>
+        return operation;
+    }
+
+    private static Dictionary<string, object>? BuildMatchEntry(
+        ReplayReadyRequestInfo request,
+        out bool hasSkippedBodyFields)
+    {
+        var matchHeaders = BuildMatchHeaders(request.Headers);
+        var (matchBody, skippedBodyFields) = BuildMatchBody(request.Body, request.Headers);
+        hasSkippedBodyFields = skippedBodyFields;
+
+        if (request.Query is not { Count: > 0 } && matchHeaders.Count == 0
+            && matchBody is null && !hasSkippedBodyFields)
         {
-            ["openapi"] = "3.1.0",
-            ["info"] = new Dictionary<string, object>
+            return null;
+        }
+
+        var matchEntry = new Dictionary<string, object>();
+
+        if (request.Query is { Count: > 0 })
+        {
+            var queryMap = new Dictionary<string, object>();
+            foreach (var (key, values) in request.Query.OrderBy(q => q.Key, StringComparer.Ordinal))
             {
-                ["title"] = "Draft Stub",
-                ["version"] = "0.0.0",
-            },
-            ["paths"] = new Dictionary<string, object>
+                queryMap[key] = values.Length == 1 ? (object)values[0] : values;
+            }
+            matchEntry["query"] = queryMap;
+        }
+
+        if (matchHeaders.Count > 0)
+        {
+            var headerMap = new Dictionary<string, object>();
+            foreach (var (key, value) in matchHeaders.OrderBy(h => h.Key, StringComparer.OrdinalIgnoreCase))
             {
-                [request.Path] = new Dictionary<string, object>
+                headerMap[key] = value;
+            }
+            matchEntry["headers"] = headerMap;
+        }
+
+        if (matchBody is not null)
+        {
+            var bodyMap = new Dictionary<string, object?>();
+            foreach (var (key, value) in matchBody.OrderBy(p => p.Key, StringComparer.Ordinal))
+            {
+                bodyMap[key] = value;
+            }
+            matchEntry["body"] = bodyMap;
+        }
+
+        matchEntry["response"] = new Dictionary<string, object>
+        {
+            ["statusCode"] = 200,
+            ["content"] = new Dictionary<string, object>
+            {
+                ["application/json"] = new Dictionary<string, object>
                 {
-                    [request.Method.ToLowerInvariant()] = operation,
+                    ["example"] = new Dictionary<string, object>(),
                 },
             },
         };
 
-        var yaml = _serializer.Serialize(document);
+        return matchEntry;
+    }
 
-        if (hasSkippedBodyFields)
+    private static Dictionary<string, object> BuildRequestBodyContent(IEnumerable<ReplayReadyRequestInfo> requests)
+    {
+        var content = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var request in requests)
         {
-            yaml += "# TODO: body contained nested fields that were skipped — complete x-match.body manually\n";
+            var contentType = DetectContentType(request.Headers);
+            if (string.IsNullOrEmpty(request.Body) || contentType is null || content.ContainsKey(contentType))
+            {
+                continue;
+            }
+
+            content[contentType] = new Dictionary<string, object>
+            {
+                ["example"] = new Dictionary<string, object>(),
+            };
         }
 
-        return yaml;
+        return content;
     }
 
     private static string BuildOperationId(string method, string path)

--- a/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/StubInspectionEndpointTests.cs
@@ -554,6 +554,37 @@ public sealed class StubInspectionEndpointTests : IClassFixture<WebApplicationFa
     }
 
     [Fact]
+    public async Task ExportRequestsAsYaml_ReturnsNotFound_WhenNoRequestsRecorded()
+    {
+        await using var factory = new WebApplicationFactory<Program>();
+        using var freshClient = factory.CreateClient();
+
+        var response = await freshClient.GetAsync("/_semanticstub/runtime/requests/export/yaml");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ExportRequestsAsYaml_GroupsRecentRequestsIntoYamlSuggestions()
+    {
+        var adminResponse = await client.GetAsync("/users?role=admin");
+        adminResponse.EnsureSuccessStatusCode();
+        var guestResponse = await client.GetAsync("/users?role=guest");
+        guestResponse.EnsureSuccessStatusCode();
+
+        var response = await client.GetAsync("/_semanticstub/runtime/requests/export/yaml?limit=2");
+        response.EnsureSuccessStatusCode();
+
+        Assert.Equal("application/yaml", response.Content.Headers.ContentType?.MediaType);
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.Contains("openapi: 3.1.0", content);
+        Assert.Contains("  /users:", content);
+        Assert.Contains("operationId: getUsers", content);
+        Assert.Contains("role: admin", content);
+        Assert.Contains("role: guest", content);
+    }
+
+    [Fact]
     public async Task ExportRequestAsCurl_ReturnsNotFound_WhenIndexOutOfRange()
     {
         var routedResponse = await client.GetAsync("/hello");

--- a/tests/SemanticStub.Api.Tests/Unit/Inspection/DraftYamlExporterTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Inspection/DraftYamlExporterTests.cs
@@ -458,8 +458,90 @@ public sealed class DraftYamlExporterTests
     }
 
     [Fact]
+    public void Export_MultipleRequestsWithSameMethodAndPath_GroupsAsOneOperation()
+    {
+        var requests = new[]
+        {
+            MakeRequest("GET", "/users", query: new Dictionary<string, string[]>
+            {
+                ["role"] = ["admin"],
+            }),
+            MakeRequest("GET", "/users", query: new Dictionary<string, string[]>
+            {
+                ["role"] = ["guest"],
+            }),
+        };
+
+        var result = DraftYamlExporter.Export(requests);
+
+        Assert.Equal(1, CountOccurrences(result, "    get:"));
+        Assert.Equal(2, CountOccurrences(result, "      - query:"));
+        Assert.Contains("role: admin", result);
+        Assert.Contains("role: guest", result);
+    }
+
+    [Fact]
+    public void Export_MultipleRequestsWithDifferentPaths_KeepsSeparateRoutes()
+    {
+        var requests = new[]
+        {
+            MakeRequest("GET", "/users"),
+            MakeRequest("GET", "/orders"),
+        };
+
+        var result = DraftYamlExporter.Export(requests);
+
+        Assert.Contains("  /users:", result);
+        Assert.Contains("  /orders:", result);
+        Assert.Contains("operationId: getUsers", result);
+        Assert.Contains("operationId: getOrders", result);
+    }
+
+    [Fact]
+    public void Export_MultipleRequestsWithDifferentMethodsOnSamePath_KeepsSeparateOperations()
+    {
+        var requests = new[]
+        {
+            MakeRequest("GET", "/users"),
+            MakeRequest("POST", "/users",
+                headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Content-Type"] = "application/json",
+                },
+                body: """{"name":"demo"}"""),
+        };
+
+        var result = DraftYamlExporter.Export(requests);
+
+        Assert.Contains("    get:", result);
+        Assert.Contains("    post:", result);
+        Assert.Contains("operationId: getUsers", result);
+        Assert.Contains("operationId: postUsers", result);
+    }
+
+    [Fact]
+    public void Export_MultipleRequests_ThrowsWhenRequestsIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => DraftYamlExporter.Export((IEnumerable<ReplayReadyRequestInfo>)null!));
+    }
+
+    [Fact]
     public void Export_ThrowsWhenRequestIsNull()
     {
-        Assert.Throws<ArgumentNullException>(() => DraftYamlExporter.Export(null!));
+        Assert.Throws<ArgumentNullException>(() => DraftYamlExporter.Export((ReplayReadyRequestInfo)null!));
+    }
+
+    private static int CountOccurrences(string value, string search)
+    {
+        var count = 0;
+        var index = 0;
+
+        while ((index = value.IndexOf(search, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += search.Length;
+        }
+
+        return count;
     }
 }


### PR DESCRIPTION
## Summary
- Add grouped YAML suggestion export for recent recorded requests
- Group requests conservatively by method and path into reviewable x-match candidates
- Cover exporter grouping and runtime inspection endpoint behavior

Closes #297

## Tests
- dotnet test tests/SemanticStub.Api.Tests/SemanticStub.Api.Tests.csproj --no-restore
- dotnet test SemanticStub.sln --no-restore