### PR TITLE
feat: suggest match improvements for ambiguous definitions (#298)

### DIFF
--- a/src/SemanticStub.Api/Controllers/StubInspectionController.cs
+++ b/src/SemanticStub.Api/Controllers/StubInspectionController.cs
@@ -186,6 +186,61 @@ public sealed class StubInspectionController : ControllerBase
         });
     }
 
+    /// <summary>Analyzes a recorded real request and returns match improvement suggestions.</summary>
+    /// <param name="index">Zero-based index into the recent request history (0 = most recent).</param>
+    [HttpGet("requests/{index:int}/suggest-improvements")]
+    public async Task<IActionResult> SuggestImprovementsForRequest(int index)
+    {
+        if (index < 0)
+        {
+            return NotFoundProblem("Request not found", $"No recorded request at index {index}.");
+        }
+
+        var requests = _inspectionService.GetRecentRequests(index + 1);
+
+        if (index >= requests.Count)
+        {
+            return NotFoundProblem("Request not found", $"No recorded request at index {index}.");
+        }
+
+        var replayRequest = ReplayRequestExporter.Export(requests[index]);
+
+        var matchRequest = new MatchRequestInfo
+        {
+            Method = replayRequest.Method,
+            Path = replayRequest.Path,
+            Query = replayRequest.Query is { Count: > 0 }
+                ? new Dictionary<string, string[]>(replayRequest.Query, StringComparer.Ordinal)
+                : new Dictionary<string, string[]>(),
+            Headers = replayRequest.Headers is { Count: > 0 }
+                ? new Dictionary<string, string>(replayRequest.Headers, StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            Body = replayRequest.Body,
+            IncludeCandidates = true,
+        };
+
+        var explanation = await _inspectionService.ExplainMatchAsync(matchRequest, HttpContext.RequestAborted);
+        return Ok(MatchImprovementAnalyzer.Analyze(explanation));
+    }
+
+    /// <summary>Analyzes a virtual request and returns match improvement suggestions.</summary>
+    [HttpPost("suggest-improvements")]
+    public async Task<IActionResult> SuggestImprovements([FromBody] MatchRequestInfo request)
+    {
+        var explainRequest = new MatchRequestInfo
+        {
+            Method = request.Method,
+            Path = request.Path,
+            Query = request.Query,
+            Headers = request.Headers,
+            Body = request.Body,
+            IncludeCandidates = true,
+            IncludeSemanticCandidates = request.IncludeSemanticCandidates,
+        };
+        var explanation = await _inspectionService.ExplainMatchAsync(explainRequest, HttpContext.RequestAborted);
+        return Ok(MatchImprovementAnalyzer.Analyze(explanation));
+    }
+
     /// <summary>Simulates how the runtime would match a virtual request without executing a response.</summary>
     [HttpPost("test-match")]
     public async Task<IActionResult> TestMatch([FromBody] MatchRequestInfo request)

--- a/src/SemanticStub.Api/Inspection/MatchImprovementAnalyzer.cs
+++ b/src/SemanticStub.Api/Inspection/MatchImprovementAnalyzer.cs
@@ -1,0 +1,107 @@
+namespace SemanticStub.Api.Inspection;
+
+/// <summary>
+/// Analyzes a match explanation and produces actionable suggestions for improving stub definitions.
+/// </summary>
+public static class MatchImprovementAnalyzer
+{
+    /// <summary>
+    /// Analyzes the supplied explanation and returns a report containing improvement suggestions.
+    /// </summary>
+    /// <param name="explanation">The match explanation to analyze.</param>
+    /// <returns>
+    /// A <see cref="MatchImprovementReportInfo"/> whose <c>Suggestions</c> list is empty
+    /// when no issues are detected.
+    /// </returns>
+    public static MatchImprovementReportInfo Analyze(MatchExplanationInfo explanation)
+    {
+        ArgumentNullException.ThrowIfNull(explanation);
+
+        var suggestions = new List<MatchImprovementSuggestionInfo>();
+
+        if (!explanation.PathMatched)
+        {
+            suggestions.Add(new MatchImprovementSuggestionInfo
+            {
+                Kind = "NoMatchFound",
+                Reason = "No stub is defined for this request path.",
+                YamlHint = "Add a new path entry under 'paths:' in your stub YAML for this endpoint.",
+            });
+            return new MatchImprovementReportInfo { Explanation = explanation, Suggestions = suggestions };
+        }
+
+        if (!explanation.MethodMatched)
+        {
+            suggestions.Add(new MatchImprovementSuggestionInfo
+            {
+                Kind = "NoMatchFound",
+                Reason = "The request path is defined but the HTTP method is not.",
+                YamlHint = "Add the missing HTTP method under the path entry in your stub YAML.",
+            });
+            return new MatchImprovementReportInfo { Explanation = explanation, Suggestions = suggestions };
+        }
+
+        if (IsSemanticMatch(explanation))
+        {
+            suggestions.Add(new MatchImprovementSuggestionInfo
+            {
+                Kind = "SemanticFallbackUsed",
+                Reason = "The request was matched using semantic (vector) similarity because no deterministic x-match condition matched.",
+                YamlHint = "Add explicit 'x-match' conditions (query, headers, or body fields) to make this match deterministic and predictable.",
+            });
+        }
+
+        if (IsNoConditionsRoute(explanation))
+        {
+            suggestions.Add(new MatchImprovementSuggestionInfo
+            {
+                Kind = "NoConditionsOnRoute",
+                Reason = "No 'x-match' conditions are defined for this route — any request to this path and method will match.",
+                YamlHint = "Add 'x-match' entries with query, header, or body conditions to distinguish different request scenarios.",
+            });
+        }
+
+        foreach (var candidate in explanation.DeterministicCandidates)
+        {
+            if (candidate.Matched)
+            {
+                continue;
+            }
+
+            var failedMatchDimensions = candidate.MismatchReasons
+                .Select(m => m.Dimension)
+                .Where(d => d is not "response" and not "scenario")
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+
+            if (failedMatchDimensions.Count != 1)
+            {
+                continue;
+            }
+
+            var dimension = failedMatchDimensions[0];
+            var firstMismatch = candidate.MismatchReasons.FirstOrDefault(m => m.Dimension == dimension);
+
+            var keyDetail = firstMismatch?.Key is { Length: > 0 } key ? $" (key: '{key}')" : string.Empty;
+
+            suggestions.Add(new MatchImprovementSuggestionInfo
+            {
+                Kind = "NearMissCandidate",
+                CandidateIndex = candidate.CandidateIndex,
+                Dimension = dimension,
+                Reason = $"Candidate {candidate.CandidateIndex} nearly matched — only '{dimension}' did not pass{keyDetail}.",
+                YamlHint = $"Review the '{dimension}' condition in x-match[{candidate.CandidateIndex}]. " +
+                           "Consider whether the condition is too strict or whether the incoming request needs adjustment.",
+            });
+        }
+
+        return new MatchImprovementReportInfo { Explanation = explanation, Suggestions = suggestions };
+    }
+
+    private static bool IsSemanticMatch(MatchExplanationInfo explanation) =>
+        string.Equals(explanation.Result.MatchMode, "semantic", StringComparison.Ordinal);
+
+    private static bool IsNoConditionsRoute(MatchExplanationInfo explanation) =>
+        explanation.DeterministicCandidates.Count == 0 &&
+        string.Equals(explanation.Result.MatchMode, "fallback", StringComparison.Ordinal);
+}

--- a/src/SemanticStub.Api/Inspection/MatchImprovementAnalyzer.cs
+++ b/src/SemanticStub.Api/Inspection/MatchImprovementAnalyzer.cs
@@ -105,6 +105,7 @@ public static class MatchImprovementAnalyzer
     }
 
     private static bool IsSemanticMatch(MatchExplanationInfo explanation) =>
+        explanation.Result.Matched &&
         string.Equals(explanation.Result.MatchMode, "semantic", StringComparison.Ordinal);
 
     private static bool IsNoConditionsRoute(MatchExplanationInfo explanation) =>

--- a/src/SemanticStub.Api/Inspection/MatchImprovementAnalyzer.cs
+++ b/src/SemanticStub.Api/Inspection/MatchImprovementAnalyzer.cs
@@ -70,7 +70,7 @@ public static class MatchImprovementAnalyzer
 
             var failedMatchDimensions = candidate.MismatchReasons
                 .Select(m => m.Dimension)
-                .Where(d => d is not "response" and not "scenario")
+                .Where(d => d is not "response")
                 .Distinct(StringComparer.Ordinal)
                 .ToList();
 
@@ -80,6 +80,12 @@ public static class MatchImprovementAnalyzer
             }
 
             var dimension = failedMatchDimensions[0];
+
+            // scenario failures are not correctable via x-match conditions
+            if (dimension is "scenario")
+            {
+                continue;
+            }
             var firstMismatch = candidate.MismatchReasons.FirstOrDefault(m => m.Dimension == dimension);
 
             var keyDetail = firstMismatch?.Key is { Length: > 0 } key ? $" (key: '{key}')" : string.Empty;

--- a/src/SemanticStub.Api/Inspection/MatchImprovementReportInfo.cs
+++ b/src/SemanticStub.Api/Inspection/MatchImprovementReportInfo.cs
@@ -1,0 +1,17 @@
+namespace SemanticStub.Api.Inspection;
+
+/// <summary>
+/// Wraps the match improvement suggestions produced for a single request evaluation.
+/// </summary>
+public sealed class MatchImprovementReportInfo
+{
+    /// <summary>
+    /// Gets the explanation that the suggestions were derived from.
+    /// </summary>
+    public required MatchExplanationInfo Explanation { get; init; }
+
+    /// <summary>
+    /// Gets the ordered list of improvement suggestions. Empty when no issues were detected.
+    /// </summary>
+    public IReadOnlyList<MatchImprovementSuggestionInfo> Suggestions { get; init; } = [];
+}

--- a/src/SemanticStub.Api/Inspection/MatchImprovementSuggestionInfo.cs
+++ b/src/SemanticStub.Api/Inspection/MatchImprovementSuggestionInfo.cs
@@ -1,0 +1,35 @@
+namespace SemanticStub.Api.Inspection;
+
+/// <summary>
+/// Describes one actionable suggestion for improving an existing stub definition.
+/// </summary>
+public sealed class MatchImprovementSuggestionInfo
+{
+    /// <summary>
+    /// Gets the suggestion kind. One of <c>SemanticFallbackUsed</c>, <c>NoConditionsOnRoute</c>,
+    /// <c>NearMissCandidate</c>, or <c>NoMatchFound</c>.
+    /// </summary>
+    public string Kind { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets a human-readable description of the detected issue.
+    /// </summary>
+    public string Reason { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets a YAML-oriented hint describing what to add or change in the stub definition.
+    /// </summary>
+    public string YamlHint { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the candidate index within the operation's <c>x-match</c> list when the suggestion
+    /// is tied to a specific candidate. <see langword="null"/> for route-level suggestions.
+    /// </summary>
+    public int? CandidateIndex { get; init; }
+
+    /// <summary>
+    /// Gets the matching dimension that the suggestion targets, such as <c>query</c>,
+    /// <c>header</c>, or <c>body</c>. <see langword="null"/> when not dimension-specific.
+    /// </summary>
+    public string? Dimension { get; init; }
+}

--- a/tests/SemanticStub.Api.Tests/Unit/Inspection/MatchImprovementAnalyzerTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Inspection/MatchImprovementAnalyzerTests.cs
@@ -96,6 +96,16 @@ public sealed class MatchImprovementAnalyzerTests
     }
 
     [Fact]
+    public void Analyze_WhenSemanticModeButResponseNotConfigured_DoesNotSuggestSemanticFallback()
+    {
+        var explanation = MakeExplanation(matchMode: "semantic", matched: false);
+
+        var report = MatchImprovementAnalyzer.Analyze(explanation);
+
+        Assert.DoesNotContain(report.Suggestions, s => s.Kind == "SemanticFallbackUsed");
+    }
+
+    [Fact]
     public void Analyze_WhenNoConditionsOnRoute_SuggestsAddingConditions()
     {
         var explanation = MakeExplanation(matchMode: "fallback", deterministicCandidates: []);

--- a/tests/SemanticStub.Api.Tests/Unit/Inspection/MatchImprovementAnalyzerTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Inspection/MatchImprovementAnalyzerTests.cs
@@ -1,0 +1,200 @@
+using SemanticStub.Api.Inspection;
+using Xunit;
+
+namespace SemanticStub.Api.Tests.Unit.Inspection;
+
+public sealed class MatchImprovementAnalyzerTests
+{
+    private static MatchExplanationInfo MakeExplanation(
+        bool pathMatched = true,
+        bool methodMatched = true,
+        string? matchMode = "exact",
+        bool matched = true,
+        IReadOnlyList<MatchCandidateInfo>? deterministicCandidates = null)
+    {
+        return new MatchExplanationInfo
+        {
+            PathMatched = pathMatched,
+            MethodMatched = methodMatched,
+            DeterministicCandidates = deterministicCandidates ?? [],
+            SelectionReason = string.Empty,
+            Result = new MatchSimulationInfo
+            {
+                Matched = matched,
+                MatchResult = matched ? "Matched" : "NotMatched",
+                MatchMode = matchMode,
+            },
+        };
+    }
+
+    private static MatchCandidateInfo MakeCandidate(
+        int index = 0,
+        bool matched = true,
+        IReadOnlyList<MatchDimensionMismatchInfo>? mismatches = null)
+    {
+        return new MatchCandidateInfo
+        {
+            CandidateIndex = index,
+            Matched = matched,
+            QueryMatched = true,
+            HeaderMatched = true,
+            BodyMatched = true,
+            ScenarioMatched = true,
+            ResponseConfigured = true,
+            MismatchReasons = mismatches ?? [],
+        };
+    }
+
+    private static MatchDimensionMismatchInfo MakeMismatch(string dimension, string key = "field") =>
+        new() { Dimension = dimension, Key = key, Expected = "expected", Actual = "actual", Kind = "unequal" };
+
+    [Fact]
+    public void Analyze_WhenCleanDeterministicMatch_ReturnsNoSuggestions()
+    {
+        var explanation = MakeExplanation(
+            matchMode: "exact",
+            deterministicCandidates: [MakeCandidate(matched: true)]);
+
+        var report = MatchImprovementAnalyzer.Analyze(explanation);
+
+        Assert.Empty(report.Suggestions);
+    }
+
+    [Fact]
+    public void Analyze_WhenPathNotFound_ReturnsSingleNoMatchFoundSuggestion()
+    {
+        var explanation = MakeExplanation(pathMatched: false, methodMatched: false, matchMode: null, matched: false);
+
+        var report = MatchImprovementAnalyzer.Analyze(explanation);
+
+        Assert.Single(report.Suggestions);
+        Assert.Equal("NoMatchFound", report.Suggestions[0].Kind);
+        Assert.Contains("path", report.Suggestions[0].Reason);
+    }
+
+    [Fact]
+    public void Analyze_WhenMethodNotFound_ReturnsSingleNoMatchFoundSuggestion()
+    {
+        var explanation = MakeExplanation(pathMatched: true, methodMatched: false, matchMode: null, matched: false);
+
+        var report = MatchImprovementAnalyzer.Analyze(explanation);
+
+        Assert.Single(report.Suggestions);
+        Assert.Equal("NoMatchFound", report.Suggestions[0].Kind);
+        Assert.Contains("method", report.Suggestions[0].Reason);
+    }
+
+    [Fact]
+    public void Analyze_WhenSemanticFallback_SuggestsAddingExplicitConditions()
+    {
+        var explanation = MakeExplanation(matchMode: "semantic");
+
+        var report = MatchImprovementAnalyzer.Analyze(explanation);
+
+        var suggestion = Assert.Single(report.Suggestions, s => s.Kind == "SemanticFallbackUsed");
+        Assert.Contains("x-match", suggestion.YamlHint);
+    }
+
+    [Fact]
+    public void Analyze_WhenNoConditionsOnRoute_SuggestsAddingConditions()
+    {
+        var explanation = MakeExplanation(matchMode: "fallback", deterministicCandidates: []);
+
+        var report = MatchImprovementAnalyzer.Analyze(explanation);
+
+        var suggestion = Assert.Single(report.Suggestions, s => s.Kind == "NoConditionsOnRoute");
+        Assert.Contains("x-match", suggestion.YamlHint);
+    }
+
+    [Fact]
+    public void Analyze_WhenNearMissCandidate_SuggestsConditionRefinement()
+    {
+        var candidate = MakeCandidate(
+            index: 1,
+            matched: false,
+            mismatches: [MakeMismatch("query", "status")]);
+
+        var explanation = MakeExplanation(
+            matchMode: null,
+            matched: false,
+            deterministicCandidates: [candidate]);
+
+        var report = MatchImprovementAnalyzer.Analyze(explanation);
+
+        var suggestion = Assert.Single(report.Suggestions, s => s.Kind == "NearMissCandidate");
+        Assert.Equal(1, suggestion.CandidateIndex);
+        Assert.Equal("query", suggestion.Dimension);
+        Assert.Contains("status", suggestion.Reason);
+        Assert.Contains("x-match[1]", suggestion.YamlHint);
+    }
+
+    [Fact]
+    public void Analyze_WhenCandidateMissesOnMultipleDimensions_DoesNotSuggestNearMiss()
+    {
+        var candidate = MakeCandidate(
+            index: 0,
+            matched: false,
+            mismatches:
+            [
+                MakeMismatch("query", "type"),
+                MakeMismatch("body", "id"),
+            ]);
+
+        var explanation = MakeExplanation(
+            matchMode: null,
+            matched: false,
+            deterministicCandidates: [candidate]);
+
+        var report = MatchImprovementAnalyzer.Analyze(explanation);
+
+        Assert.DoesNotContain(report.Suggestions, s => s.Kind == "NearMissCandidate");
+    }
+
+    [Fact]
+    public void Analyze_WhenCandidateMatchedSuccessfully_DoesNotSuggestNearMiss()
+    {
+        var candidate = MakeCandidate(index: 0, matched: true);
+
+        var explanation = MakeExplanation(
+            matchMode: "exact",
+            deterministicCandidates: [candidate]);
+
+        var report = MatchImprovementAnalyzer.Analyze(explanation);
+
+        Assert.DoesNotContain(report.Suggestions, s => s.Kind == "NearMissCandidate");
+    }
+
+    [Fact]
+    public void Analyze_WhenResponseDimensionOnlyMismatch_DoesNotSuggestNearMiss()
+    {
+        var candidate = MakeCandidate(
+            index: 0,
+            matched: false,
+            mismatches: [new MatchDimensionMismatchInfo { Dimension = "response", Kind = "notConfigured" }]);
+
+        var explanation = MakeExplanation(
+            matchMode: null,
+            matched: false,
+            deterministicCandidates: [candidate]);
+
+        var report = MatchImprovementAnalyzer.Analyze(explanation);
+
+        Assert.DoesNotContain(report.Suggestions, s => s.Kind == "NearMissCandidate");
+    }
+
+    [Fact]
+    public void Analyze_ReturnsExplanationInReport()
+    {
+        var explanation = MakeExplanation();
+
+        var report = MatchImprovementAnalyzer.Analyze(explanation);
+
+        Assert.Same(explanation, report.Explanation);
+    }
+
+    [Fact]
+    public void Analyze_ThrowsWhenExplanationIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => MatchImprovementAnalyzer.Analyze(null!));
+    }
+}

--- a/tests/SemanticStub.Api.Tests/Unit/Inspection/MatchImprovementAnalyzerTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Inspection/MatchImprovementAnalyzerTests.cs
@@ -165,6 +165,46 @@ public sealed class MatchImprovementAnalyzerTests
     }
 
     [Fact]
+    public void Analyze_WhenCandidateMissesOnScenarioAndOneDimension_DoesNotSuggestNearMiss()
+    {
+        var candidate = MakeCandidate(
+            index: 0,
+            matched: false,
+            mismatches:
+            [
+                MakeMismatch("scenario", "myScenario"),
+                MakeMismatch("query", "status"),
+            ]);
+
+        var explanation = MakeExplanation(
+            matchMode: null,
+            matched: false,
+            deterministicCandidates: [candidate]);
+
+        var report = MatchImprovementAnalyzer.Analyze(explanation);
+
+        Assert.DoesNotContain(report.Suggestions, s => s.Kind == "NearMissCandidate");
+    }
+
+    [Fact]
+    public void Analyze_WhenCandidateMissesOnScenarioOnly_DoesNotSuggestNearMiss()
+    {
+        var candidate = MakeCandidate(
+            index: 0,
+            matched: false,
+            mismatches: [MakeMismatch("scenario", "myScenario")]);
+
+        var explanation = MakeExplanation(
+            matchMode: null,
+            matched: false,
+            deterministicCandidates: [candidate]);
+
+        var report = MatchImprovementAnalyzer.Analyze(explanation);
+
+        Assert.DoesNotContain(report.Suggestions, s => s.Kind == "NearMissCandidate");
+    }
+
+    [Fact]
     public void Analyze_WhenResponseDimensionOnlyMismatch_DoesNotSuggestNearMiss()
     {
         var candidate = MakeCandidate(


### PR DESCRIPTION
## Summary

- Add `MatchImprovementAnalyzer` that analyzes a `MatchExplanationInfo` and returns actionable, YAML-oriented improvement suggestions
- Add `MatchImprovementSuggestionInfo` and `MatchImprovementReportInfo` models for the suggestion output
- Expose two new inspection endpoints on `StubInspectionController`:
  - `GET /_semanticstub/runtime/requests/{index}/suggest-improvements` — analyze a recorded request
  - `POST /_semanticstub/runtime/suggest-improvements` — analyze a virtual request

## Detected suggestion kinds

| Kind | Trigger | YAML hint |
|------|---------|-----------|
| `NoMatchFound` | Path or method not defined | Add the missing path/method to stub YAML |
| `SemanticFallbackUsed` | Match resolved via semantic vector similarity | Add explicit `x-match` conditions |
| `NoConditionsOnRoute` | No `x-match` defined; any request matches | Add `x-match` entries to distinguish scenarios |
| `NearMissCandidate` | A candidate failed on exactly one match dimension | Review the specific condition — too strict or too loose |

## Test plan

- [x] `dotnet test` passes (562 tests, 0 failures)
- [x] `dotnet format --verify-no-changes` passes
- [x] 11 new unit tests covering all suggestion kinds and edge cases
- [x] Read-only feature — no existing routing, YAML, or matching behavior changed

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)