### PR TITLE
feat: expose MCP tools for stub generation and refinement (#296)

### DIFF
--- a/mcp/README.ja.md
+++ b/mcp/README.ja.md
@@ -1,7 +1,7 @@
 # semantic-stub-mcp
 
 SemanticStub の Runtime Inspection API を MCP 経由で利用するための TypeScript 製サーバーです。
-Claude Desktop など tool 中心のクライアントで使いやすいように、runtime inspection / match simulation / scenario reset を tool として公開します。
+Claude Desktop など tool 中心のクライアントで使いやすいように、runtime inspection / match simulation / stub generation / match improvement suggestions / scenario reset を tool として公開します。
 
 英語版は [README.md](./README.md) を参照してください。
 
@@ -58,14 +58,18 @@ npm run build
 | `explain_match` | `POST /_semanticstub/runtime/explain` | マッチ詳細説明 |
 | `get_last_explain` | `GET /_semanticstub/runtime/explain/last` | 直近の explain 結果 |
 | `reset_scenario_state` | `POST /_semanticstub/runtime/scenarios/resets` / `POST /_semanticstub/runtime/scenarios/{name}/resets` | シナリオ状態のリセット |
+| `export_stubs_as_yaml` | `GET /_semanticstub/runtime/requests/export/yaml` / `GET /_semanticstub/runtime/requests/{index}/export/yaml` | 記録済みリクエストを YAML スタブドラフトとして出力 |
+| `suggest_improvements` | `GET /_semanticstub/runtime/requests/{index}/suggest-improvements` / `POST /_semanticstub/runtime/suggest-improvements` | あいまいな定義に対する YAML 改善候補を提示 |
 
 ## 入力メモ
 
-- `test_match` と `explain_match` の `body` は JSON object ではなく raw string です。
+- `test_match` / `explain_match` / `suggest_improvements` の `body` は JSON object ではなく raw string です。
 - JSON body を送りたい場合は、たとえば `"{\"message\":\"hello\"}"` のように文字列化して渡してください。
 - `includeCandidates` のデフォルトは `test_match` では `false`、`explain_match` では `true` です。
 - `includeSemanticCandidates` を指定すると、semantic matching 実行時の候補スコアを含められます。
 - `test_match` と `explain_match` の結果には、該当する場合に response id、status code、source（`responses` または `x-match`）、candidate index などの selected response 情報も含まれます。
+- `export_stubs_as_yaml` は YAML テキストをそのまま返します。出力はドラフトなので、`TODO` プレースホルダーを埋めてから利用してください。
+- `suggest_improvements` は `index`（記録済みリクエストを分析）または `method` + `path`（仮想リクエストを分析）のいずれかで呼び出します。`method`/`path` を使う場合は両方必須です。
 
 ## 制約
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,7 +1,7 @@
 # semantic-stub-mcp
 
 A TypeScript MCP server for SemanticStub's Runtime Inspection API.
-It exposes runtime inspection, match simulation, and scenario reset as tools so it works well with tool-centric clients such as Claude Desktop.
+It exposes runtime inspection, match simulation, stub generation, match improvement suggestions, and scenario reset as tools so it works well with tool-centric clients such as Claude Desktop.
 
 Japanese documentation is available in [README.ja.md](./README.ja.md).
 
@@ -59,14 +59,18 @@ Add this server to `claude_desktop_config.json`.
 | `explain_match` | `POST /_semanticstub/runtime/explain` | Detailed match explanation |
 | `get_last_explain` | `GET /_semanticstub/runtime/explain/last` | Latest real-request explanation |
 | `reset_scenario_state` | `POST /_semanticstub/runtime/scenarios/resets` / `POST /_semanticstub/runtime/scenarios/{name}/resets` | Reset scenario state |
+| `export_stubs_as_yaml` | `GET /_semanticstub/runtime/requests/export/yaml` / `GET /_semanticstub/runtime/requests/{index}/export/yaml` | Export recorded requests as draft YAML stub definitions |
+| `suggest_improvements` | `GET /_semanticstub/runtime/requests/{index}/suggest-improvements` / `POST /_semanticstub/runtime/suggest-improvements` | Suggest YAML improvements for ambiguous or low-quality stub matches |
 
 ## Input Notes
 
-- The `body` field for `test_match` and `explain_match` must be a raw string, not a JSON object.
+- The `body` field for `test_match`, `explain_match`, and `suggest_improvements` must be a raw string, not a JSON object.
 - If you want to send JSON content, stringify it first, for example `"{\"message\":\"hello\"}"`.
 - `test_match` defaults `includeCandidates` to `false`, while `explain_match` defaults it to `true`.
 - Set `includeSemanticCandidates` to include semantic candidate scores when semantic matching is attempted.
 - The result payload for `test_match` and `explain_match` includes selected response metadata such as response id, status code, source (`responses` or `x-match`), and candidate index when applicable.
+- `export_stubs_as_yaml` returns raw YAML text. The output is a reviewable draft — fill in the `TODO` placeholders before activating.
+- `suggest_improvements` accepts either an `index` (to analyze a recorded request) or `method` + `path` (to analyze a virtual request). When using `method`/`path`, both are required.
 
 ## Constraints
 

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -290,6 +290,112 @@ server.registerTool(
   }
 );
 
+server.registerTool(
+  "export_stubs_as_yaml",
+  {
+    description:
+      "Export recorded real requests as draft YAML stub definitions. " +
+      "If `index` is provided, exports that single recorded request as a YAML draft. " +
+      "Otherwise, exports the most recent `limit` requests grouped by path and method into a combined YAML document. " +
+      "The output is a reviewable OpenAPI 3.1 draft — copy it into your stub YAML and fill in the TODO placeholders before activating.",
+    inputSchema: {
+      index: z
+        .number()
+        .int()
+        .min(0)
+        .optional()
+        .describe(
+          "Zero-based index into the recent request history (0 = most recent). " +
+          "Omit to export all recent requests grouped into a single YAML document."
+        ),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .optional()
+        .default(20)
+        .describe("Number of recent requests to include when `index` is omitted (default: 20, max: 100)."),
+    },
+    annotations: {
+      readOnlyHint: true,
+    },
+  },
+  async ({ index, limit }) => {
+    const path = index !== undefined
+      ? `/requests/${index}/export/yaml`
+      : `/requests/export/yaml?limit=${limit}`;
+
+    const res = await callApi(path);
+
+    if (!res.ok) {
+      throw new Error(await formatApiError(res));
+    }
+
+    const yaml = await res.text();
+    return { content: [{ type: "text" as const, text: yaml }] };
+  }
+);
+
+server.registerTool(
+  "suggest_improvements",
+  {
+    description:
+      "Analyze a request against the active stub definitions and return actionable YAML improvement suggestions. " +
+      "Detects ambiguous or low-quality matches such as semantic fallback usage, missing x-match conditions, " +
+      "near-miss candidates, and undefined routes. " +
+      "If `index` is provided, the recorded real request at that index is analyzed. " +
+      "Otherwise, a virtual request is constructed from the supplied `method` and `path` fields.",
+    inputSchema: {
+      index: z
+        .number()
+        .int()
+        .min(0)
+        .optional()
+        .describe(
+          "Zero-based index into the recent request history (0 = most recent). " +
+          "When provided, analyzes that recorded request. Omit to analyze a virtual request instead."
+        ),
+      method: z
+        .string()
+        .optional()
+        .describe("HTTP method for the virtual request (required when `index` is omitted)."),
+      path: z
+        .string()
+        .optional()
+        .describe("Request path for the virtual request (required when `index` is omitted)."),
+      query: z
+        .record(z.array(z.string()))
+        .optional()
+        .describe("Query parameters for the virtual request."),
+      headers: z
+        .record(z.string())
+        .optional()
+        .describe("Request headers for the virtual request."),
+      body: z
+        .string()
+        .optional()
+        .describe("Raw request body string for the virtual request. JSON payloads should be stringified first."),
+    },
+    annotations: {
+      readOnlyHint: true,
+    },
+  },
+  async ({ index, method, path, query, headers, body }) => {
+    if (index !== undefined) {
+      return toText(await readJson(`/requests/${index}/suggest-improvements`));
+    }
+
+    if (!method || !path) {
+      throw new Error("Either `index` or both `method` and `path` must be provided.");
+    }
+
+    return toText(
+      await readJson("/suggest-improvements", "POST", { method, path, query, headers, body })
+    );
+  }
+);
+
 // ─── Start ────────────────────────────────────────────────────────────────────
 
 const transport = new StdioServerTransport();


### PR DESCRIPTION
## Summary

- Add `export_stubs_as_yaml` MCP tool — exports recorded requests as draft OpenAPI 3.1 YAML stubs (wraps the `/requests/export/yaml` and `/requests/{index}/export/yaml` endpoints)
- Add `suggest_improvements` MCP tool — analyzes a request against active stub definitions and returns actionable YAML improvement suggestions (wraps the `/requests/{index}/suggest-improvements` and `/suggest-improvements` endpoints)
- Update `mcp/README.md` and `mcp/README.ja.md` with the new tools

## Tool details

### `export_stubs_as_yaml`
- With `index`: exports a single recorded request as a YAML stub draft
- Without `index`: exports recent requests (up to `limit`) grouped by path and method into one YAML document
- Returns raw YAML text with `TODO` placeholders for user review

### `suggest_improvements`
- With `index`: analyzes the recorded request at that index
- Without `index`: constructs a virtual request from `method` + `path` (both required)
- Returns a `MatchImprovementReportInfo` with `explanation` and `suggestions`
- Suggestion kinds: `NoMatchFound`, `SemanticFallbackUsed`, `NoConditionsOnRoute`, `NearMissCandidate`

## Test plan

- [x] `npm run build` passes (TypeScript compiles without errors)
- [x] `dotnet test` passes (565 tests, 0 failures) — .NET API endpoints used by these tools are regression-tested
- [x] Both tools follow the established thin-bridge delegation pattern
- [x] No existing tool contracts modified

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)