### PR TITLE
feat: response body template substitution for path, query, header, and body parameters

### DIFF
--- a/samples/basic-routing.yaml
+++ b/samples/basic-routing.yaml
@@ -449,6 +449,35 @@ paths:
               example:
                 result: complete
 
+  /users/{id}:
+    get:
+      operationId: getUserById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: User found by id
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                required:
+                  - id
+                  - name
+              example:
+                id: "{{path.id}}"
+                name: "User {{path.id}}"
+
   /orders/{orderId}:
     get:
       operationId: getOrderById

--- a/src/SemanticStub.Api/Services/Matching/StubDefaultResponseSelector.cs
+++ b/src/SemanticStub.Api/Services/Matching/StubDefaultResponseSelector.cs
@@ -20,7 +20,8 @@ internal sealed class StubDefaultResponseSelector
     public bool TrySelect(
         OperationDefinition operation,
         bool mutateScenarioState,
-        out StubDefaultResponseSelection selection)
+        out StubDefaultResponseSelection selection,
+        TemplateSubstitutionContext? context = null)
     {
         selection = null!;
 
@@ -32,7 +33,7 @@ internal sealed class StubDefaultResponseSelector
             return false;
         }
 
-        if (!_responseBuilder.TryBuild(statusCode, matchedResponse.Value, out var response))
+        if (!_responseBuilder.TryBuild(statusCode, matchedResponse.Value, out var response, context))
         {
             return false;
         }

--- a/src/SemanticStub.Api/Services/Resolution/StubDispatchSelector.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubDispatchSelector.cs
@@ -35,6 +35,7 @@ internal sealed class StubDispatchSelector
     public async Task<StubDispatchSelectionResult> SelectAsync(
         string method,
         string path,
+        string pathPattern,
         PathItemDefinition pathItem,
         OperationDefinition operation,
         IReadOnlyDictionary<string, StringValues> query,
@@ -44,6 +45,9 @@ internal sealed class StubDispatchSelector
         bool includeSemanticCandidates,
         CancellationToken cancellationToken = default)
     {
+        var pathParameters = StubRouteResolver.ExtractPathParameters(pathPattern, path);
+        var templateContext = new TemplateSubstitutionContext(pathParameters, query, headers, body);
+
         var selectedDeterministicCandidate = _matcherService.FindBestMatch(
             pathItem.Parameters,
             operation,
@@ -56,7 +60,7 @@ internal sealed class StubDispatchSelector
         {
             var matchedCandidateIndex = operation.Matches.FindIndex(candidate => ReferenceEquals(candidate, selectedDeterministicCandidate));
 
-            if (!_responseBuilder.TryBuild(selectedDeterministicCandidate.Response, out var deterministicResponse))
+            if (!_responseBuilder.TryBuild(selectedDeterministicCandidate.Response, out var deterministicResponse, templateContext))
             {
                 return new StubDispatchSelectionResult
                 {
@@ -115,7 +119,7 @@ internal sealed class StubDispatchSelector
         {
             var selectedSemanticCandidateIndex = operation.Matches.FindIndex(candidate => ReferenceEquals(candidate, semanticExplanation.SelectedCandidate));
 
-            if (!_responseBuilder.TryBuild(semanticExplanation.SelectedCandidate.Response, out var semanticResponse))
+            if (!_responseBuilder.TryBuild(semanticExplanation.SelectedCandidate.Response, out var semanticResponse, templateContext))
             {
                 return new StubDispatchSelectionResult
                 {
@@ -157,7 +161,7 @@ internal sealed class StubDispatchSelector
             };
         }
 
-        if (_defaultResponseSelector.TrySelect(operation, mutateScenarioState, out var defaultSelection))
+        if (_defaultResponseSelector.TrySelect(operation, mutateScenarioState, out var defaultSelection, templateContext))
         {
             return new StubDispatchSelectionResult
             {

--- a/src/SemanticStub.Api/Services/Resolution/StubResponseBuilder.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubResponseBuilder.cs
@@ -1,8 +1,17 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Primitives;
 using SemanticStub.Api.Models;
 using SemanticStub.Application.Models;
 using SemanticStub.Application.Utilities;
 
 namespace SemanticStub.Api.Services;
+
+internal sealed record TemplateSubstitutionContext(
+    IReadOnlyDictionary<string, string> PathParameters,
+    IReadOnlyDictionary<string, StringValues> Query,
+    IReadOnlyDictionary<string, string> Headers,
+    string? Body);
 
 internal sealed class StubResponseBuilder
 {
@@ -14,7 +23,7 @@ internal sealed class StubResponseBuilder
         _responseFileReader = responseFileReader;
     }
 
-    public bool TryBuild(int statusCode, ResponseDefinition responseDefinition, out StubResponse response)
+    public bool TryBuild(int statusCode, ResponseDefinition responseDefinition, out StubResponse response, TemplateSubstitutionContext? context = null)
     {
         response = null!;
 
@@ -37,6 +46,11 @@ internal sealed class StubResponseBuilder
             return false;
         }
 
+        if (context is not null)
+        {
+            responseBody = ApplySubstitution(responseBody, context);
+        }
+
         response = CreateStubResponse(
             statusCode,
             responseDefinition.DelayMilliseconds,
@@ -48,7 +62,7 @@ internal sealed class StubResponseBuilder
         return true;
     }
 
-    public bool TryBuild(QueryMatchResponseDefinition responseDefinition, out StubResponse response)
+    public bool TryBuild(QueryMatchResponseDefinition responseDefinition, out StubResponse response, TemplateSubstitutionContext? context = null)
     {
         response = null!;
 
@@ -74,6 +88,11 @@ internal sealed class StubResponseBuilder
         if (responseBody is null)
         {
             return false;
+        }
+
+        if (context is not null)
+        {
+            responseBody = ApplySubstitution(responseBody, context);
         }
 
         response = CreateStubResponse(
@@ -164,5 +183,60 @@ internal sealed class StubResponseBuilder
     {
         return contentType.Equals(JsonContentType, StringComparison.OrdinalIgnoreCase)
             || contentType.EndsWith("+json", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static readonly Regex TemplatePlaceholder = new(@"\{\{(\w+)\.([-\w]+)\}\}", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+
+    private static string ApplySubstitution(string body, TemplateSubstitutionContext context)
+    {
+        return TemplatePlaceholder.Replace(body, match =>
+        {
+            var source = match.Groups[1].Value;
+            var name = match.Groups[2].Value;
+
+            return source switch
+            {
+                "path" => context.PathParameters.TryGetValue(name, out var pathVal) ? pathVal : match.Value,
+                "query" => context.Query.TryGetValue(name, out var queryVal) ? queryVal.FirstOrDefault() ?? match.Value : match.Value,
+                "header" => context.Headers.TryGetValue(name, out var headerVal) ? headerVal : match.Value,
+                "body" => TryExtractBodyValue(context.Body, name, out var bodyVal) ? bodyVal : match.Value,
+                _ => match.Value,
+            };
+        });
+    }
+
+    private static bool TryExtractBodyValue(string? body, string key, out string value)
+    {
+        value = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return false;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+
+            if (doc.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                return false;
+            }
+
+            if (!doc.RootElement.TryGetProperty(key, out var element))
+            {
+                return false;
+            }
+
+            value = element.ValueKind == JsonValueKind.String
+                ? element.GetString() ?? string.Empty
+                : element.GetRawText();
+
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
     }
 }

--- a/src/SemanticStub.Api/Services/Resolution/StubResponseBuilder.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubResponseBuilder.cs
@@ -48,7 +48,8 @@ internal sealed class StubResponseBuilder
 
         if (context is not null)
         {
-            responseBody = ApplySubstitution(responseBody, context);
+            var isJson = IsJsonContentType(SelectMediaTypeKey(responseDefinition.Content) ?? string.Empty);
+            responseBody = ApplySubstitution(responseBody, context, isJson);
         }
 
         response = CreateStubResponse(
@@ -92,7 +93,8 @@ internal sealed class StubResponseBuilder
 
         if (context is not null)
         {
-            responseBody = ApplySubstitution(responseBody, context);
+            var isJson = IsJsonContentType(SelectMediaTypeKey(responseDefinition.Content) ?? string.Empty);
+            responseBody = ApplySubstitution(responseBody, context, isJson);
         }
 
         response = CreateStubResponse(
@@ -187,22 +189,35 @@ internal sealed class StubResponseBuilder
 
     private static readonly Regex TemplatePlaceholder = new(@"\{\{(\w+)\.([-\w]+)\}\}", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
 
-    private static string ApplySubstitution(string body, TemplateSubstitutionContext context)
+    private static string ApplySubstitution(string body, TemplateSubstitutionContext context, bool escapeForJson)
     {
         return TemplatePlaceholder.Replace(body, match =>
         {
             var source = match.Groups[1].Value;
             var name = match.Groups[2].Value;
 
-            return source switch
+            var resolved = source switch
             {
-                "path" => context.PathParameters.TryGetValue(name, out var pathVal) ? pathVal : match.Value,
-                "query" => context.Query.TryGetValue(name, out var queryVal) ? queryVal.FirstOrDefault() ?? match.Value : match.Value,
-                "header" => context.Headers.TryGetValue(name, out var headerVal) ? headerVal : match.Value,
-                "body" => TryExtractBodyValue(context.Body, name, out var bodyVal) ? bodyVal : match.Value,
-                _ => match.Value,
+                "path" => context.PathParameters.TryGetValue(name, out var pathVal) ? pathVal : null,
+                "query" => context.Query.TryGetValue(name, out var queryVal) ? queryVal.FirstOrDefault() : null,
+                "header" => context.Headers.TryGetValue(name, out var headerVal) ? headerVal : null,
+                "body" => TryExtractBodyValue(context.Body, name, out var bodyVal) ? bodyVal : null,
+                _ => null,
             };
+
+            if (resolved is null)
+            {
+                return match.Value;
+            }
+
+            return escapeForJson ? JsonEncodeStringValue(resolved) : resolved;
         });
+    }
+
+    private static string JsonEncodeStringValue(string value)
+    {
+        var serialized = JsonSerializer.Serialize(value);
+        return serialized[1..^1];
     }
 
     private static bool TryExtractBodyValue(string? body, string key, out string value)

--- a/src/SemanticStub.Api/Services/Resolution/StubRouteResolver.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubRouteResolver.cs
@@ -84,6 +84,29 @@ internal static class StubRouteResolver
         return path.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
     }
 
+    public static IReadOnlyDictionary<string, string> ExtractPathParameters(string pathPattern, string requestPath)
+    {
+        var patternSegments = GetPathSegments(pathPattern);
+        var requestSegments = GetPathSegments(requestPath);
+
+        if (patternSegments.Length != requestSegments.Length)
+        {
+            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        for (var i = 0; i < patternSegments.Length; i++)
+        {
+            if (IsPathParameterSegment(patternSegments[i]))
+            {
+                result[patternSegments[i][1..^1]] = requestSegments[i];
+            }
+        }
+
+        return result;
+    }
+
     private static bool IsPathParameterSegment(string segment)
     {
         return segment.Length > 2 &&

--- a/src/SemanticStub.Api/Services/Resolution/StubService.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubService.cs
@@ -170,6 +170,7 @@ public sealed class StubService : IStubService
         var selection = await _dispatchSelector.SelectAsync(
             method,
             path,
+            pathPattern,
             pathItem,
             operation,
             query,

--- a/tests/SemanticStub.Api.Tests/Integration/BasicRoutingStubTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/BasicRoutingStubTests.cs
@@ -530,6 +530,19 @@ public sealed class BasicRoutingStubTests : IClassFixture<WebApplicationFactory<
         return output.ToArray();
     }
 
+    [Fact]
+    public async Task GetUserById_WithPathParameter_ReturnsBodyWithActualId()
+    {
+        var response = await client.GetAsync("/users/abc-123");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var payload = await response.Content.ReadFromJsonAsync<UserByIdResponse>();
+        Assert.NotNull(payload);
+        Assert.Equal("abc-123", payload.Id);
+        Assert.Equal("User abc-123", payload.Name);
+    }
+
     private static string DecompressGzip(byte[] content)
     {
         using var input = new MemoryStream(content);
@@ -538,4 +551,8 @@ public sealed class BasicRoutingStubTests : IClassFixture<WebApplicationFactory<
 
         return reader.ReadToEnd();
     }
+
+    private sealed record UserByIdResponse(
+        [property: JsonPropertyName("id")] string Id,
+        [property: JsonPropertyName("name")] string Name);
 }

--- a/tests/SemanticStub.Api.Tests/Unit/Resolution/StubDispatchSelectorTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Resolution/StubDispatchSelectorTests.cs
@@ -50,7 +50,7 @@ public sealed class StubDispatchSelectorTests
             ["role"] = new("admin")
         };
 
-        var result = await selector.SelectAsync(HttpMethods.Get, "/users", pathItem, operation, query, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase), null, mutateScenarioState: true, includeSemanticCandidates: false);
+        var result = await selector.SelectAsync(HttpMethods.Get, "/users", "/users", pathItem, operation, query, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase), null, mutateScenarioState: true, includeSemanticCandidates: false);
 
         Assert.Equal(StubMatchResult.ResponseNotConfigured, result.Result);
         Assert.Equal("exact", result.MatchMode);
@@ -122,6 +122,7 @@ public sealed class StubDispatchSelectorTests
         var result = await selector.SelectAsync(
             HttpMethods.Get,
             "/users",
+            "/users",
             new PathItemDefinition(),
             operation,
             query,
@@ -168,6 +169,7 @@ public sealed class StubDispatchSelectorTests
 
         var result = await selector.SelectAsync(
             HttpMethods.Get,
+            "/users",
             "/users",
             new PathItemDefinition(),
             new OperationDefinition { Matches = [semanticCandidate] },
@@ -222,6 +224,7 @@ public sealed class StubDispatchSelectorTests
         var dryRun = await selector.SelectAsync(
             HttpMethods.Post,
             "/checkout",
+            "/checkout",
             new PathItemDefinition(),
             operation,
             new Dictionary<string, StringValues>(StringComparer.Ordinal),
@@ -232,6 +235,7 @@ public sealed class StubDispatchSelectorTests
         var snapshotAfterDryRun = scenarioService.GetSnapshot("checkout-flow");
         var liveRun = await selector.SelectAsync(
             HttpMethods.Post,
+            "/checkout",
             "/checkout",
             new PathItemDefinition(),
             operation,
@@ -265,13 +269,14 @@ public sealed class StubDispatchSelectorTests
         await selector.SelectAsync(
             HttpMethods.Get,
             "/users",
+            "/users",
             new PathItemDefinition(),
             new OperationDefinition(),
             new Dictionary<string, StringValues>(StringComparer.Ordinal),
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
             null,
-            mutateScenarioState: false,
-            includeSemanticCandidates: false,
+            false,
+            false,
             cancellationSource.Token);
 
         Assert.Equal(cancellationSource.Token, spy.ReceivedCancellationToken);

--- a/tests/SemanticStub.Api.Tests/Unit/Resolution/StubResponseBuilderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Resolution/StubResponseBuilderTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Primitives;
 using SemanticStub.Api.Models;
 using SemanticStub.Application.Models;
 using SemanticStub.Api.Services;
@@ -71,5 +72,160 @@ public sealed class StubResponseBuilderTests
         Assert.True(built);
         Assert.Equal("Hello, world!", response.Body);
         Assert.Equal("text/plain", response.ContentType);
+    }
+
+    [Fact]
+    public void TryBuild_WithPathTemplate_SubstitutesValue()
+    {
+        var builder = new StubResponseBuilder(_ => throw new InvalidOperationException());
+        var responseDefinition = new ResponseDefinition
+        {
+            Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+            {
+                ["application/json"] = new()
+                {
+                    Example = new Dictionary<object, object> { ["id"] = "{{path.id}}" }
+                }
+            }
+        };
+        var context = new TemplateSubstitutionContext(
+            PathParameters: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["id"] = "42" },
+            Query: new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            Headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            Body: null);
+
+        var built = builder.TryBuild(200, responseDefinition, out var response, context);
+
+        Assert.True(built);
+        Assert.Contains("\"42\"", response.Body);
+    }
+
+    [Fact]
+    public void TryBuild_WithQueryTemplate_SubstitutesValue()
+    {
+        var builder = new StubResponseBuilder(_ => throw new InvalidOperationException());
+        var responseDefinition = new ResponseDefinition
+        {
+            Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+            {
+                ["application/json"] = new()
+                {
+                    Example = new Dictionary<object, object> { ["role"] = "{{query.role}}" }
+                }
+            }
+        };
+        var context = new TemplateSubstitutionContext(
+            PathParameters: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            Query: new Dictionary<string, StringValues>(StringComparer.Ordinal) { ["role"] = new StringValues("admin") },
+            Headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            Body: null);
+
+        var built = builder.TryBuild(200, responseDefinition, out var response, context);
+
+        Assert.True(built);
+        Assert.Contains("\"admin\"", response.Body);
+    }
+
+    [Fact]
+    public void TryBuild_WithHeaderTemplate_SubstitutesValue()
+    {
+        var builder = new StubResponseBuilder(_ => throw new InvalidOperationException());
+        var responseDefinition = new ResponseDefinition
+        {
+            Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+            {
+                ["application/json"] = new()
+                {
+                    Example = new Dictionary<object, object> { ["requestId"] = "{{header.X-Request-Id}}" }
+                }
+            }
+        };
+        var context = new TemplateSubstitutionContext(
+            PathParameters: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            Query: new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            Headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["X-Request-Id"] = "req-abc" },
+            Body: null);
+
+        var built = builder.TryBuild(200, responseDefinition, out var response, context);
+
+        Assert.True(built);
+        Assert.Contains("\"req-abc\"", response.Body);
+    }
+
+    [Fact]
+    public void TryBuild_WithBodyTemplate_SubstitutesValue()
+    {
+        var builder = new StubResponseBuilder(_ => throw new InvalidOperationException());
+        var responseDefinition = new ResponseDefinition
+        {
+            Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+            {
+                ["application/json"] = new()
+                {
+                    Example = new Dictionary<object, object> { ["echo"] = "{{body.userId}}" }
+                }
+            }
+        };
+        var context = new TemplateSubstitutionContext(
+            PathParameters: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            Query: new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            Headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            Body: """{"userId":"user-99"}""");
+
+        var built = builder.TryBuild(200, responseDefinition, out var response, context);
+
+        Assert.True(built);
+        Assert.Contains("\"user-99\"", response.Body);
+    }
+
+    [Fact]
+    public void TryBuild_WithMissingKey_LeavesPlaceholderIntact()
+    {
+        var builder = new StubResponseBuilder(_ => throw new InvalidOperationException());
+        var responseDefinition = new ResponseDefinition
+        {
+            Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+            {
+                ["application/json"] = new()
+                {
+                    Example = new Dictionary<object, object> { ["id"] = "{{path.id}}" }
+                }
+            }
+        };
+        var context = new TemplateSubstitutionContext(
+            PathParameters: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            Query: new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            Headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            Body: null);
+
+        var built = builder.TryBuild(200, responseDefinition, out var response, context);
+
+        Assert.True(built);
+        Assert.Contains("{{path.id}}", response.Body);
+    }
+
+    [Fact]
+    public void TryBuild_WithAbsoluteResponseFile_SkipsSubstitution()
+    {
+        var filePath = Path.Combine(Path.GetTempPath(), $"semanticstub-{Guid.NewGuid():N}.bin");
+        var builder = new StubResponseBuilder(_ => throw new InvalidOperationException("Reader should not be called."));
+        var responseDefinition = new ResponseDefinition
+        {
+            ResponseFile = filePath,
+            Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+            {
+                ["application/octet-stream"] = new()
+            }
+        };
+        var context = new TemplateSubstitutionContext(
+            PathParameters: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["id"] = "42" },
+            Query: new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            Headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            Body: null);
+
+        var built = builder.TryBuild(200, responseDefinition, out var response, context);
+
+        Assert.True(built);
+        Assert.Equal(filePath, response.FilePath);
     }
 }

--- a/tests/SemanticStub.Api.Tests/Unit/Resolution/StubResponseBuilderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Resolution/StubResponseBuilderTests.cs
@@ -205,6 +205,33 @@ public sealed class StubResponseBuilderTests
     }
 
     [Fact]
+    public void TryBuild_WithSpecialCharsInValue_JsonEscapesInJsonResponse()
+    {
+        var builder = new StubResponseBuilder(_ => throw new InvalidOperationException());
+        var responseDefinition = new ResponseDefinition
+        {
+            Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+            {
+                ["application/json"] = new()
+                {
+                    Example = new Dictionary<object, object> { ["id"] = "{{path.id}}" }
+                }
+            }
+        };
+        var context = new TemplateSubstitutionContext(
+            PathParameters: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["id"] = "foo\"bar\nbaz" },
+            Query: new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            Headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            Body: null);
+
+        var built = builder.TryBuild(200, responseDefinition, out var response, context);
+
+        Assert.True(built);
+        var parsed = System.Text.Json.JsonDocument.Parse(response.Body);
+        Assert.Equal("foo\"bar\nbaz", parsed.RootElement.GetProperty("id").GetString());
+    }
+
+    [Fact]
     public void TryBuild_WithAbsoluteResponseFile_SkipsSubstitution()
     {
         var filePath = Path.Combine(Path.GetTempPath(), $"semanticstub-{Guid.NewGuid():N}.bin");

--- a/tests/SemanticStub.Api.Tests/Unit/Resolution/StubRouteResolverTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Resolution/StubRouteResolverTests.cs
@@ -65,4 +65,39 @@ public sealed class StubRouteResolverTests
 
         Assert.Equal("/orders/123", normalizedPath);
     }
+
+    [Fact]
+    public void ExtractPathParameters_WithSingleParam_ReturnsParam()
+    {
+        var result = StubRouteResolver.ExtractPathParameters("/users/{id}", "/users/42");
+
+        Assert.Single(result);
+        Assert.Equal("42", result["id"]);
+    }
+
+    [Fact]
+    public void ExtractPathParameters_WithMultipleParams_ReturnsAllParams()
+    {
+        var result = StubRouteResolver.ExtractPathParameters("/orders/{orderId}/items/{itemId}", "/orders/99/items/7");
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("99", result["orderId"]);
+        Assert.Equal("7", result["itemId"]);
+    }
+
+    [Fact]
+    public void ExtractPathParameters_WithNoParams_ReturnsEmpty()
+    {
+        var result = StubRouteResolver.ExtractPathParameters("/hello", "/hello");
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ExtractPathParameters_WithMismatchedSegmentCount_ReturnsEmpty()
+    {
+        var result = StubRouteResolver.ExtractPathParameters("/users/{id}", "/users/42/extra");
+
+        Assert.Empty(result);
+    }
 }


### PR DESCRIPTION
## Summary

Closes #311

- Adds `{{source.name}}` template substitution engine to `StubResponseBuilder`, replacing placeholders in response bodies with actual request values at dispatch time
- Supported sources: `{{path.name}}`, `{{query.name}}`, `{{header.Name}}` (case-insensitive), `{{body.name}}` (top-level JSON key)
- Substituted values are JSON-escaped when the response content type is JSON, preventing malformed output when values contain `"`, newlines, or other special characters
- Unresolved placeholders are left verbatim; file-backed responses (`responseFile`) are excluded per spec
- Adds `StubRouteResolver.ExtractPathParameters` to extract `{param}` → value pairs from a matched path
- Wires `TemplateSubstitutionContext` through `StubDispatchSelector` → `StubResponseBuilder` and `StubDefaultResponseSelector` for all response paths (deterministic, semantic, default)

## Test plan

- [ ] Unit: `ExtractPathParameters` — single param, multiple params, no params, mismatched segment count
- [ ] Unit: `StubResponseBuilder` — `{{path.*}}`, `{{query.*}}`, `{{header.*}}`, `{{body.*}}` substitution; missing key leaves placeholder intact; file-backed response skips substitution; special chars in value are JSON-escaped
- [ ] Integration: `GET /users/{id}` with `{{path.id}}` in example returns body containing the actual ID value
- [ ] All 577 tests pass (`dotnet test`)
- [ ] `dotnet format --verify-no-changes` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)