### PR TITLE
feat: nested body key access in response template substitution ({{body.user.id}})

### DIFF
--- a/samples/basic-routing.yaml
+++ b/samples/basic-routing.yaml
@@ -522,6 +522,29 @@ paths:
               example:
                 result: exact
 
+  /create-order:
+    post:
+      operationId: createOrder
+      responses:
+        '201':
+          description: Order created
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                properties:
+                  orderId:
+                    type: string
+                  customerName:
+                    type: string
+                required:
+                  - orderId
+                  - customerName
+              example:
+                orderId: "{{body.order.id}}"
+                customerName: "{{body.customer.profile.name}}"
+
   /download:
     get:
       operationId: downloadFile

--- a/src/SemanticStub.Api/Services/Resolution/StubResponseBuilder.cs
+++ b/src/SemanticStub.Api/Services/Resolution/StubResponseBuilder.cs
@@ -187,7 +187,7 @@ internal sealed class StubResponseBuilder
             || contentType.EndsWith("+json", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static readonly Regex TemplatePlaceholder = new(@"\{\{(\w+)\.([-\w]+)\}\}", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+    private static readonly Regex TemplatePlaceholder = new(@"\{\{(\w+)\.([-\w]+(?:\.[-\w]+)*)\}\}", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
 
     private static string ApplySubstitution(string body, TemplateSubstitutionContext context, bool escapeForJson)
     {
@@ -238,7 +238,18 @@ internal sealed class StubResponseBuilder
                 return false;
             }
 
-            if (!doc.RootElement.TryGetProperty(key, out var element))
+            var segments = key.Split('.');
+            var current = doc.RootElement;
+
+            for (var i = 0; i < segments.Length - 1; i++)
+            {
+                if (current.ValueKind != JsonValueKind.Object || !current.TryGetProperty(segments[i], out current))
+                {
+                    return false;
+                }
+            }
+
+            if (current.ValueKind != JsonValueKind.Object || !current.TryGetProperty(segments[^1], out var element))
             {
                 return false;
             }

--- a/tests/SemanticStub.Api.Tests/Integration/BasicRoutingStubTests.cs
+++ b/tests/SemanticStub.Api.Tests/Integration/BasicRoutingStubTests.cs
@@ -552,7 +552,30 @@ public sealed class BasicRoutingStubTests : IClassFixture<WebApplicationFactory<
         return reader.ReadToEnd();
     }
 
+    [Fact]
+    public async Task PostCreateOrder_WithNestedBodyTemplate_SubstitutesValue()
+    {
+        using var content = JsonContent.Create(new
+        {
+            order = new { id = "ord-456" },
+            customer = new { profile = new { name = "Bob" } }
+        });
+
+        var response = await client.PostAsync("/create-order", content);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var payload = await response.Content.ReadFromJsonAsync<CreateOrderResponse>();
+        Assert.NotNull(payload);
+        Assert.Equal("ord-456", payload.OrderId);
+        Assert.Equal("Bob", payload.CustomerName);
+    }
+
     private sealed record UserByIdResponse(
         [property: JsonPropertyName("id")] string Id,
         [property: JsonPropertyName("name")] string Name);
+
+    private sealed record CreateOrderResponse(
+        [property: JsonPropertyName("orderId")] string OrderId,
+        [property: JsonPropertyName("customerName")] string CustomerName);
 }

--- a/tests/SemanticStub.Api.Tests/Unit/Resolution/StubResponseBuilderTests.cs
+++ b/tests/SemanticStub.Api.Tests/Unit/Resolution/StubResponseBuilderTests.cs
@@ -232,6 +232,110 @@ public sealed class StubResponseBuilderTests
     }
 
     [Fact]
+    public void TryBuild_WithNestedBodyTemplate_TwoLevels_SubstitutesValue()
+    {
+        var builder = new StubResponseBuilder(_ => throw new InvalidOperationException());
+        var responseDefinition = new ResponseDefinition
+        {
+            Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+            {
+                ["application/json"] = new()
+                {
+                    Example = new Dictionary<object, object> { ["orderId"] = "{{body.order.id}}" }
+                }
+            }
+        };
+        var context = new TemplateSubstitutionContext(
+            PathParameters: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            Query: new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            Headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            Body: """{"order":{"id":"abc-123"}}""");
+
+        var built = builder.TryBuild(200, responseDefinition, out var response, context);
+
+        Assert.True(built);
+        Assert.Contains("\"abc-123\"", response.Body);
+    }
+
+    [Fact]
+    public void TryBuild_WithNestedBodyTemplate_ThreeLevels_SubstitutesValue()
+    {
+        var builder = new StubResponseBuilder(_ => throw new InvalidOperationException());
+        var responseDefinition = new ResponseDefinition
+        {
+            Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+            {
+                ["application/json"] = new()
+                {
+                    Example = new Dictionary<object, object> { ["customerName"] = "{{body.customer.profile.name}}" }
+                }
+            }
+        };
+        var context = new TemplateSubstitutionContext(
+            PathParameters: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            Query: new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            Headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            Body: """{"customer":{"profile":{"name":"Alice"}}}""");
+
+        var built = builder.TryBuild(200, responseDefinition, out var response, context);
+
+        Assert.True(built);
+        Assert.Contains("\"Alice\"", response.Body);
+    }
+
+    [Fact]
+    public void TryBuild_WithNestedBodyTemplate_MissingIntermediateKey_LeavesPlaceholderIntact()
+    {
+        var builder = new StubResponseBuilder(_ => throw new InvalidOperationException());
+        var responseDefinition = new ResponseDefinition
+        {
+            Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+            {
+                ["application/json"] = new()
+                {
+                    Example = new Dictionary<object, object> { ["val"] = "{{body.missing.id}}" }
+                }
+            }
+        };
+        var context = new TemplateSubstitutionContext(
+            PathParameters: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            Query: new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            Headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            Body: """{"order":{"id":"abc-123"}}""");
+
+        var built = builder.TryBuild(200, responseDefinition, out var response, context);
+
+        Assert.True(built);
+        Assert.Contains("{{body.missing.id}}", response.Body);
+    }
+
+    [Fact]
+    public void TryBuild_WithNestedBodyTemplate_NonObjectIntermediateNode_LeavesPlaceholderIntact()
+    {
+        var builder = new StubResponseBuilder(_ => throw new InvalidOperationException());
+        var responseDefinition = new ResponseDefinition
+        {
+            Content = new Dictionary<string, MediaTypeDefinition>(StringComparer.Ordinal)
+            {
+                ["application/json"] = new()
+                {
+                    Example = new Dictionary<object, object> { ["val"] = "{{body.order.id.extra}}" }
+                }
+            }
+        };
+        var context = new TemplateSubstitutionContext(
+            PathParameters: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            Query: new Dictionary<string, StringValues>(StringComparer.Ordinal),
+            Headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            Body: """{"order":{"id":"abc-123"}}""");
+
+        var built = builder.TryBuild(200, responseDefinition, out var response, context);
+
+        Assert.True(built);
+        Assert.Contains("{{body.order.id.extra}}", response.Body);
+    }
+
+    [Fact]
     public void TryBuild_WithAbsoluteResponseFile_SkipsSubstitution()
     {
         var filePath = Path.Combine(Path.GetTempPath(), $"semanticstub-{Guid.NewGuid():N}.bin");


### PR DESCRIPTION
## Summary

- Extends `{{body.*}}` template placeholder to support dot-notation paths for nested JSON body traversal (e.g. `{{body.order.id}}`, `{{body.customer.profile.name}}`)
- Updates `TemplatePlaceholder` regex to allow dots in the key segment
- Updates `TryExtractBodyValue` to split the key on `.` and traverse the JSON object depth-first; returns `false` (leaves placeholder intact) if any intermediate segment is missing or is not an object
- `{{path.*}}`, `{{query.*}}`, and `{{header.*}}` are unaffected

## Test plan

- [x] Unit tests: 2-level nested access, 3-level nested access, missing intermediate key leaves placeholder, non-object intermediate node leaves placeholder
- [x] Integration test: POST `/create-order` with `{{body.order.id}}` and `{{body.customer.profile.name}}` resolves correctly
- [x] All 582 tests pass

Closes #312